### PR TITLE
EE-1228: Clarify unbonding lock up period.

### DIFF
--- a/staking/index.rst
+++ b/staking/index.rst
@@ -58,7 +58,7 @@ Validators have to win a staking auction by competing with prospective and curre
 Unbonding Period
 ----------------
 
-For security purposes, whenever a token is un-staked or un-delegated, the protocol will continue to keep the token locked for 1 day.
+For security purposes, whenever a token is un-staked or un-delegated, the protocol will continue to keep the token locked for 14 hours.
 
 
 Next Steps


### PR DESCRIPTION
This PR clarifies the specification on unbonding lock-up period. Our mainnet is currently configured for 14h (7 eras * 120min) as according to our chainspec:

https://github.com/CasperLabs/casper-node/blob/8cff3369480aaa7645bd7626ae0af19628873b2c/resources/production/chainspec.toml#L25-L39