### PR TITLE
Updated top menu and landing page in documentation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -7,23 +7,21 @@
 Casper Documentation
 ************************
 
-We present the design for a new Turing-complete smart contract platform, backed
-by a Proof of Stake (PoS) consensus algorithm, and WebAssembly (Wasm). The
-intent is for this design to be implemented as a new permissionless,
-decentralized, public blockchain. The consensus protocol is built on Vlad
-Zamfir's
-`correct-by-construction (CBC) Casper <https://github.com/cbc-casper/cbc-casper-paper>`_
-work. Here, we describe The Highway Protocol, a member of the CBC Casper family which 
-is provably safe and live under partial synchrony. Rust is supported as the primary programming language
-for smart contracts because of its good support for compilation to wasm; 
-however, the platform itself does not make assumptions about the source language,
-so libraries facilitating contract development in other programming language having
-wasm as a compile target are expected. Other features of the execution engine include:
-an account permissions model allowing for lost key recovery, and
-a permissions model to securely share state between accounts and/or
-contracts (without the need for  expensive cryptographic checks). We also
-provide discussions of the economics of our proof-of-stake implementation
-and our token policies.
+We present the Casper Network, a new Turing-complete smart-contract platform, backed by a Proof-of-Stake (PoS) consensus algorithm and WebAssembly (wasm). The network is a permissionless, decentralized, public blockchain. The consensus protocol is called Highway, and the complete paper is found in GitHub: https://github.com/CasperLabs/highway. The consensus protocol allows clients to use different confidence thresholds to convince themselves that a given block is *finalized*. This protocol is built on Vlad Zamfir's `correct-by-construction (CBC) Casper <https://github.com/cbc-casper/cbc-casper-paper>`_ research. 
+
+Rust is the primary programming language for smart contracts on the Casper blockchain because of its good support for compilation to wasm. However, the platform does not make assumptions about the source language and supports libraries facilitating contract development in other programming languages having wasm as a compile target. Other essential features include an account permissions model that allows the recovery of lost keys and a permissions model to securely share state between accounts and contracts (without expensive cryptographic checks). We also provide discussions of the economics of our proof-of-stake implementation and our token policies.
+
+================================================================  ========================================================================  
+`Developers <dapp-dev-guide/index.html>`_                         Get started with smart contract development on the Casper blockchain in AssemblyScript or Rust 
+`Node Operators <node-operator/index.html>`_                      Run node infrastructure on the Casper Network
+`Design <implementation/index.html>`_                             Understand the architecture of the Casper Network, including network communication, execution semantics, account management, block structure, global state, serialization, unforgeable references, and tokens 
+`Economics <economics/index.html>`_                               Conceptualize Casper's economic activity by understanding consensus, runtime, ecosystem, and the macroeconomy
+`Staking Guide <staking/index.html>`_                             Participate in the protocol by staking CSPR tokens with a validator in the Casper Network 
+`Glossary <glossary/index.html>`_                                 Explore key definitions in the context of the Casper Network  
+`FAQ <faq/index.html>`_                                           Find answers regarding the Casper Network, CasperLabs, and the CSPR token sale  
+================================================================  ========================================================================
+   
+
 
 .. include:: disclaimer.rst
 
@@ -32,10 +30,10 @@ and our token policies.
    :maxdepth: 3
    :titlesonly:
 
+   dapp-dev-guide/index
+   node-operator/index
    implementation/index
    economics/index
    staking/index
-   dapp-dev-guide/index
-   node-operator/index
    glossary/index
    faq/index


### PR DESCRIPTION
The goal of this PR is to improve the documentation landing page and to move the Developers and Operators top menu links to the left. 