### PR TITLE
Add a changelog to the docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,14 @@
+Changelog
+---------
+
+This page is a reference library for all the past technical releases and changelogs for the Casper Network. Click on the links below to see details about the released versions such as release dates, key changes and milestones completed, known issues, and calls to action for validators, dApp developers, contract authors, and exchanges.
+
+Visit the `technical roadmap <https://github.com/casper-network/roadmap/projects/2>`_ and the `engineering status <https://github.com/casper-network/roadmap/wiki/Current-Status>`_ pages to review the work currently in progress.
+
+Casper Network Release Notes
+============================
+
+`Version 1.2.0 <https://medium.com/casper-association/technical-release-notes-and-changelog-for-1-2-0-26bbe921ab51>`_ 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+

--- a/index.rst
+++ b/index.rst
@@ -19,6 +19,7 @@ Rust is the primary programming language for smart contracts on the Casper block
 `Staking Guide <staking/index.html>`_                             Participate in the protocol by staking CSPR tokens with a validator in the Casper Network 
 `Glossary <glossary/index.html>`_                                 Explore key definitions in the context of the Casper Network  
 `FAQ <faq/index.html>`_                                           Find answers regarding the Casper Network, CasperLabs, and the CSPR token sale  
+`Changelog <changelog.html>`_                                     Review past technical releases and changelogs for the Casper Network 
 ================================================================  ========================================================================
    
 


### PR DESCRIPTION
This PR adds a changelog page to the documentation, acting as a library to past releases:

<img width="1175" alt="Screen Shot 2021-06-01 at 2 54 25 PM" src="https://user-images.githubusercontent.com/4185994/120340522-f5dc0c80-c2aa-11eb-8ddf-181bd8374083.png">

On the changelog page, each version will be formatted as a heading, so that a direct link can be created:

<img width="386" alt="Screen Shot 2021-06-01 at 2 55 42 PM" src="https://user-images.githubusercontent.com/4185994/120340386-d7761100-c2aa-11eb-888b-da8463040bbc.png">

Also, a list will be shown in the top right corner of the changelog page:

<img width="1185" alt="Screen_Shot_2021-06-01_at_2_54_51_PM" src="https://user-images.githubusercontent.com/4185994/120345528-66852800-c2af-11eb-9bdd-7a4f113f5143.png">

The changelog can be accessed in two ways:
1. from the documentation landing page (see below)
2. or by knowing the direct link https://docs.casperlabs.io/en/latest/changelog.html

<img width="1038" alt="Screen_Shot_2021-06-01_at_2_44_24_PM" src="https://user-images.githubusercontent.com/4185994/120340613-0c826380-c2ab-11eb-8e3b-9ba69788321a.png">

