### PR TITLE
Update URef rights and initial supply section

### DIFF
--- a/implementation/tokens.rst
+++ b/implementation/tokens.rst
@@ -15,9 +15,7 @@ This chapter describes how we define tokens and how one can use them on the Casp
 Token Generation and Distribution
 ---------------------------------
 
-A blockchain system generally needs to have a supply of tokens available to pay for computation and reward validators for processing transactions on the network. A great deal of effort has been taken to ensure that no single individual or entity acquires more than 1% of the tokens from the onset.
-
-In addition to the initial supply, the system will have a low rate of inflation, the results of which will be paid out to validators in the form of seigniorage.
+A blockchain system generally needs to have a supply of tokens available to pay for computation and reward validators for processing transactions on the network. The initial supply at the launch of Mainnet was 10 billion CSPR, the current supply is available `here <https://api.cspr.live/supply>`_. In addition to the initial supply, the system will have a low rate of inflation, the results of which will be paid out to validators in the form of seigniorage.
 
 The number of tokens used as a basis for calculating seigniorage is 10 billion.
 
@@ -103,7 +101,7 @@ It is dangerous to pass a purse's ``URef`` with ``Write`` permissions to a contr
        _ => contract_api::revert(1),
    }
 
-To avoid this inconvenience, it is a better practice for application developers intending to accept payment on-chain to make a version of their own purse ``URef`` with ``Read`` access rights publicly available. This allows clients to pay via a transfer using their purse, without either party exposing ``Write`` access to any purse.
+To avoid this inconvenience, it is a better practice for application developers intending to accept payment on-chain to make a version of their own purse ``URef`` with ``Read`` and ``Add``  access rights publicly available. This allows clients to pay via a transfer using their purse, without either party exposing ``Write`` access to any purse.
 
 
 .. _tokens-purses-and-accounts:

--- a/implementation/tokens.rst
+++ b/implementation/tokens.rst
@@ -15,7 +15,7 @@ This chapter describes how we define tokens and how one can use them on the Casp
 Token Generation and Distribution
 ---------------------------------
 
-A blockchain system generally needs to have a supply of tokens available to pay for computation and reward validators for processing transactions on the network. The initial supply at the launch of Mainnet was 10 billion CSPR, the current supply is available `here <https://api.cspr.live/supply>`_. In addition to the initial supply, the system will have a low rate of inflation, the results of which will be paid out to validators in the form of seigniorage.
+A blockchain system generally needs to have a supply of tokens available to pay for computation and reward validators for processing transactions on the network. The initial supply at the launch of Mainnet was 10 billion CSPR. The current supply is available `here <https://api.cspr.live/supply>`_. In addition to the initial supply, the system will have a low rate of inflation, the results of which will be paid out to validators in the form of seigniorage.
 
 The number of tokens used as a basis for calculating seigniorage is 10 billion.
 


### PR DESCRIPTION
CHANGELOG:

- Update section in URef usage to specify both `Read` and `Add` access rights
- Updated section of generation and distribution to mention the initial supply of 10 bil CSPR alongside a link to view current available supply