### PR TITLE
script-sdk: fix unused gasPrice variable

### DIFF
--- a/dapp-dev-guide/sdk/script-sdk.rst
+++ b/dapp-dev-guide/sdk/script-sdk.rst
@@ -127,6 +127,7 @@ The ``sendTransfer`` function below will return a ``transfer-hash`` which you ca
     let deployParams = new DeployUtil.DeployParams(
         signKeyPair.publicKey,
         networkName,
+        gasPrice,
         ttl
     );
 


### PR DESCRIPTION
```
const ttl = 1800000;

let deployParams = new DeployUtil.DeployParams(
    signKeyPair.publicKey,
    networkName,
    ttl
);
```

The gasPrice variable is not used in the construction of the deploy params. It could be misleading as a copy-paste would set gasPrice to the value of ttl i.e 1800000