### PR TITLE
Updating Network Payment GAS cost.

### DIFF
--- a/workflow/delegate.rst
+++ b/workflow/delegate.rst
@@ -69,7 +69,7 @@ Send a deploy containing the ``delegate.wasm`` to the network to initiate the de
     --node-address http://<peer-ip-address>:7777/rpc \
     --chain-name casper \
     --session-path <path-to-wasm>/delegate.wasm \
-    --payment-amount 2500000000 \
+    --payment-amount 3000000000 \
     --session-arg "validator:public_key='<hex-encoded-validator-public-key>'" \
     --session-arg "amount:u512='<amount-to-delegate>'" \
     --session-arg "delegator:public_key='<hex-encoded-public-key>'" \


### PR DESCRIPTION
Existing value 2500000000 non-functional and leads to failed transaction and wasted Casper.  Needs 3000000000 minimum to function.