### PR TITLE
Update README to fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ to missing LaTeX packages.
 sudo apt-get install texlive*
 ```
 
-If you are still running into problems, you may solve them using
-[TeX Live's own distribution](https://www.tug.org/texlive/acquire-netinstall.html)
+If you are still running into problems, you may solve them using the
+[TeX Live distribution](https://www.tug.org/texlive/acquire-netinstall.html)
 instead of the packages from the native package manager.
 
 ## Building


### PR DESCRIPTION
Build for PR 369 is OK: https://drone-auto-casper-network.casperlabs.io/casper-network/docs/123
After merging the PR, the build fails due to timeouts:
https://drone-auto-casper-network.casperlabs.io/casper-network/docs/124/1/3
There is nothing wrong with those links, they work. Somehow the drone running the CI/CD pipeline could not fetch the links and they timed out.
I am making a simple change to re-trigger the build with this PR:
https://github.com/casper-network/docs/pull/370/files.