### PR TITLE
C# SDK link updated. Now under make-software GitHub org.

### DIFF
--- a/dapp-dev-guide/sdk/csharp-sdk.rst
+++ b/dapp-dev-guide/sdk/csharp-sdk.rst
@@ -1,7 +1,7 @@
 C# SDK (NetCasperSDK)
 =====================
 
-The `C# SDK <https://github.com/davidatwhiletrue/netcaspersdk>`_ allows developers to interact with the Casper Network using C#. This page covers different examples of using the SDK.
+The `C# SDK <https://github.com/make-software/casper-net-sdk>`_ allows developers to interact with the Casper Network using C#. This page covers different examples of using the SDK.
 
 Build
 ^^^^^

--- a/dapp-dev-guide/sdk/index.rst
+++ b/dapp-dev-guide/sdk/index.rst
@@ -12,7 +12,7 @@ The following table provides links to the SDK documentation, in addition to the 
  Java SDK (work in progress)                                                              https://github.com/casper-network/casper-java-sdk/
  `Golang SDK <go-sdk.html>`_ (work in progress)                                           https://github.com/casper-ecosystem/casper-golang-sdk/
  `Python SDK <python-sdk.html>`_ (work in progress)                                       https://github.com/casper-network/casper-python-sdk/ 
- `C# SDK <csharp-sdk.html>`_ (work in progress)                                           https://github.com/davidatwhiletrue/netcaspersdk  
+ `C# SDK <csharp-sdk.html>`_ (work in progress)                                           https://github.com/make-software/casper-net-sdk
 ======================================================================================    ==========================================================================================================================================
 
 .. toctree::

--- a/dapp-dev-guide/testing.rst
+++ b/dapp-dev-guide/testing.rst
@@ -5,7 +5,7 @@
 Testing Contracts
 =================
 
-As part of the Casper local Rust contract development environment we provide an in-memory virtual machine you can run your contract against. A full node is not required for testing.  The testing framework is designed to be used in the following way:
+As part of the Casper local Rust contract development environment we provide an in-memory virtual machine and `testing framework https://docs.rs/casper-engine-test-support/latest/casper_engine_test_support/>`_ you can run your contract against. A full node is not required for testing. The testing framework is designed to be used in the following way:
 
 
 #. Initialize the system (context).
@@ -18,7 +18,7 @@ This environment enables the testing of blockchain enabled systems from end to e
 The TestContext for Rust Contracts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A  `TestContext <https://docs.rs/casper-engine-test-support/latest/casper_engine_test_support/struct.TestContext.html>`_ provides a virtual machine instance. It should be a mutable object as its internal data will change with each deploy. It's also important to set an initial balance for the account to use for deploys, as the system requires a balance in order to create an account.
+A  TestContext provides a virtual machine instance. It should be a mutable object as its internal data will change with each deploy. It's also important to set an initial balance for the account to use for deploys, as the system requires a balance in order to create an account.
 
 .. code-block:: rust
 
@@ -33,7 +33,7 @@ Account is type of ``[u8; 32]``. Balance is type of ``U512``.
 Running the Rust Smart Contract
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Before the contract can be deployed to the context, the request has to be prepared. A request is referred to as a `Session <https://docs.rs/casper-engine-test-support/latest/casper_engine_test_support/struct.Session.html>`_. Each session call has 4 elements:
+Before the contract can be deployed to the context, the request has to be prepared. A request is referred to as a Session. Each session call has 4 elements:
 
 
 * A Wasm file path.

--- a/dapp-dev-guide/writing-contracts/writing-rust-contracts.rst
+++ b/dapp-dev-guide/writing-contracts/writing-rust-contracts.rst
@@ -140,7 +140,7 @@ Account is type of ``[u8; 32]``. Balance is type of ``U512``.
 Run Smart Contract
 ^^^^^^^^^^^^^^^^^^
 
-Before we can deploy the contract to the context, we need to prepare the request. We call the request a `Session <https://docs.rs/casper-engine-test-support/latest/casper_engine_test_support/struct.Session.html>`_. Each session call should have 4 elements:
+Before we can deploy the contract to the context, we need to prepare the request. We call the request a session, and each session call should have 4 elements:
 
 
 * Wasm file path.

--- a/dapp-dev-guide/writing-contracts/writing-rust-contracts.rst
+++ b/dapp-dev-guide/writing-contracts/writing-rust-contracts.rst
@@ -125,7 +125,7 @@ As part of the Casper local environment we provide the in-memory virtual machine
 TestContext
 ^^^^^^^^^^^
 
-A  `TestContext <https://docs.rs/casper-engine-test-support/latest/casper_engine_test_support/struct.TestContext.html>`_ provides a virtual machine instance. It should be a mutable object as we will change its internal data while making deploys. It's also important to set an initial balance for the account to use for deploys.
+A  TestContext provides a virtual machine instance. It should be a mutable object as we will change its internal data while making deploys. It's also important to set an initial balance for the account to use for deploys.
 
 .. code-block:: rust
 


### PR DESCRIPTION
NetCasperSDK is now renamed to Casper .NET SDK and moved to `make-software` organization in GitHub. 
This PR is to update the links in the related C# SDK documentation page.