### PR TITLE
Remove extra cd command from install instructions

### DIFF
--- a/source/docs/casper/dapp-dev-guide/getting-started.md
+++ b/source/docs/casper/dapp-dev-guide/getting-started.md
@@ -118,7 +118,6 @@ cargo casper --help
 To build the project, go into the `my-project` folder, install the Rust toolchain and specify the target build as WebAssembly (wasm32):
 
 ```
-cd contract
 cd my-project
 rustup install $(cat rust-toolchain)
 rustup target add --toolchain $(cat rust-toolchain) wasm32-unknown-unknown


### PR DESCRIPTION
### Changes

rustup install nightly instructions contained an extra cd that was unncessary
