### PR TITLE
Fix formatting for password requirements in Signer Guide

### DIFF
--- a/source/docs/casper/workflow/signer-guide.md
+++ b/source/docs/casper/workflow/signer-guide.md
@@ -28,7 +28,21 @@ To log in to the Casper Signer, you must create a vault and import or create acc
 1. Next to the address bar of your browser, you will find the extensions icon. Click the extensions icon <img src={useBaseUrl("/image/tutorials/signer/ext-icon.png")} class="inline-img" width="25"/> and select CasperLabs Signer from the list.
 
     1. If you are logging in for the first time, a pop-up window to create a new vault will appear.
-    2. On the New Vault pop-up window, enter a password for your vault, confirm the password, and click **CREATE VAULT**. This vault safeguards your Casper accounts, so make sure you use a strong password and keep the password safe. Password requirements: - It must be at least 10 characters long - It must contain the following: - at least one uppercase letter - at least one lowercase letter - at least one number - at least one special character - It may not contain sequences of three or more repeated characters
+    2. On the New Vault pop-up window, enter a password for your vault, confirm the password, and click **CREATE VAULT**. This vault safeguards your Casper accounts, so make sure you use a strong password and keep the password safe.
+    
+    :::note
+
+    Password requirements: 
+    
+    - It must be at least 10 characters long 
+    - It must contain the following: 
+       - at least one uppercase letter 
+       - at least one lowercase letter 
+       - at least one number 
+       - at least one special character 
+    - It may not contain sequences of three or more repeated characters
+
+    :::
 
 2. If you have already created a password for your vault, the Unlock Vault pop-up window is displayed. Enter your password and click **UNLOCK**.
 3. You can now import an account or create a new one.


### PR DESCRIPTION
I noticed that this section was not formatted well:

<img width="689" alt="Signer formatting" src="https://user-images.githubusercontent.com/4185994/146095674-34eee159-c5e1-48b2-b955-5110179b8816.png">


I've updated it to look like this:

<img width="694" alt="Screen Shot 2021-12-14 at 7 27 03 PM" src="https://user-images.githubusercontent.com/4185994/146095680-ece72b34-f712-425a-89c4-ee187c23692e.png">

