### PR TITLE
GitHub Pages CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,9 @@ jobs:
         run: |
           yarn build --out-dir ./docs
 
-    # Popular action to deploy to GitHub Pages:
-    # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # Build output to publish to the `gh-pages` branch:
           publish_dir: ./docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: Docusaurus CICD
+
+on:
+  push:
+    branches: "*"
+
+jobs:
+  cicd:
+    runs-on: ubuntu-latest
+
+    env:
+      selected_node_version: 14
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ env.selected_node_version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.selected_node_version }}
+          cache: yarn
+          
+      - name: Yarn install
+        run: |
+          yarn install
+
+      - name: Run code analysis
+        run: |
+          yarn format
+
+      - name: Build app
+        run: |
+          yarn build --out-dir ./docs
+
+    # Popular action to deploy to GitHub Pages:
+    # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages` branch:
+          publish_dir: ./docs

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ dist
 
 # IDE
 .idea
+
+#act github action testing
+.secrets
+.act/
+
+#vim
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,3 @@ dist
 
 # IDE
 .idea
-
-#act github action testing
-.secrets
-.act/
-
-#vim
-*.swp


### PR DESCRIPTION
### Related links

N/A

### Changes

First setup of a Github Action setup to automatically build and deploy to the Github Pages site (CI/CD). 
The deployment happens only on pushes to the main branch (pull requests merges counts as such).

For the moment, it will deploy to the site: https://casper-network.github.io/ and will not affect the current prod.

After, if everything works correctly, the casper.network/docs site will need to point to casper-network.github.io/docs.
This might lead to other small changes.

### Notes

In the previous unmerged version there was a "test-deploy" phase in which  there were system tests on AWS LocalStack which had to pass before deploying to prod. Those, will be implemented in subsequent pull requests using Jekyll most probably. (See https://github.com/bradjohnl/docs/blob/bradjohnl-cicd_aws_ghactions/.github/workflows/main.yml).

Following DevOps and CI/CD best practices, I am requesting to merge a first basic version and then build up complexity on top of that with future pull requests.

The changes in this PR are set to replicate the CircleCI setup under .circleci/config.yml. Using GithubPages, as you can see results in greater simplicity and cost reduction for hosting static websites.

