### PR TITLE
Bradjohnl cicd on pull request too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: "*"
   pull_request:
-    branches: 
-      - main
     types: [ opened, reopened, synchronize ]
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches: "*"
   pull_request:
-    branches:
-    - main
+    branches: 
+      - main
+    types: [ opened, reopened, synchronize ]
 
 jobs:
   cicd:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
           cache: yarn
       
       - name: Template credentials
+        if: github.ref == 'refs/heads/main'
         uses: cuchi/jinja2-action@v1.2.0
         with:
           template: .github/templates/.env.production.j2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: Docusaurus CICD
 on:
   push:
     branches: "*"
+  pull_request:
+    branches:
+    - main
 
 jobs:
   cicd:


### PR DESCRIPTION
### Related links

https://stackoverflow.com/a/58655352

### Changes

I noticed that the GitHub Actions pipeline was not being triggered when the pull request was created using a fork. This pull request allows it.
Also the templating of the .env.production files has been set up to be executed only when on the main branch as that file is needed only if you are about to deploy to prod.
As I noticed that sometimes pull requests are created to non-main branches, I changed the workflow to run on pull-requests with any branch as target.

### Notes

It's good to be able to check the build status when a pull request gets created. The reviewer does not have to check the fork where it comes from and already knows that he/she should not check it if the workflow is not successful.

The reviewer should also not trust the build action results of a forked repository.

Further improvements can be done using this setting:
https://stackoverflow.com/a/58655352
In this way, the pull requests get rejected automatically if the CICD action fail.
