### PR TITLE
Implementation of Prod tests post deployment with rollback if one fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   backup:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,21 @@ on:
     types: [ opened, reopened, synchronize ]
 
 jobs:
-  cicd:
+  backup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: gh-pages-backup
+          path: .
+        
+
+  build:
     runs-on: ubuntu-latest
 
     env:
@@ -48,9 +62,64 @@ jobs:
         run: |
           yarn build --out-dir ./docs
 
-      - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
+      - uses: actions/upload-artifact@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
+          name: gh-pages-depl-payload
+          path: ./docs
+
+  deploy-prod:
+    if: github.ref == 'refs/heads/main'
+    needs: [build, backup]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@master
+      with:
+        name: gh-pages-depl-payload
+        path: ./docs
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+
+  test-prod:
+    needs: deploy-prod
+    runs-on: ubuntu-latest
+
+    env:
+      prod_pages_url: ${{ secrets.PROD_PAGES_URL }}
+
+    steps:
+      - name: Test home page
+        run: |
+          echo "Testing if homepage responds correctly"
+          curl --fail $prod_pages_url
+      - name: Test a random page
+        run: |
+          echo "Testing if a page responds correctly"
+          curl --fail $prod_pages_url/operators/create
+      - name: Test another random page
+        run: |
+          echo "Testing if a page responds correctly"
+          curl --fail $prod_pages_url/design/serialization-standard
+
+  rollback-if-tests-fail:
+    if: ${{ always() && (needs.test-prod.result=='failure') }}
+    needs: test-prod
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@master
+      with:
+        name: gh-pages-backup
+        path: ./docs
+
+    - name: Deploy the previous version to Github Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs
+
+      


### PR DESCRIPTION
### Changes

Post-deployment tests are performed and the previous version of the site is deployed in case of failures
Tests can be expanded with more functionality.

The same strategy will be used in a planned feature where the GitHub pages site is first deployed locally by the runner.
