### PR TITLE
The deployment artifact should be uploaded only if a deployment is expected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,7 @@ jobs:
           yarn build --out-dir ./docs
 
       - uses: actions/upload-artifact@v2
+        if: github.ref == 'refs/heads/main'
         with:
           name: gh-pages-depl-payload
           path: ./docs


### PR DESCRIPTION
### Changes

This change prevents Github Actions from uploading the deployment artifact when no deployment is going to be made based on existing conditions.
