### PR TITLE
Updated readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Follow these steps to run the documentation website locally, displayed in your l
 
 ### Running the website locally
 
-1. Clone this repository on your machine: https://github.com/casper-network/docs/.
+1. Create a fork of the documentation repository: https://github.com/casper-network/docs/.
+2. Clone the fork on your machine.
 2. In the root folder, run the following commands:
     - `yarn install` - This is required only once for a folder
     - `yarn run start` - This will start the localhost server
@@ -32,7 +33,7 @@ Follow these steps to run the documentation website locally, displayed in your l
 1. Navigate to the `source/docs/casper` folder.
 2. Find the content you want to update and modify the markdown file(s). If you want to add new content, read the [Developer Guide](#developer-guide).
 3. [Run the website locally](#running-the-website-locally) to test your changes.
-4. Submit your changes using a pull request.
+4. Submit changes to the [documentation](https://github.com/casper-network/docs) using a pull request from your forked repository.
 
 **Note**: The website refreshes as you make changes to the markdown files. However, if you change the structure or configuration of the website, you need to re-start the application.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Follow these steps to run the documentation website locally, displayed in your l
 
 1. Create a fork of the documentation repository: https://github.com/casper-network/docs/.
 2. Clone the fork on your machine.
-2. In the root folder, run the following commands:
+2. In the forked folder, run the following commands:
     - `yarn install` - This is required only once for a folder
     - `yarn run start` - This will start the localhost server
 3. Access http://localhost:3000/ in your browser.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ Follow these steps to run the documentation website locally, displayed in your l
 
 ### Pre-requisites
 
--   Install `npm` (version 14.0+).
 -   Install a code editor, such as Visual Studio Code (`vscode`). You may also want to install editing extensions such as `prettier`, `eslint`, and others listed in the `.vscode/extensions.json` file.
--   Install Node.js from the [Node.js download page](https://nodejs.org/en/download/).
+-   Install [Node.js](https://nodejs.org/en/download/) (version 14+).
 -   Install `yarn` via `npm` using this command:
 
     ```
@@ -21,21 +20,21 @@ Follow these steps to run the documentation website locally, displayed in your l
 
 ### Running the website locally
 
-1. Clone this repository on your machine: [docs-app](https://github.com/casper-network/casper-node/docs-app).
-2. Open the `docs-app` directory.
-3. Run the following commands:
+1. Clone this repository on your machine: https://github.com/casper-network/docs/.
+2. In the root folder, run the following commands:
     - `yarn install` - This is required only once for a folder
     - `yarn run start` - This will start the localhost server
-4. Access http://localhost:3000/ in your browser.
-
-**Note**: The website refreshes as you make changes to the markdown files. However, if you change the structure or configuration of the website, you need to rerun steps 3 and 4.
+3. Access http://localhost:3000/ in your browser.
+4. See the next section for details on how to [update the content](#updating-existing-content).
 
 ### Updating existing content
 
 1. Navigate to the `source/docs/casper` folder.
 2. Find the content you want to update and modify the markdown file(s). If you want to add new content, read the [Developer Guide](#developer-guide).
-3. Test your changes locally.
+3. [Run the website locally](#running-the-website-locally) to test your changes.
 4. Submit your changes using a pull request.
+
+**Note**: The website refreshes as you make changes to the markdown files. However, if you change the structure or configuration of the website, you need to re-start yarn using `yarn stop` and `yarn run start`.
 
 ### Adding new content
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Follow these steps to run the documentation website locally, displayed in your l
 3. [Run the website locally](#running-the-website-locally) to test your changes.
 4. Submit your changes using a pull request.
 
-**Note**: The website refreshes as you make changes to the markdown files. However, if you change the structure or configuration of the website, you need to re-start yarn using `yarn stop` and `yarn run start`.
+**Note**: The website refreshes as you make changes to the markdown files. However, if you change the structure or configuration of the website, you need to re-start the application.
 
 ### Adding new content
 

--- a/source/README.md
+++ b/source/README.md
@@ -1,9 +1,0 @@
-> NOTE If you are looking for the Casper Network documentation, please go here: https://github.com/casper-network/docs/. This repository is used for the next version of the docs, which is still in development.
-
-## OVERVIEW
-
-It has been made for supporting all contributions or public activity about casper network core documentation source.
-
-## GITHUB FLOW
-
-This repository is the partial publication about documentation, i18n localization of [casper-network docs-app](https://github.com/casper-network/docs-app). All codebase of this repository has been embedded as a subtree module into [casper-network docs-app](https://github.com/casper-network/docs-app) source dir. We do not need to care about git subtree flow in this repository. we can simply use normal git flow based on the company own rule.


### PR DESCRIPTION
### Related links

Requirements card: https://github.com/casper-network/docs/issues/183

### Changes

- Updated the main README file:
    - removed references to the docs-app directory (the old name)
    - the source/docs/casper directory is already mentioned, so I pointed to the next section
    - specified Node version 14+ (instead of npm version 14); npm comes with the Node.js installation
- Removed an old README file in another directory

### Notes

I ran the site locally as well, even though the readme changes shouldn't have had any impact.
I cannot see any precomit hooks failing, but I reached out to the team to follow up on it.