### PR TITLE
Minor updates to the `getting started` and `nctl` guides

### DIFF
--- a/source/docs/casper/dapp-dev-guide/getting-started.md
+++ b/source/docs/casper/dapp-dev-guide/getting-started.md
@@ -124,7 +124,7 @@ The Casper local environment provides an in-memory virtual machine against which
 
 :::note
 
-Since the test script automatically builds the contract, during development you only need to run the command `make test` without the need for `cargo build`.
+Since the test script automatically builds the contract, during development you only need to run the command `make test` without the need for `make build-contract`.
 
 :::
 

--- a/source/docs/casper/dapp-dev-guide/setup-nctl.md
+++ b/source/docs/casper/dapp-dev-guide/setup-nctl.md
@@ -163,6 +163,12 @@ Instructions for MacOS and Linux:
 (env) $ nctl-compile
 ```
 
+:::note
+
+The compilation takes some time, so it might be a perfect moment to get some coffee.
+
+:::
+
 **Step 14.** Set up all the assets required to run a local network, including binaries, chainspec, config, faucet, and keys. Also, spin up the network right after. The default network will have 10 nodes, with 5 active nodes and 5 inactive nodes.
 
 Instructions for MacOS and Linux:


### PR DESCRIPTION
### Related links

Requirements: https://github.com/casper-network/docs/issues/185

### Changes

**Getting Started updates:**
- I updated the docs language in the “Test the Contract” section . It used to read:  “Since the test script automatically builds the contract, during development you only need to run the command make test without the need for “cargo build”.” However, we are no longer telling them to issue cargo build commands.

**NCTL guide updates:**
- The command “nctl-compile” takes well over 1 hour to compile everything. Added a note in the docs to go get coffee. I am not sure if this is in accordance with our style guide, but I wanted to let the reader know to expect a delay. @GloreenS and @Buddhika-Pathirathna, what do you think?
- Reply by Buddhika - @ipopescu - I think it's cool - audience-friendly - but not sure how seems on a professional level :) 
- <img width="697" alt="Screen Shot 2022-01-24 at 11 25 25 AM" src="https://user-images.githubusercontent.com/4185994/150765799-16e6b422-f1ef-4500-8f10-1aefaca42d94.png">

### Notes

The videos will also be updated as part of a different card since editing takes some time.


