### PR TITLE
Integrating Atlassian SRE FAQ

### DIFF
--- a/source/docs/casper/faq/faq-developer.md
+++ b/source/docs/casper/faq/faq-developer.md
@@ -86,6 +86,30 @@ sudo snap install cmake
 
 </details>
 
+<details>
+<summary><b>Can blockchain smart contracts interact with the outside world?</b></summary>
+
+No, smart contracts cannot interact with the world outside of the blockchain on which they live. For example, a smart contract cannot act as a REST endpoint or data source. Smart contracts can interact with other contracts in the same environment, or with compatible external libraries. When creating an external library to interact with a Casper smart contract, consider the following:
+
+* WASM is expressed as `little-endian` by default. Check for endianness compatibility.
+
+* As `wasm32-unknown-unknown` is a 32-bit platform, it cannot support 64-bit external code. Your library needs to be compatible with 32-bit code.
+
+* Consider a library that supports `no_std`.
+
+* Try to avoid native operating system calls. If the library uses the filesystem, sockets, or other native OS functionality, then it may not work with a Casper smart contract.
+
+</details>
+
+<details>
+<summary><b>Where can I begin learning about deploying NFTs on the Casper Network?</b></summary>
+
+The following link contains the current standard and an example implementation:
+
+[Enhancing the Casper NFT Standard](https://gitcoin.co/issue/casper-network/gitcoin-hackathon/8/100026584)
+
+</details>
+
 ### Finality Signatures {#finality-signatures}
 
 <details>
@@ -151,5 +175,199 @@ On-chain accounts are associated with an account address. Transaction data inclu
 **Question**: For wallet generation, can you point me to an open-source implementation or library? I see that Casper uses the ed25519 curve cryptography. Can you give me more details for seed generation?
 
 **Answer**: The <a href="https://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce">CasperLabs Signer</a> is a wallet-like application. But, it is simplistic and has not been security reviewed. The Casper Network supports ed25519 as well as secp256k1 keys; therefore, extending a current wallet implementation would not be difficult.
+
+</details>
+
+### Hackathon Questions
+
+<details>
+<summary><b>Why do I get an 'Encountered operation forbidden by gas rules' error?</b></summary>
+
+Casper node does not natively allow floating point opcodes. 
+
+</details>
+
+<details>
+<summary><b>How do I update my status in the Hackathon list?</b></summary>
+
+To update your status on the [Hackathon list](https://github.com/casper-network/gitcoin-hackathon/issues/29), you must update or submit your work on the [Gitcoin UI](https://gitcoin.co/issue/casper-network/gitcoin-hackathon/29).
+
+</details>
+
+<details>
+<summary><b>Do I need to use the `stop work` button after a project submission on Gitcoin?</b></summary>
+
+Yes, you will need to `stop work` to flag the submission as ready for review.
+
+</details>
+
+[//]: # "Is this still relevant?"
+
+<details>
+<summary><b>When installing casper-node, I receive a compilation error due to failing to select a version for snow.</b></summary>
+
+Use the following command:
+
+```
+cargo +nightly-2021-06-17 install casper-client --locked
+
+```
+
+</details>
+
+<details>
+<summary><b>When using the command ntcl-assets-setup && nctl-start, I receive a 'path too long' error.</b></summary>
+
+Choose a short path for your working directory. Otherwise, the NCTL tool will report that the path is too long.
+
+</details>
+
+<details>
+<summary><b>Why do I receive a 'casper-client: command not found' error when I run 'casper-client get-state-root-hash --node-address http://localhost:11101/`?</b></summary>
+
+1. Open this link: [https://repo.casperlabs.io/](https://repo.casperlabs.io/)
+2. Use the instructions to add our repo to your apt dependencies (Assuming you use Ubuntu).
+3. Use the command `sudo apt install casper-client`
+
+</details>
+
+<details>
+<summary><b>How do I resolve a `Failed to get RPC response: error sending request for url (http://127.0.0.1:22102/rpc): connection error: Connection reset by peer (os error 54)` error?</b></summary>
+
+You should specify RPC ports as follows:
+
+```
+
+[rpc_server]
+address = "0.0.0.0:11102"
+
+```
+
+You can find more command info [here](https://github.com/casper-network/casper-node/blob/master/utils/nctl/docs/commands-view-node.md#nctl-viewing-node-information)
+
+</details>
+
+<details>
+<summary><b>What is the '--chain-name' for NCTL?</b></summary>
+
+The chain name is Casper-net-1.
+
+</details>
+
+<details>
+<summary><b>Is there a way to query all the '(key, value)' pairs in a 'casper dictionary'?</b></summary>
+
+No, you need to know the keys before hand. If you want to iterate over the dictionary list, you can list keys numerically and keep the length in another value.
+
+</details>
+
+<details>
+<summary><b>How do I add ZK proofs within Casper?</b></summary>
+
+ZK proof inclusion would require building the proof verification inside the smart contract. You would need to add either of the following to your contract:
+
+[GitHub - paritytech/bn: Pairing cryptography library in Rust](https://github.com/paritytech/bn)
+
+or
+
+[GitHub - zkcrypto/pairing: Pairing-friendly elliptic curve library.](https://github.com/zkcrypto/pairing)
+
+Verifications would then need to use the associated library.
+
+</details>
+
+<details>
+<summary><b>How do I rectify an 'Invalid context' error caused by the 'mint_one' function from a CEP47 contract?</b></summary>
+
+Deploying a CEP47 contract sets the deploying account as admin by default. Only this account can execute burn and mint functions.
+
+</details>
+
+<details>
+<summary><b>Some NCTL commands are working correctly, while others are causing errors.</b></summary>
+
+This issue may be caused by an incomplete or unsuccessful install of NCTL. Once it is installed, use the command `nctl-status` to see if it is running normally. It should show five running noes and five stopped.
+
+If it does not, the NCTL install did not install correctly. Usually, the failure reasons are OS and hardware specifications. If you are running Linus on Windows, we suggest switching to VirtualBox.
+
+</details>
+
+<details>
+<summary><b>When running 'nctl-assets-setup && nctl-start' I receive a 'Command 'supervisord' not found' error.</b></summary>
+
+You need to install supervisor in your Python virtual environment using `pip install supervisor`
+
+</details>
+
+<details>
+<summary><b>Can you explain 'get-account-key', 'get-key-pair', 'get-key-pair-from-*', 'get-signature' and 'get-hash'?</b></summary>
+
+These are cryptography related functions. Casper Node supports two ECC curves, secp256k1 and ed25519. Additionally, it supports blake2b as a hashing algorithm by default. The Python implementations are as follows:
+
+[casper-python-sdk/pycspr/crypto at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/tree/main/pycspr/crypto)
+
+[casper-python-sdk/ecc.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/ecc.py)
+
+[casper-python-sdk-hashifier.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/hashifier.py)
+
+[casper-python-sdk/hashifier_blake2b.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/hashifier_blake2b.py)
+
+The following are Java implementations:
+
+[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/CasperSdk.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/CasperSdk.java)
+
+[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/SigningService.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/SigningService.java)
+
+[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java)
+
+Both `get-account-key` and `get-account-hash` are higher level CL specific cryptographic functions. `get-account-key` returns the underlying key pair's public key, prefixed with a single byte indicating the ECC curve type. `get-account-hash` returns the on-chain address of hte account associated with an account key. Here are the Python implementations:
+
+[casper-python-sdk/cl_operations.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/cl_operations.py)
+
+Here are the Java implementations:
+
+[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java)
+
+The `get-account-hash` function is specific and needs to be implemented correctly. Otherwise, the derived on-chain account addresses will be incorrect and funds may be lost.
+
+</details>
+
+<details>
+<summary><b>'Keys-manager.js' does not appear in client code. How is it used?</b></summary>
+
+`scenario-*.js` accesses functions from `key-manager.js` through `const keyManager = require('./key-manager');`
+
+</details>
+
+<details>
+<summary><b>Libs.rs and api.rs are not present in contract/src within keys-manager as per the video tutorial. I only see main.rs and errors.rs.</b></summary>
+
+This is a correctly compiled and deployed. All important functions fall under main.rs after a recent update.
+
+</details>
+
+<details>
+<summary><b>What is the difference between key management and deployment?</b></summary>
+
+There are two types of action that an account can perform: deployment and key management. Deployment is simply executing some code on the blockchain, while key management involves changing the associated keys. Key management cannot be performed independently, but must come via a deploy. Therefore, a key management action implies that a deployment action also occurs.
+
+</details>
+
+<details>
+
+<summary><b>When I attempted to run 'nctl-compile' on MacOS, I received the following error: 'error: failed to run custom build command for 'openssl-sys v0.9.67'</b></summary>
+
+If you issue the command `brew info openssl` it will return info that appears similar to the following:
+
+```
+...
+For pkg-config to find openssl@3 you may need to set:
+    export PKG_CONFIG_PATH="usr/local/opt/openssl@3/lib/pkgconfig"
+...
+```
+
+The next step is to issue the above command. In this example, you would use `PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"`
+
+After this, `nctl-compile` should work correctly.
 
 </details>

--- a/source/docs/casper/faq/faq-developer.md
+++ b/source/docs/casper/faq/faq-developer.md
@@ -1,6 +1,6 @@
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
 # FAQ - Developers
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This section covers frequently asked questions and our recommendations from the developer's perspective.
 
@@ -92,21 +92,95 @@ sudo snap install cmake
 No, smart contracts cannot interact with the world outside of the blockchain on which they live. For example, a smart contract cannot act as a REST endpoint or data source. Smart contracts can interact with other contracts in the same environment, or with compatible external libraries. When creating an external library to interact with a Casper smart contract, consider the following:
 
 * WASM is expressed as `little-endian` by default. Check for endianness compatibility.
-
 * As `wasm32-unknown-unknown` is a 32-bit platform, it cannot support 64-bit external code. Your library needs to be compatible with 32-bit code.
-
 * Consider a library that supports `no_std`.
-
 * Try to avoid native operating system calls. If the library uses the filesystem, sockets, or other native OS functionality, then it may not work with a Casper smart contract.
 
 </details>
 
 <details>
-<summary><b>Where can I begin learning about deploying NFTs on the Casper Network?</b></summary>
+<summary><b>Is CSPR an ERC-20 token?</b></summary>
 
-The following link contains the current standard and an example implementation:
+No, CSPR is a native token that resides on a layer 1 protocol. It does not rely on another token.
 
-[Enhancing the Casper NFT Standard](https://gitcoin.co/issue/casper-network/gitcoin-hackathon/8/100026584)
+</details>
+
+<details>
+<summary><b>What determines the cost of a deploy?</b></summary>
+
+Native system transfers have a fixed gas cost. Calling system contracts by their hashes also has a fixed cost.
+
+If two calls with different arguments but for the same hash show different gas costs, it is a result of executed WASM code. Different arguments may lead to different code paths and executed opcodes. You cannot predict the number of executed opcodes or host functions.
+
+If the calls use the same arguments, yet the cost is increasing, you might consider reviewing your global state usage. There is a chance that you are reading a collection from the global state, updating it and writing back with a larger size.
+
+</details>
+
+<details>
+<summary><b>Why do I receive a 'casper-client: command not found' error?</b></summary>
+
+Refer to the [Casper Command-line Client](https://casper.network/docs/workflow/setup#the-casper-command-line-client) document for instructions on interacting with the Casper Network.
+
+</details>
+
+### CSPR Transactions {#cspr-transactions}
+
+<details>
+<summary><b>What should I do if I am encountering errors installing cargo-casper?</b></summary>
+
+Ensure that you have installed both Rust and CMake before attempting to install cargo-casper.
+
+</details>
+
+<details>
+<summary><b>Why does my deploy get an 'Out of Gas' error?</b></summary>
+
+If you receive this error, try specifying a higher amount of CSPR for the deployment.
+
+</details>
+
+<details>
+<summary><b>Is there an API available to query CSPR transactions?</b></summary>
+
+The client API of Casper Node is available at [Casper RPC API](http://casper-rpc-docs.s3-website-us-east-1.amazonaws.com/). You can find specific node-addresses at cspr.live for the [testnet](https://testnet.cspr.live/tools/peers) or [mainnet](https://cspr.live/tools/peers).
+
+</details>
+
+<details>
+ <summary><b>How can I query a transaction for an account?</b></summary>
+
+On-chain accounts are associated with an account address. Transaction data includes account address as a sub-field.
+
+</details>
+
+### Information on nctl
+
+
+<details>
+<summary><b>Some nctl commands are working correctly, while others are causing errors.</b></summary>
+
+This issue may be caused by an incomplete or unsuccessful install of nctl. Once it is installed, use the command `nctl-status` to see if it is running normally. It should show five running noes and five stopped.
+
+If it does not, the nctl install did not install correctly. Usually, the failure reasons are OS and hardware specifications. If you are running Linus on Windows, we suggest switching to VirtualBox.
+
+</details>
+
+<details>
+
+<summary><b>When I attempted to run 'nctl-compile' on MacOS, I received the following error: 'error: failed to run custom build command for 'openssl-sys v0.9.67'</b></summary>
+
+If you issue the command `brew info openssl` it will return info that appears similar to the following:
+
+```
+...
+For pkg-config to find openssl@3 you may need to set:
+    export PKG_CONFIG_PATH="usr/local/opt/openssl@3/lib/pkgconfig"
+...
+```
+
+The next step is to issue the above command. In this example, you would use `PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"`.
+
+After this, `nctl-compile` should work correctly.
 
 </details>
 
@@ -147,38 +221,7 @@ Suppose an exchange connects to someone else's node RPC to send transactions to 
 
 </details>
 
-### Other
-
-<details>
- <summary><b>Does the node API have a 'getTransactions' function?</b></summary>
-
-The node API JSON-RPC is found <a href="http://casper-rpc-docs.s3-website-us-east-1.amazonaws.com/ ">here</a>. Also, the node emits the following events:
-
--   BlockAdded
--   DeployProcessed
--   ConsensusFinalitySignature
-
-With these APIs, you can pull information from the node, such as transaction sets.
-
-</details>
-
-<details>
- <summary><b>How can I query a transaction for an account?</b></summary>
-
-On-chain accounts are associated with an account address. Transaction data includes account address as a sub-field.
-
-</details>
-
-<details>
- <summary><b>Do you have an example wallet or library?</b></summary>
-
-**Question**: For wallet generation, can you point me to an open-source implementation or library? I see that Casper uses the ed25519 curve cryptography. Can you give me more details for seed generation?
-
-**Answer**: The <a href="https://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce">CasperLabs Signer</a> is a wallet-like application. But, it is simplistic and has not been security reviewed. The Casper Network supports ed25519 as well as secp256k1 keys; therefore, extending a current wallet implementation would not be difficult.
-
-</details>
-
-### Hackathon Questions
+### Floating Point Opcodes {#floating-point-opcodes}
 
 <details>
 <summary><b>Why do I get an 'Encountered operation forbidden by gas rules' error?</b></summary>
@@ -187,79 +230,7 @@ Casper node does not natively allow floating point opcodes.
 
 </details>
 
-<details>
-<summary><b>How do I update my status in the Hackathon list?</b></summary>
-
-To update your status on the [Hackathon list](https://github.com/casper-network/gitcoin-hackathon/issues/29), you must update or submit your work on the [Gitcoin UI](https://gitcoin.co/issue/casper-network/gitcoin-hackathon/29).
-
-</details>
-
-<details>
-<summary><b>Do I need to use the `stop work` button after a project submission on Gitcoin?</b></summary>
-
-Yes, you will need to `stop work` to flag the submission as ready for review.
-
-</details>
-
-[//]: # "Is this still relevant?"
-
-<details>
-<summary><b>When installing casper-node, I receive a compilation error due to failing to select a version for snow.</b></summary>
-
-Use the following command:
-
-```
-cargo +nightly-2021-06-17 install casper-client --locked
-
-```
-
-</details>
-
-<details>
-<summary><b>When using the command ntcl-assets-setup && nctl-start, I receive a 'path too long' error.</b></summary>
-
-Choose a short path for your working directory. Otherwise, the NCTL tool will report that the path is too long.
-
-</details>
-
-<details>
-<summary><b>Why do I receive a 'casper-client: command not found' error when I run 'casper-client get-state-root-hash --node-address http://localhost:11101/`?</b></summary>
-
-1. Open this link: [https://repo.casperlabs.io/](https://repo.casperlabs.io/)
-2. Use the instructions to add our repo to your apt dependencies (Assuming you use Ubuntu).
-3. Use the command `sudo apt install casper-client`
-
-</details>
-
-<details>
-<summary><b>How do I resolve a `Failed to get RPC response: error sending request for url (http://127.0.0.1:22102/rpc): connection error: Connection reset by peer (os error 54)` error?</b></summary>
-
-You should specify RPC ports as follows:
-
-```
-
-[rpc_server]
-address = "0.0.0.0:11102"
-
-```
-
-You can find more command info [here](https://github.com/casper-network/casper-node/blob/master/utils/nctl/docs/commands-view-node.md#nctl-viewing-node-information)
-
-</details>
-
-<details>
-<summary><b>What is the '--chain-name' for NCTL?</b></summary>
-
-The chain name is Casper-net-1.
-
-</details>
-
-<details>
-<summary><b>Is there a way to query all the '(key, value)' pairs in a 'casper dictionary'?</b></summary>
-
-No, you need to know the keys before hand. If you want to iterate over the dictionary list, you can list keys numerically and keep the length in another value.
-
-</details>
+### ZK Proofs {#zk-proofs}
 
 <details>
 <summary><b>How do I add ZK proofs within Casper?</b></summary>
@@ -276,98 +247,59 @@ Verifications would then need to use the associated library.
 
 </details>
 
-<details>
-<summary><b>How do I rectify an 'Invalid context' error caused by the 'mint_one' function from a CEP47 contract?</b></summary>
+### Other
 
-Deploying a CEP47 contract sets the deploying account as admin by default. Only this account can execute burn and mint functions.
+<details>
+ <summary><b>Does the node API have a 'getTransactions' function?</b></summary>
+
+The node API JSON-RPC is found <a href="http://casper-rpc-docs.s3-website-us-east-1.amazonaws.com/ ">here</a>. Also, the node emits the following events:
+
+-   BlockAdded
+-   DeployProcessed
+-   ConsensusFinalitySignature
+
+With these APIs, you can pull information from the node, such as transaction sets.
 
 </details>
 
 <details>
-<summary><b>Some NCTL commands are working correctly, while others are causing errors.</b></summary>
+<summary><b>How do I resolve a `Failed to get RPC response: error sending request for url (http://127.0.0.1:22102/rpc): connection error: Connection reset by peer (os error 54)` error?</b></summary>
 
-This issue may be caused by an incomplete or unsuccessful install of NCTL. Once it is installed, use the command `nctl-status` to see if it is running normally. It should show five running noes and five stopped.
+You should specify RPC ports as follows:
 
-If it does not, the NCTL install did not install correctly. Usually, the failure reasons are OS and hardware specifications. If you are running Linus on Windows, we suggest switching to VirtualBox.
+```
+
+[rpc_server]
+address = "0.0.0.0:11102"
+
+```
+
+You can find more command info [here](https://github.com/casper-network/casper-node/blob/master/utils/nctl/docs/commands-view-node.md#nctl-viewing-node-information).
 
 </details>
 
 <details>
-<summary><b>When running 'nctl-assets-setup && nctl-start' I receive a 'Command 'supervisord' not found' error.</b></summary>
+<summary><b>Is there a way to query all the '(key, value)' pairs in a 'casper dictionary'?</b></summary>
 
-You need to install supervisor in your Python virtual environment using `pip install supervisor`
-
-</details>
-
-<details>
-<summary><b>Can you explain 'get-account-key', 'get-key-pair', 'get-key-pair-from-*', 'get-signature' and 'get-hash'?</b></summary>
-
-These are cryptography related functions. Casper Node supports two ECC curves, secp256k1 and ed25519. Additionally, it supports blake2b as a hashing algorithm by default. The Python implementations are as follows:
-
-[casper-python-sdk/pycspr/crypto at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/tree/main/pycspr/crypto)
-
-[casper-python-sdk/ecc.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/ecc.py)
-
-[casper-python-sdk-hashifier.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/hashifier.py)
-
-[casper-python-sdk/hashifier_blake2b.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/hashifier_blake2b.py)
-
-The following are Java implementations:
-
-[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/CasperSdk.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/CasperSdk.java)
-
-[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/SigningService.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/SigningService.java)
-
-[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java)
-
-Both `get-account-key` and `get-account-hash` are higher level CL specific cryptographic functions. `get-account-key` returns the underlying key pair's public key, prefixed with a single byte indicating the ECC curve type. `get-account-hash` returns the on-chain address of hte account associated with an account key. Here are the Python implementations:
-
-[casper-python-sdk/cl_operations.py at main - casper-network/casper-python-sdk](https://github.com/casper-network/casper-python-sdk/blob/main/pycspr/crypto/cl_operations.py)
-
-Here are the Java implementations:
-
-[https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java](https://github.com/casper-network/casper-java-sdk/blob/main/src/main/java/com/casper/sdk/service/HashService.java)
-
-The `get-account-hash` function is specific and needs to be implemented correctly. Otherwise, the derived on-chain account addresses will be incorrect and funds may be lost.
+No, you need to know the keys beforehand. If you want to iterate over the dictionary list, you can list keys numerically and keep the length in another value.
 
 </details>
 
 <details>
 <summary><b>'Keys-manager.js' does not appear in client code. How is it used?</b></summary>
 
-`scenario-*.js` accesses functions from `key-manager.js` through `const keyManager = require('./key-manager');`
-
-</details>
-
-<details>
-<summary><b>Libs.rs and api.rs are not present in contract/src within keys-manager as per the video tutorial. I only see main.rs and errors.rs.</b></summary>
-
-This is a correctly compiled and deployed. All important functions fall under main.rs after a recent update.
+`scenario-*.js` accesses functions from `key-manager.js` through `const keyManager = require('./key-manager');`.
 
 </details>
 
 <details>
 <summary><b>What is the difference between key management and deployment?</b></summary>
 
-There are two types of action that an account can perform: deployment and key management. Deployment is simply executing some code on the blockchain, while key management involves changing the associated keys. Key management cannot be performed independently, but must come via a deploy. Therefore, a key management action implies that a deployment action also occurs.
+There are two types of action that an account can perform: deployment and key management. Deployment is simply executing some code on the blockchain, while key management involves changing the associated keys. Key management cannot occur independently, but must come via a deploy. Therefore, a key management action implies that a deployment action also occurs.
 
-</details>
+You may also reference the following two documents for additional information:
 
-<details>
-
-<summary><b>When I attempted to run 'nctl-compile' on MacOS, I received the following error: 'error: failed to run custom build command for 'openssl-sys v0.9.67'</b></summary>
-
-If you issue the command `brew info openssl` it will return info that appears similar to the following:
-
-```
-...
-For pkg-config to find openssl@3 you may need to set:
-    export PKG_CONFIG_PATH="usr/local/opt/openssl@3/lib/pkgconfig"
-...
-```
-
-The next step is to issue the above command. In this example, you would use `PKG_CONFIG_PATH="/usr/local/opt/openssl@3/lib/pkgconfig"`
-
-After this, `nctl-compile` should work correctly.
+[Accounts](https://casper.network/docs/design/accounts)
+[Multi-Signature Tutorial](https://casper.network/docs/multi-sig)
 
 </details>

--- a/source/docs/casper/faq/faq-enterpise.md
+++ b/source/docs/casper/faq/faq-enterpise.md
@@ -12,9 +12,9 @@ Casper is an open-source Proof-of-Stake blockchain network built off the CBC ([C
 </details>
 
 <details>
- <summary><b>When is Casper's mainnet launch?</b></summary>
+ <summary><b>When was Casper's mainnet launch?</b></summary>
 
-Casper's mainnet launch will occur in Q1 2021.
+Casper's mainnet launched on [March 30th, 2021](https://casper.network/network/blog/casper-mainnet-is-live).
 
 </details>
 
@@ -62,7 +62,7 @@ Visit the [CasperLabs website](https://casperlabs.io/), [read the blog](https://
 <details>
   <summary><b>What's the difference between CasperLabs and Casper?</b></summary>
 
-CasperLabs is the development team that is currently building the Casper Network. CasperLabs has been developing Casper during its testnet phase and is currently planning for mainnet launch in Q1 2021. As a public, open-source network, Casper can be developed on and by anyone in addition to the CasperLabs team.
+CasperLabs is the development team that is currently building the Casper Network. CasperLabs has been developing Casper throughout both the testnet and mainnet periods. As a public, open-source network, Casper can be developed on and by anyone in addition to the CasperLabs team.
 
 </details>
 

--- a/source/docs/casper/faq/faq-general.md
+++ b/source/docs/casper/faq/faq-general.md
@@ -1,5 +1,16 @@
 # FAQ - General
 
+### Choosing a Validator {#choosing-a-validator}
+<details>
+
+<summary><b>What are the important aspects to consider when delegating tokens to a validator?</b></summary>
+
+Users should consider consistent uptime, prompt upgrades and commission rates when choosing a validator. Offline and out-of-date validators do not generate rewards.
+
+Active engagement in the community is another important aspect.
+
+</details>
+
 ### Deploy Processing {#deploy-processing}
 
 <details>
@@ -16,5 +27,62 @@ If a deploy was executed, then it has been finalized. If the deploy status comes
   
 Exchange customers or end-users only need to see the <em>account-hex</em>. They do not need to know the <em>account_hash</em>. The <em>account_hash</em> is needed in the backend to verify transactions. 
 Store the <em>account-hash</em> to query and monitor the account. Customers do not need to know this value, so to simplify their experience, we recommend storing both values and displaying only the <em>account-hex</em> value.
+
+</details>
+
+<details>
+<summary><b>Why is my account invalid when I can see it on the testnet?</b></summary>
+
+You must deposit tokens to activate it. You can request tokens from [CSPR Live](https://testnet.cspr.live/tools/faucet).
+
+</details>
+
+### Staking {#staking}
+
+<details>
+<summary><b>How do I stake tokens via the command line?</b></summary>
+
+The following command is an example of how to stake your tokens via the command line:
+
+```bash
+
+VALIDATOR_PUBLIC_KEY=the public key hex of your desired validator, from cspr.live, or testnet.cspr.live
+VALIDATOR_PUBLIC_KEY=$(cat /etc/casper/validator_keys/public_key_hex)
+NETWORK_NAME="casper-test"
+
+sudo -u casper casper-client put-deploy \
+    --chain-name casper-test \
+    --node-address http://localhost:7777 \
+    --secret-key /path/to/secret_key.pem \
+    --session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/delegate.wasm" \
+    --payment-amount 3000000000 \
+    --session-arg "validator:public_key='$VALIDATOR_PUBLIC_KEY'" \
+    --session-arg="amount:u512='555000000000'" \
+    --session-arg "delegator:public_key='$PUBLIC_KEY_HEX'"
+
+```
+
+</details>
+
+<details>
+<summary><b>How do I stake tokens in a GUI?</b></summary>
+
+[How to Stake your CSPR](https://casper.network/docs/workflow/staking)
+
+</details>
+
+<details>
+<summary><b>What is self-stake percentage?</b></summary>
+
+Self-stake is the amount of CSPR a validator personally staked on the network from their validating node, expressed as a percentage of the total amount of CSPR staked to that validator. Most validators choose to delegate their own tokens to their validating node as a security practice, which will show as a low self-stake percentage.
+
+</details>
+
+<details>
+<summary><b>What is slashing?</b></summary>
+
+Slashing is a penalty for inappropriate or malicious behavior. Ordinarily, the official node software will not act maliciously unless intentionally altered. When this happens, the validator in question gets slashed (Note: The network treats validator and delegator tokens equally).
+
+Slashing is not currently enabled on the Casper Mainnet. If a validator behaves poorly on the network, they face eviction from the network and loss of rewards. When slashing is enabled, poor behavior will result in token removal. In this case, you will lose any rewards accrued during the eviction period.
 
 </details>

--- a/source/docs/casper/faq/faq-validator.md
+++ b/source/docs/casper/faq/faq-validator.md
@@ -1,49 +1,6 @@
 # FAQ - Validators
 
-### Basic Questions
-
-<details>
-<summary><b>Is CSPR an ERC-20 token?</b></summary>
-
-No, CSPR is a native token that resides on a layer 1 protocol. It does not rely on another token.
-
-</details>
-
-<details>
-<summary><b>What determines the cost of a deploy?</b></summary>
-
-Native system transfers have a fixed gas cost. Calling system contracts by their hashes also has a fixed cost.
-
-If two calls with different arguments but for the same hash show different gas costs, it's caused by executed WASM code. Different arguments may lead to different code paths and executed opcodes. You cannot predict the number of executed opcodes or host functions.
-
-If the calls use the same arguments, yet the cost is increasing, you might consider reviewing your global state usage. There's a chance that you are reading a collection from the global state, updating it and writing back with a larger size.
-
-</details>
-
-### CSPR Transactions
-
-<details>
-<summary><b>What should I do if I am encountering errors installing cargo-casper?</b></summary>
-
-Ensure that you have installed both Rust and CMake before attempting to install cargo-casper.
-
-</details>
-
-<details>
-<summary><b>Why does my deploy get an 'Out of Gas' error?</b></summary>
-
-If you receive this error, try specifying a higher amount of CSPR for the deployment.
-
-</details>
-
-<details>
-<summary><b>Is there an API available to query CSPR transactions?</b></summary>
-
-The client API of Casper Node is available at [Casper RPC API](http://casper-rpc-docs.s3-website-us-east-1.amazonaws.com/). You can find specific node-addresses at cspr.live for the [testnet](https://testnet.cspr.live/tools/peers) or [mainnet](https://cspr.live/tools/peers)
-
-</details>
-
-### Node Status
+### Node Status {#node-status}
 
 <details>
 <summary><b>How do I check my node status?</b></summary>
@@ -86,23 +43,6 @@ If you are running a node, you can use `localhost:7777` for RPC requests like de
 </details>
 
 <details>
-
-<summary><b>What are the important aspects to consider when delegating tokens to a validator?</b></summary>
-
-Users should consider consistent uptime, prompt upgrades and commission rates when choosing a validator. Offline and out-of-date validators do not generate rewards.
-
-Active engagement in the community is another important aspect.
-
-</details>
-
-<details>
-<summary><b>Why is my account invalid when I can see it on the testnet?</b></summary>
-
-You must deposit tokens to activate it. You can request tokens from [CSPR Live](https://testnet.cspr.live/tools/faucet).
-
-</details>
-
-<details>
 <summary><b>How can I move my node to another machine?</b></summary>
 
 **Method One**
@@ -113,32 +53,32 @@ You must deposit tokens to activate it. You can request tokens from [CSPR Live](
 
 **Method Two**
 1. Create another node in parallel.
-2. Once it's up to date, stop the nodes.
+2. Once it is up to date, stop the nodes.
 3. Swap the associated keys.
 4. Restart the new node.
 
 </details>
 
-### Casper Compatibility
+### Casper Compatibility {#casper-compatibility}
 
 <details>
 <summary><b>Does Casper run on ARM?</b></summary>
 
-Casper-node does not wowrk with ARM type servers. You can see our hardware specifications [here](https://docs.casperlabs.io/en/latest/node-operator/hardware.html)
+Casper-node does not work with ARM type servers. You can see our hardware specifications [here](https://docs.casperlabs.io/en/latest/node-operator/hardware.html).
 
 </details>
 
 <details>
-<summary><b>What OSes are supported for casper-node?</b></summary>
+<summary><b>What operating systems are supported for casper-node?</b></summary>
 
-Casper is currently tested and packaged for Ubuntu 18.04 or 20.04
+Casper is currently tested and packaged for Ubuntu 18.04 or 20.04.
 
 </details>
 
 <details>
 <summary><b>Do you have Ledger support?</b></summary>
 
-Casper is working with Ledger to integrate wallet solutions. You can monitor the progress [here](https://github.com/Zondax/ledger-casper)
+Casper is working with Ledger to integrate wallet solutions. You can monitor the progress [here](https://github.com/Zondax/ledger-casper).
 
 </details>
 
@@ -148,67 +88,5 @@ Casper is working with Ledger to integrate wallet solutions. You can monitor the
 Validators must be online 24/7. Otherwise, they face ejection and loss of rewards as a result of liveness failure. Failure to participate in consensus for one era results in ejection.
 
 If you cannot run a node 24/7, you can delegate your tokens to a healthy validator node with good uptime.
-
-</details>
-
-### Staking
-
-<details>
-<summary><b>How do I stake tokens via the command line?</b></summary>
-
-The following command is an example of how to stake your tokens via the command line:
-
-```bash
-
-VALIDATOR_PUBLIC_KEY=the public key hex of your desired validator, from cspr.live, or testnet.cspr.live
-VALIDATOR_PUBLIC_KEY=$(cat /etc/casper/validator_keys/public_key_hex)
-NETWORK_NAME="casper-test"
-
-sudo -u casper casper-client put-deploy \
-    --chain-name casper-test \
-    --node-address http://localhost:7777 \
-    --secret-key /path/to/secret_key.pem \
-    --session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/delegate.wasm" \
-    --payment-amount 3000000000 \
-    --session-arg "validator:public_key='$VALIDATOR_PUBLIC_KEY'" \
-    --session-arg="amount:u512='555000000000'" \
-    --session-arg "delegator:public_key='$PUBLIC_KEY_HEX'"
-
-```
-
-</details>
-
-<details>
-<summary><b>How do I stake tokens in a GUI?</b></summary>
-
-Staking interfaces from various services will appear differently. The current recommended GUI staking is through the Casper Signer and cspr.live.
-
-1. Download and install the [Signer extension](https://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce) in a Chrome or Chromium-based browser.
-2. Set a password for your new vault of keys and `Create Vault`
-3. Click `Create an Account`
-4. Give your keys an alias and select an algorithm (Casper supports ed25519 and secp256k1).
-5. Go to the sign-in page for [cspr.live](https://cspr.live/sign-in) and click the red `Sign In` button. This will open signer and connect to the site.
-6. After linking your keys, you can go to the wallet drop-down and visit the [delegate stake page](https://cspr.live/delegate-stake).
-7. Confirm the transaction details on the next screen.
-8. To sign the transaction and send your delegation:
-- Click `Sign with Casper Signer`
-- The Signer app window will open. Make sure that the deploy hash in the Signer window matches the deploy hash in [cspr.live](https://cspr.live/) before continuing.
-- Click `Sign` in the Signer window to sign and finalize the transaction.
-
-</details>
-
-<details>
-<summary><b>What is self-stake percentage?</b></summary>
-
-Self-stake is the amount of CSPR a validator personally staked on the network from their validating node, expressed as a percentage of the total amount of CSPR staked to that validator. Most validators choose to delegate their own tokens to their validating node as a security practice, which will show as a low self-stake percentage.
-
-</details>
-
-<details>
-<summary><b>What is slashing?</b></summary>
-
-Slashing is a penalty for inappropriate or malicious behavior. Ordinarily, the official node software will not act maliciously unless intentionally altered. When this happens, the validator in question gets slashed (Note: The network treats validator and delegator tokens equally).
-
-Slashing is not currently enabled on the Casper Mainnet. If a validator behaves poorly on the network, they face eviction from the network and loss of rewards. When slashing is enabled, poor behavior will result in token removal. In this case, you will lose any rewards accrued during the eviction period.
 
 </details>

--- a/source/docs/casper/faq/faq-validator.md
+++ b/source/docs/casper/faq/faq-validator.md
@@ -1,3 +1,214 @@
 # FAQ - Validators
 
-Coming soon
+### Basic Questions
+
+<details>
+<summary><b>Is CSPR an ERC-20 token?</b></summary>
+
+No, CSPR is a native token that resides on a layer 1 protocol. It does not rely on another token.
+
+</details>
+
+<details>
+<summary><b>What determines the cost of a deploy?</b></summary>
+
+Native system transfers have a fixed gas cost. Calling system contracts by their hashes also has a fixed cost.
+
+If two calls with different arguments but for the same hash show different gas costs, it's caused by executed WASM code. Different arguments may lead to different code paths and executed opcodes. You cannot predict the number of executed opcodes or host functions.
+
+If the calls use the same arguments, yet the cost is increasing, you might consider reviewing your global state usage. There's a chance that you are reading a collection from the global state, updating it and writing back with a larger size.
+
+</details>
+
+### CSPR Transactions
+
+<details>
+<summary><b>What should I do if I am encountering errors installing cargo-casper?</b></summary>
+
+Ensure that you have installed both Rust and CMake before attempting to install cargo-casper.
+
+</details>
+
+<details>
+<summary><b>Why does my deploy get an 'Out of Gas' error?</b></summary>
+
+If you receive this error, try specifying a higher amount of CSPR for the deployment.
+
+</details>
+
+<details>
+<summary><b>Is there an API available to query CSPR transactions?</b></summary>
+
+The client API of Casper Node is available at [Casper RPC API](http://casper-rpc-docs.s3-website-us-east-1.amazonaws.com/). You can find specific node-addresses at cspr.live for the [testnet](https://testnet.cspr.live/tools/peers) or [mainnet](https://cspr.live/tools/peers)
+
+</details>
+
+### Node Status
+
+<details>
+<summary><b>How do I check my node status?</b></summary>
+
+Once your node is running, you can run `curl -s localhost:8888/status | jq .last_added_block_info` to query your local server's synchronization status. The output will look similar to:
+
+```bash
+
+curl -s http://localhost:8888/status | jq .last_added_block_info
+{
+  "hash": "73f398f89dfe2b980634281c0d6be8379b27aedbf4029f699219fafa1e09526c",
+  "timestamp": "2021-07-09T04:56:42.240Z",
+  "era_id": 1090,
+  "height": 106926,
+  "state_root_hash": "5e7bd420cb5d3290cf50036ada510c9c1adcf63198381c398403086f739394c8",
+  "creator": "011752f095ee6d2902540ea4fafd649da4b7b0c2a6e38176fb7f661a0e463d43b4"
+}
+
+```
+
+</details>
+
+<details>
+<summary><b>What ports are required for casper-node?</b></summary>
+
+Casper-node requires the following ports:
+
+* 35000 - Required for external visibility
+* 7777 - RPC endpoint for interaction with casper-client
+* 8888 - REST endpoint for status and metrics (This port allows your node to be part of the network status)
+* 9999 - SSE endpoint for event stream
+
+</details>
+
+<details>
+<summary><b>What '--node-address' do I use for making requests?</b></summary>
+
+If you are running a node, you can use `localhost:7777` for RPC requests like deploys. For node-health queries, use `localhost-8888`.
+
+</details>
+
+<details>
+
+<summary><b>What are the important aspects to consider when delegating tokens to a validator?</b></summary>
+
+Users should consider consistent uptime, prompt upgrades and commission rates when choosing a validator. Offline and out-of-date validators do not generate rewards.
+
+Active engagement in the community is another important aspect.
+
+</details>
+
+<details>
+<summary><b>Why is my account invalid when I can see it on the testnet?</b></summary>
+
+You must deposit tokens to activate it. You can request tokens from [CSPR Live](https://testnet.cspr.live/tools/faucet).
+
+</details>
+
+<details>
+<summary><b>How can I move my node to another machine?</b></summary>
+
+**Method One**
+1. Stop the node.
+2. Copy all data.
+3. Change the mountpoint.
+4. Start the node.
+
+**Method Two**
+1. Create another node in parallel.
+2. Once it's up to date, stop the nodes.
+3. Swap the associated keys.
+4. Restart the new node.
+
+</details>
+
+### Casper Compatibility
+
+<details>
+<summary><b>Does Casper run on ARM?</b></summary>
+
+Casper-node does not wowrk with ARM type servers. You can see our hardware specifications [here](https://docs.casperlabs.io/en/latest/node-operator/hardware.html)
+
+</details>
+
+<details>
+<summary><b>What OSes are supported for casper-node?</b></summary>
+
+Casper is currently tested and packaged for Ubuntu 18.04 or 20.04
+
+</details>
+
+<details>
+<summary><b>Do you have Ledger support?</b></summary>
+
+Casper is working with Ledger to integrate wallet solutions. You can monitor the progress [here](https://github.com/Zondax/ledger-casper)
+
+</details>
+
+<details>
+<summary><b>Do I have to run a node 24/7?</b></summary>
+
+Validators must be online 24/7. Otherwise, they face ejection and loss of rewards as a result of liveness failure. Failure to participate in consensus for one era results in ejection.
+
+If you cannot run a node 24/7, you can delegate your tokens to a healthy validator node with good uptime.
+
+</details>
+
+### Staking
+
+<details>
+<summary><b>How do I stake tokens via the command line?</b></summary>
+
+The following command is an example of how to stake your tokens via the command line:
+
+```bash
+
+VALIDATOR_PUBLIC_KEY=the public key hex of your desired validator, from cspr.live, or testnet.cspr.live
+VALIDATOR_PUBLIC_KEY=$(cat /etc/casper/validator_keys/public_key_hex)
+NETWORK_NAME="casper-test"
+
+sudo -u casper casper-client put-deploy \
+    --chain-name casper-test \
+    --node-address http://localhost:7777 \
+    --secret-key /path/to/secret_key.pem \
+    --session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/delegate.wasm" \
+    --payment-amount 3000000000 \
+    --session-arg "validator:public_key='$VALIDATOR_PUBLIC_KEY'" \
+    --session-arg="amount:u512='555000000000'" \
+    --session-arg "delegator:public_key='$PUBLIC_KEY_HEX'"
+
+```
+
+</details>
+
+<details>
+<summary><b>How do I stake tokens in a GUI?</b></summary>
+
+Staking interfaces from various services will appear differently. The current recommended GUI staking is through the Casper Signer and cspr.live.
+
+1. Download and install the [Signer extension](https://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce) in a Chrome or Chromium-based browser.
+2. Set a password for your new vault of keys and `Create Vault`
+3. Click `Create an Account`
+4. Give your keys an alias and select an algorithm (Casper supports ed25519 and secp256k1).
+5. Go to the sign-in page for [cspr.live](https://cspr.live/sign-in) and click the red `Sign In` button. This will open signer and connect to the site.
+6. After linking your keys, you can go to the wallet drop-down and visit the [delegate stake page](https://cspr.live/delegate-stake).
+7. Confirm the transaction details on the next screen.
+8. To sign the transaction and send your delegation:
+- Click `Sign with Casper Signer`
+- The Signer app window will open. Make sure that the deploy hash in the Signer window matches the deploy hash in [cspr.live](https://cspr.live/) before continuing.
+- Click `Sign` in the Signer window to sign and finalize the transaction.
+
+</details>
+
+<details>
+<summary><b>What is self-stake percentage?</b></summary>
+
+Self-stake is the amount of CSPR a validator personally staked on the network from their validating node, expressed as a percentage of the total amount of CSPR staked to that validator. Most validators choose to delegate their own tokens to their validating node as a security practice, which will show as a low self-stake percentage.
+
+</details>
+
+<details>
+<summary><b>What is slashing?</b></summary>
+
+Slashing is a penalty for inappropriate or malicious behavior. Ordinarily, the official node software will not act maliciously unless intentionally altered. When this happens, the validator in question gets slashed (Note: The network treats validator and delegator tokens equally).
+
+Slashing is not currently enabled on the Casper Mainnet. If a validator behaves poorly on the network, they face eviction from the network and loss of rewards. When slashing is enabled, poor behavior will result in token removal. In this case, you will lose any rewards accrued during the eviction period.
+
+</details>


### PR DESCRIPTION
### Related links

Requirement cards:
[Move SRE FAQ to the docs #76](https://github.com/casper-network/docs/issues/76)
[Smart contracts cannot talk to the outside world #107](https://github.com/casper-network/docs/issues/107)


### Changes

I've added the information from the prior Atlassian SRE FAQ to the current documentation FAQs. This included changes to both the developer and validator FAQs.

Also included is the change requested in docs #107.

### Notes

Both pages ran locally without issue.
