### PR TITLE
Generalize cspr.live references

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -5,6 +5,7 @@ module.exports = {
         "workflow/ledger-setup",
         "workflow/signer-guide",
         "workflow/token-transfer",
+		"workflow/testnet-faucet",
         "workflow/setup",
         "workflow/querying",
         "workflow/account-hash",

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -5,7 +5,7 @@ module.exports = {
         "workflow/ledger-setup",
         "workflow/signer-guide",
         "workflow/token-transfer",
-		"workflow/testnet-faucet",
+	"workflow/testnet-faucet",
         "workflow/setup",
         "workflow/querying",
         "workflow/account-hash",

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -1,6 +1,7 @@
 module.exports = {
     workflow: [
         "workflow/index",
+	"workflow/block-explorer",
         "workflow/staking",
         "workflow/ledger-setup",
         "workflow/signer-guide",

--- a/source/docs/casper/staking/index.md
+++ b/source/docs/casper/staking/index.md
@@ -7,13 +7,13 @@ slug: /staking
 
 A feature of Proof-of-Stake protocols is that token holders can actively participate in the protocol through a mechanism known as **staking**.
 
-Persons that hold their private keys can choose to stake their tokens with any validator in the Casper network. Alternatively, it is possible to stake tokens via an exchange or custody provider as well.
+Persons that hold their private keys can choose to stake their tokens with any validator in the Casper Network. Alternatively, it is possible to stake tokens via an exchange or custody provider as well.
 
-This guide will outline the steps required to stake the CSPR token on the Casper network.
+This guide will outline the steps required to stake the CSPR token on the Casper Network.
 
 ## What you need to know before staking {#what-you-need-to-know-before-staking}
 
-Please read the following sections carefully before staking tokens on the Casper network.
+Please read the following sections carefully before staking tokens on the Casper Network.
 
 ## Slashing {#slashing}
 
@@ -51,7 +51,7 @@ For security purposes, whenever a token is un-staked or un-delegated, the protoc
     -   [1. Introduction](../workflow/staking.md#1-introduction)
     -   [2. Staking Overview](../workflow/staking.md#1-staking-overview)
     -   [3. Creating your Wallet with the CasperLabs Signer](../workflow/staking.md#3-creating-your-wallet-with-the-casperlabs-signer)
-    -   [4. Connecting to cspr.live](../workflow/staking.md#4-connecting-to-csprlive)
+    -   [4. Connecting to a Block Explorer](../workflow/staking.md#4-connecting-to-blockexplorer)
     -   [5. Funding your Account](../workflow/staking.md#5-funding-your-account)
     -   [6. Delegating Tokens](../workflow/staking.md#6-delegating-tokens)
     -   [7. Monitoring](../workflow/staking.md#7-monitoring)

--- a/source/docs/casper/workflow/block-explorer.md
+++ b/source/docs/casper/workflow/block-explorer.md
@@ -1,0 +1,24 @@
+# Block Explorers on Casper Network
+
+The Casper blockchain is available as the Mainnet and Testnet. The Mainnet is the Casper blockchain that utilizes Casper tokens (CSPR). The Testnet is an alternate Casper blockchain used to test applications on the Casper Network without spending CSPR tokens on the Casper Mainnet. Block explorers such as [cspr.live](https://cspr.live/) and [casperstats.io](https://casperstats.io/) can be used to explore the Casper blockchain.
+
+## What is a Block Explorer
+
+A block explorer is a search engine for the blockchain. It allows you to find information such as the transactions executed on the blockchain, the transaction statistics, the validators on the network and similar blockchain activity. A block explorer gives you information on your wallet and all the transactions carried out using the wallet. It can be used to find a specific transaction or view the transaction history of the blockchain. 
+
+##  Using a Block Explorer
+
+You can use a block explorer on the Casper Network to view the blockchain statistics, list of validators, list of blocks executed on the blockchain, list of deploys/transactions, and list of nodes operating on the blockchain.
+
+You can also transfer CSPR tokens, delegate stake or undelegate stake using a block explorer. To perform these actions, you must sign in to your CSPR wallet using the CasperLabs Signer. The following topics link you to detailed instructions on using a block explorer to access and work with your CSPR tokens:
+
+- Learn how to access your CSPR wallet using the [Signer guide](signer-guide.md)
+- Understand the process of transferring CSPR tokens from [Transferring Tokens using a Block Explorer](token-transfer.md)
+- Explore the concepts and the process of staking, delegating and undelegating CSPR tokens using the [Staking guide](staking.md)
+
+:::note
+
+The guides listed above use the [cspr.live](https://cspr.live/) block explorer as an example.
+
+:::
+

--- a/source/docs/casper/workflow/block-explorer.md
+++ b/source/docs/casper/workflow/block-explorer.md
@@ -1,6 +1,6 @@
 # Block Explorers on Casper Network
 
-The Casper blockchain is available as the Mainnet and Testnet. The Mainnet is the Casper blockchain that utilizes Casper tokens (CSPR). The Testnet is an alternate Casper blockchain used to test applications without spending CSPR tokens on the Casper Mainnet. Block explorers such as [cspr.live](https://cspr.live/) and [casperstats.io](https://casperstats.io/) can be used to explore the Casper blockchain.
+The Casper blockchain is available as the Mainnet and Testnet. The Mainnet is the Casper blockchain that utilizes Casper tokens (CSPR). The Testnet is an alternate Casper blockchain used to test applications without spending CSPR tokens on the Casper Mainnet. You can use block explorers such as [cspr.live](https://cspr.live/) and [casperstats.io](https://casperstats.io/) to explore the Casper blockchain.
 
 ## What is a Block Explorer
 

--- a/source/docs/casper/workflow/block-explorer.md
+++ b/source/docs/casper/workflow/block-explorer.md
@@ -1,6 +1,6 @@
 # Block Explorers on Casper Network
 
-The Casper blockchain is available as the Mainnet and Testnet. The Mainnet is the Casper blockchain that utilizes Casper tokens (CSPR). The Testnet is an alternate Casper blockchain used to test applications on the Casper Network without spending CSPR tokens on the Casper Mainnet. Block explorers such as [cspr.live](https://cspr.live/) and [casperstats.io](https://casperstats.io/) can be used to explore the Casper blockchain.
+The Casper blockchain is available as the Mainnet and Testnet. The Mainnet is the Casper blockchain that utilizes Casper tokens (CSPR). The Testnet is an alternate Casper blockchain used to test applications without spending CSPR tokens on the Casper Mainnet. Block explorers such as [cspr.live](https://cspr.live/) and [casperstats.io](https://casperstats.io/) can be used to explore the Casper blockchain.
 
 ## What is a Block Explorer
 

--- a/source/docs/casper/workflow/deploy-transfer.md
+++ b/source/docs/casper/workflow/deploy-transfer.md
@@ -278,6 +278,6 @@ To verify the status of your transfer, see [Verifying a Transfer](verify-transfe
 
 :::tip 
 
-You can also verify if the transfer was successful by checking your account balance on a block explorer such as [cspr.live](https://cspr.live/) or [casperstats.io](https://casperstats.io/). 
+You can also verify if the transfer was successful by checking your account balance using a [block explorer](block-explorer.md). 
 
 :::

--- a/source/docs/casper/workflow/deploy-transfer.md
+++ b/source/docs/casper/workflow/deploy-transfer.md
@@ -278,6 +278,6 @@ To verify the status of your transfer, see [Verifying a Transfer](verify-transfe
 
 :::tip 
 
-You can also verify if the transfer was successful by logging on to the https://cspr.live/ website and checking your account balance. 
+You can also verify if the transfer was successful by checking your account balance on a block explorer such as [cspr.live](https://cspr.live/) or [casperstats.io](https://casperstats.io/). 
 
 :::

--- a/source/docs/casper/workflow/index.md
+++ b/source/docs/casper/workflow/index.md
@@ -12,7 +12,8 @@ These user guides contain step-by-step instructions for interacting with the Cas
 -   [Staking guide](staking.md): a guide to staking your Casper tokens
 -   [Ledger setup](ledger-setup.md): a guide to setting up your Ledger device
 -   [Signer guide](signer-guide.md): a guide to help you navigate the Signer app
--   [Token Transfer guide](token-transfer.md): a guide to help you transfer CSPR tokens on [Casper Testnet](https://testnet.cspr.live/)
+-   [Token Transfer guide](token-transfer.md): a guide to transferring your CSPR tokens 
+-   [Funding Testnet Accounts](testnet-faucet.md): a guide to funding your Testnet account
 
 ## Developer Guides {#developer-guides}
 

--- a/source/docs/casper/workflow/index.md
+++ b/source/docs/casper/workflow/index.md
@@ -9,10 +9,11 @@ slug: /workflow
 
 These user guides contain step-by-step instructions for interacting with the Casper blockchain.
 
+-   [Block Explorers on Casper Network](block-explorer.md): a guide to understanding block explorers
 -   [Staking guide](staking.md): a guide to staking your Casper tokens
 -   [Ledger setup](ledger-setup.md): a guide to setting up your Ledger device
 -   [Signer guide](signer-guide.md): a guide to help you navigate the Signer app
--   [Token Transfer guide](token-transfer.md): a guide to transferring your CSPR tokens 
+-   [Transferring Tokens using a Block Explorer](token-transfer.md): a guide to transferring your CSPR tokens 
 -   [Funding Testnet Accounts](testnet-faucet.md): a guide to funding your Testnet account
 
 ## Developer Guides {#developer-guides}

--- a/source/docs/casper/workflow/ledger-setup.md
+++ b/source/docs/casper/workflow/ledger-setup.md
@@ -2,7 +2,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Ledger Setup
 
-A Ledger Device is a hardware wallet that is considered one of the most secure ways to store your digital assets. Ledger uses an offline, or cold storage, method of generating private keys, making it a preferred method for many crypto users. This guide will help you to connect your Ledger device to the Casper Web wallet (<https://cspr.live>). The Casper Web wallet enables you to send and receive CSPR tokens.
+A Ledger Device is a hardware wallet that is considered one of the most secure ways to store your digital assets. Ledger uses an offline, or cold storage, method of generating private keys, making it a preferred method for many crypto users. This guide will help you to connect your Ledger device to a Casper Web wallet on a block explorer such as (<https://cspr.live>). The Casper Web wallet enables you to send and receive CSPR tokens.
 
 If you need help, contact us on the following services:
 

--- a/source/docs/casper/workflow/ledger-setup.md
+++ b/source/docs/casper/workflow/ledger-setup.md
@@ -2,7 +2,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Ledger Setup
 
-A Ledger Device is a hardware wallet that is considered one of the most secure ways to store your digital assets. Ledger uses an offline, or cold storage, method of generating private keys, making it a preferred method for many crypto users. This guide will help you to connect your Ledger device to a Casper Web wallet on a block explorer such as (<https://cspr.live>). The Casper Web wallet enables you to send and receive CSPR tokens.
+A Ledger Device is a hardware wallet that is considered one of the most secure ways to store your digital assets. Ledger uses an offline, or cold storage, method of generating private keys, making it a preferred method for many crypto users. This guide will help you to connect your Ledger device to a Casper Web wallet on a block explorer such as [cspr.live](https://cspr.live/). The Casper Web wallet enables you to send and receive CSPR tokens.
 
 If you need help, contact us on the following services:
 

--- a/source/docs/casper/workflow/signer-guide.md
+++ b/source/docs/casper/workflow/signer-guide.md
@@ -6,6 +6,8 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Casper Signer allows you to safely access your Casper Token (CSPR) wallet. The CSPR wallet can be used to transfer CSPR tokens to another user, delegate stake, or ungelegate stake. The Casper Signer can be used for more than one CSPR account and all the accounts are securely stored in a vault, which is a mechanism to protect online information with a password. You set a password for the vault while creating a Casper Signer account. To login using Casper Signer, you must download and install the CasperLabs Signer extension for your browser. The following sections take you through the process of downloading and signing in to the Casper Signer.
 
+> **Note**: These steps use the [cspr.live](https://cspr.live/) as an example, you can install and setup your Signer account on any Casper Network block explorer such as [cspr.live](https://cspr.live/) or [casperstats.io](https://casperstats.io/). 
+
 ### 1.1 Installing the CasperLabs Signer Extension
 
 To install the CaperLabs Signer extension, follow these steps:
@@ -16,7 +18,7 @@ Alternatively, you can use this link to download the [CasperLabs Signer](https:/
 
 :::
 
-1. Navigate to the CSPR mainnet https://cspr.live/, using Chrome or a Chromium-based browser like Brave.
+1. Navigate to [cspr.live](https://cspr.live/), using Chrome or a Chromium-based browser like Brave.
 2. Click the **Sign in** option on the top-right corner of the screen. The Casper Signer is displayed.
 3. In the Casper Signer, click the **Download Signer** button. A new window with the Chrome extension is displayed.
 4. On the CasperLabs Signer extension page, click the **Add to Chrome** button. A pop-up will let you know the permissions required. To approve the extension access, click **Add extension**. The CasperLabs Signer extension is now added to your browser.
@@ -152,18 +154,18 @@ To view your account information, do the following:
 1. On the CSPR home page, click the option in the top-right corner of the screen that displays a few digits of your public key. A menu with your public key is displayed.
 2. To view your account details for the displayed public key, click **View Account**.
 
-## 7. Accessing the CSPR Wallet from cspr.live
+## 7. Accessing the CSPR Wallet from a Block Explorer
 
 Once you are logged in to the Casper Signer, you can access the wallet for each account registered in the Signer. For more information on how to log in to the Signer, see [Logging in to the Casper Signer](signer-guide#12-logging-in-to-the-casper-signer).
 
 Alternatively, you can follow these steps to log in to your Signer/CSPR wallet:
 
-1. Navigate to the CSPR Mainnet https://cspr.live/.
+1. Navigate to the [cspr.live](https://cspr.live/).
 2. Click the **Sign in** option on the top-right corner of the screen. The Casper Signer is displayed.
 3. In the Casper Signer, click the **Sign In** button. The Unlock Vault pop-up is displayed.
 4. Enter your password and click **UNLOCK**. The Connection Request message is displayed.
 5. To continue with the connection, click **CONNECT**. The Approve Connection message appears.
-6. To approve the connection, click **CONNECT**. You are now connected to the CSPR wallet.
+6. To approve the connection, click **CONNECT**. You are now connected to your CSPR wallet.
 
 ## 8. Logging out of the Casper Signer
 

--- a/source/docs/casper/workflow/signer-guide.md
+++ b/source/docs/casper/workflow/signer-guide.md
@@ -160,7 +160,7 @@ Once you are logged in to the Casper Signer, you can access the wallet for each 
 
 Alternatively, you can follow these steps to log in to your Signer/CSPR wallet:
 
-1. Navigate to the [cspr.live](https://cspr.live/).
+1. Navigate to [cspr.live](https://cspr.live/), using Chrome or a Chromium-based browser like Brave.
 2. Click the **Sign in** option on the top-right corner of the screen. The Casper Signer is displayed.
 3. In the Casper Signer, click the **Sign In** button. The Unlock Vault pop-up is displayed.
 4. Enter your password and click **UNLOCK**. The Connection Request message is displayed.

--- a/source/docs/casper/workflow/signer-guide.md
+++ b/source/docs/casper/workflow/signer-guide.md
@@ -6,7 +6,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 The Casper Signer allows you to safely access your Casper Token (CSPR) wallet. The CSPR wallet can be used to transfer CSPR tokens to another user, delegate stake, or ungelegate stake. The Casper Signer can be used for more than one CSPR account and all the accounts are securely stored in a vault, which is a mechanism to protect online information with a password. You set a password for the vault while creating a Casper Signer account. To login using Casper Signer, you must download and install the CasperLabs Signer extension for your browser. The following sections take you through the process of downloading and signing in to the Casper Signer.
 
-> **Note**: These steps use the [cspr.live](https://cspr.live/) as an example, you can install and setup your Signer account on any Casper Network block explorer such as [cspr.live](https://cspr.live/) or [casperstats.io](https://casperstats.io/). 
+> **Note**: These steps use the [cspr.live](https://cspr.live/) as an example, you can install and setup your Signer account on any Casper Network [block explorer](block-explorer). 
 
 ### 1.1 Installing the CasperLabs Signer Extension
 

--- a/source/docs/casper/workflow/staking.md
+++ b/source/docs/casper/workflow/staking.md
@@ -89,7 +89,7 @@ If you do not have these three files, you need to enable multiple downloads in y
 
 ### 3.3 Importing an Existing Account {#33-importing-an-existing-account}
 
-If you already have your secret keys and would like to set up and use your wallet with your existing accounts, you can do so with the following steps:
+If you already have your secret key and would like to set up and use your wallet with an existing account, you can do so with the following steps:
 
 1.  Import your existing account by clicking the **IMPORT ACCOUNT** button.
 2.  Then, click on the **UPLOAD** button and select your secret key file (the file with the secret_key.pem extension).

--- a/source/docs/casper/workflow/staking.md
+++ b/source/docs/casper/workflow/staking.md
@@ -89,7 +89,7 @@ If you do not have these three files, you need to enable multiple downloads in y
 
 ### 3.3 Importing an Existing Account {#33-importing-an-existing-account}
 
-If you already have your secret key and would like to set up and use your wallet with an existing account, you can do so with the following steps:
+If you already have your secret key and would like to set up and use your wallet with an existing account, you can do so with the following steps.
 
 1.  Import your existing account by clicking the **IMPORT ACCOUNT** button.
 2.  Then, click on the **UPLOAD** button and select your secret key file (the file with the secret_key.pem extension).

--- a/source/docs/casper/workflow/staking.md
+++ b/source/docs/casper/workflow/staking.md
@@ -50,7 +50,7 @@ You can create, store, and use one or more CSPR accounts with your Signer wallet
 
 If you are new or have logged out of the Signer, you can log in with these steps:
 
-1.  Using Chrome or a Chromium-based browser like Brave, navigate to the block explorer on the mainnet (<https://cspr.live/>), and click on the **Sign-in** menu.
+1.  Using Chrome or a Chromium-based browser like Brave, navigate to a block explorer on the Mainnet, for this example we are using (<https://cspr.live/>), and click on the **Sign-in** menu.
 2.  Download the [CasperLabs Signer extension](https://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce).
 3.  You will need to create a vault that will safeguard your accounts with a password. In this step, we assume that you have not used the Signer before, so click **Reset Vault**.
 4.  Create a password for your new vault. Confirm the password, and then click **Create Vault**.
@@ -89,7 +89,7 @@ If you do not have these three files, you need to enable multiple downloads in y
 
 ### 3.3 Importing an Existing Account {#33-importing-an-existing-account}
 
-If you already have your secret keys and would like to set up and use your wallet with your existing accounts, you can do so with the following steps. These steps also apply for users migrating from the outdated Clarity tool to [cspr.live](https://cspr.live/).
+If you already have your secret keys and would like to set up and use your wallet with your existing accounts, you can do so with the following steps. These steps also apply for users migrating from the outdated Clarity tool to [cspr.live](https://cspr.live/) or any similar block explorer for the Casper Network.
 
 1.  Import your existing account by clicking the **IMPORT ACCOUNT** button.
 2.  Then, click on the **UPLOAD** button and select your secret key file (the file with the secret_key.pem extension).
@@ -98,11 +98,11 @@ If you already have your secret keys and would like to set up and use your walle
 
 <img class="align-center" src={useBaseUrl("/image/tutorials/staking/3.3.4.1.png" )}alt="3.3.4.1" width="200" />
 
-Now that you have your CasperLabs Signer wallet, you can continue to connect to the mainnet blockchain.
+Now that you have your CasperLabs Signer wallet, you can continue to connect to the Mainnet blockchain.
 
-## 4. Connecting to cspr.live {#4-connecting-to-csprlive}
+## 4. Connecting to a Block Explorer {#4-connecting-to-blockexplorer}
 
-Using the active account in the Signer tool, connect to the Casper blockchain by clicking on the **DISCONNECTED** button to toggle the connection.
+Using the active account in the Signer tool, connect to the Casper blockchain by clicking on the **DISCONNECTED** button to toggle the connection. For this example, we are using the [cspr.live](https://cspr.live/) block explorer.
 
 <img class="align-center" src={useBaseUrl("/image/tutorials/staking/4.1.png")} alt="4.1" width="200" />
 

--- a/source/docs/casper/workflow/staking.md
+++ b/source/docs/casper/workflow/staking.md
@@ -89,7 +89,7 @@ If you do not have these three files, you need to enable multiple downloads in y
 
 ### 3.3 Importing an Existing Account {#33-importing-an-existing-account}
 
-If you already have your secret keys and would like to set up and use your wallet with your existing accounts, you can do so with the following steps. These steps also apply for users migrating from the outdated Clarity tool to [cspr.live](https://cspr.live/) or any similar block explorer for the Casper Network.
+If you already have your secret keys and would like to set up and use your wallet with your existing accounts, you can do so with the following steps:
 
 1.  Import your existing account by clicking the **IMPORT ACCOUNT** button.
 2.  Then, click on the **UPLOAD** button and select your secret key file (the file with the secret_key.pem extension).

--- a/source/docs/casper/workflow/staking.md
+++ b/source/docs/casper/workflow/staking.md
@@ -50,7 +50,7 @@ You can create, store, and use one or more CSPR accounts with your Signer wallet
 
 If you are new or have logged out of the Signer, you can log in with these steps:
 
-1.  Using Chrome or a Chromium-based browser like Brave, navigate to a block explorer on the Mainnet, for this example we are using (<https://cspr.live/>), and click on the **Sign-in** menu.
+1.  Using Chrome or a Chromium-based browser like Brave, navigate to a block explorer on the Mainnet, (for this example we are using [cspr.live](https://cspr.live/)), and click on the **Sign-in** menu.
 2.  Download the [CasperLabs Signer extension](https://chrome.google.com/webstore/detail/casperlabs-signer/djhndpllfiibmcdbnmaaahkhchcoijce).
 3.  You will need to create a vault that will safeguard your accounts with a password. In this step, we assume that you have not used the Signer before, so click **Reset Vault**.
 4.  Create a password for your new vault. Confirm the password, and then click **Create Vault**.

--- a/source/docs/casper/workflow/testnet-faucet.md
+++ b/source/docs/casper/workflow/testnet-faucet.md
@@ -1,0 +1,27 @@
+# Funding Testnet Accounts
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+The Casper Testnet is an alternate Casper blockchain aimed at testing applications running on the Casper Network without spending CSPR tokens on the Casper Mainnet. Testnet tokens are independent and separate from the actual Casper Token (CSPR). While test tokens do not have any monetary value, they possess the same functionality as the CSPR token within the confines of the Testnet. The Testnet is deployed independently from the Casper Mainnet for users to experiment with Casper Network features such as transferring, delegating, and undelegating tokens. You can access the Casper Testnet using https://testnet.cspr.live/. 
+
+**Figure 1**: Casper Testnet Home
+
+<img src={useBaseUrl("/image/workflow/testnet-home.png")} width="500" alt="Casper Testnet Home" />
+
+## 2. The Faucet
+
+The faucet functionality on Testnet allows you to request test tokens, which are required to complete transactions on the network, including transferring, delegating, and undelegating tokens. In this section, we will discuss how to request test tokens.
+
+### 2.1 Requesting Testnet Tokens 
+
+To request test tokens, follow these steps:
+1. Sign-in into the Casper Testnet with the Signer. For detailed instructions, see the [Signer Guide](signer-guide.md). 
+2. Click **Tools** on the top menu bar and then select **Faucet** from the drop-down menu. 
+3. Click **Request tokens** on the Faucet page, as shown in Figure 2. 
+
+    **Figure 2**: Casper Faucet Functionality 
+
+    <img src={useBaseUrl("/image/workflow/faucet-function.png")} width="500" />
+
+4. The Testnet will credit your account with test tokens. For instructions on how to view your CSPR balance, see [Viewing Account Details](signer-guide#6-viewing-account-details).
+

--- a/source/docs/casper/workflow/testnet-faucet.md
+++ b/source/docs/casper/workflow/testnet-faucet.md
@@ -8,11 +8,11 @@ The Casper Testnet is an alternate Casper blockchain aimed at testing applicatio
 
 <img src={useBaseUrl("/image/workflow/testnet-home.png")} width="500" alt="Casper Testnet Home" />
 
-## 2. The Faucet
+## The Faucet
 
 The faucet functionality on Testnet allows you to request test tokens, which are required to complete transactions on the network, including transferring, delegating, and undelegating tokens. In this section, we will discuss how to request test tokens.
 
-### 2.1 Requesting Testnet Tokens 
+### Requesting Testnet Tokens 
 
 To request test tokens, follow these steps:
 1. Sign-in into the Casper Testnet with the Signer. For detailed instructions, see the [Signer Guide](signer-guide.md). 

--- a/source/docs/casper/workflow/token-transfer.md
+++ b/source/docs/casper/workflow/token-transfer.md
@@ -2,7 +2,7 @@
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-You can transfer Casper tokens (CSPR) using block explorers such as [cspr.live](https://cspr.live/) or [casperstats.io](https://casperstats.io/). The Wallet feature on these block explorers can be used to transfer tokens to another user, delegate stake, or undelegate stake. In this section, we will discuss the steps to transfer CSPR tokens.
+You can transfer Casper tokens (CSPR) using any [block explorer](block-explorer) built to explore the Casper blockchain. The Wallet feature on these block explorers can be used to transfer tokens to another user, delegate stake, or undelegate stake. In this section, we will discuss the steps to transfer CSPR tokens.
 
 ## Transferring Tokens 
 

--- a/source/docs/casper/workflow/token-transfer.md
+++ b/source/docs/casper/workflow/token-transfer.md
@@ -1,55 +1,13 @@
+# Transferring Tokens using a Block Explorer
+
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-# Transferring Tokens on the Casper Testnet
+You can transfer Casper tokens (CSPR) using block explorers such as [cspr.live](https://cspr.live/) or [casperstats.io](https://casperstats.io/). The Wallet feature on these block explorers can be used to transfer tokens to another user, delegate stake, or undelegate stake. In this section, we will discuss the steps to transfer CSPR tokens.
 
-## 1. Introduction
-
-The [Casper Testnet](https://testnet.cspr.live/) is an alternate Casper blockchain aimed at testing applications running on the Casper Network without spending CSPR tokens on the [Casper Mainnet](https://cspr.live/). Testnet tokens are independent and separate from the actual Casper Token (CSPR). While test tokens do not have any monetary value, they possess the same functionality as the CSPR token within the confines of the Testnet. The Testnet is deployed independently from the Casper Mainnet for users to experiment with Casper Network features such as transferring, delegating, and undelegating tokens. The Wallet may be utilized to transfer test tokens to another user, delegate stake, or undelegate stake.
-
-**Figure 1**: Casper Testnet Home
-
-<img src={useBaseUrl("/image/workflow/testnet-home.png")} width="500" alt="Casper Testnet Home" />
-
-### 1.1	Logging in to the Casper Testnet 
-
-To login to the testnet, follow these steps:
-1. Navigate to the CSPR testnet https://testnet.cspr.live/, using Chrome or a Chromium-based browser like Brave. 
-2. Sign in with your account password. See the [Signer Guide](signer-guide.md) for help with logging in.
-
-### 1.2 Viewing Account Information
-
-You can view your account details, such as, the public key, account hash, CSPR token balance, and the transaction history including deploys, delegation, staking rewards, and transfers.
-
-To view your account information, do the following:
-
-1. Click the option in the top-right corner of the screen that displays a few digits of your public key. A menu with your public key is displayed.
-2. To view your account details for the displayed public key, click **View Account**.
-
-## 2. The Faucet
-
-The faucet functionality on Testnet allows you to request test tokens, which are required to complete transactions on the network, including transferring, delegating, and undelegating tokens. In this section, we will discuss how to request test tokens.
-
-### 2.1 Requesting Testnet Tokens 
-
-To request test tokens, follow these steps:
-1. Sign-in into the Casper Testnet with the Signer. 
-2. Click **Tools** on the top menu bar and then select **Faucet** from the drop-down menu. 
-3. Select the **Request tokens** option against your public key on the Faucet webpage, as shown in Figure 2. You can submit multiple requests to complete your testing.
-
-    **Figure 2**: Casper Faucet Functionality 
-
-    <img src={useBaseUrl("/image/workflow/faucet-function.png")} width="500" />
-
-4. The Testnet will credit your account with test tokens. You can view your account balance as described in [Section 1.2](#12-viewing-account-information).
-
-## 3. The Wallet
-
-You can employ the wallet functionality on the Testnet to transfer, delegate, and undelegate test tokens. In this section, we will discuss the steps to transfer test tokens.
-
-### 3.1 Transferring Tokens 
+## Transferring Tokens 
 
 To transfer tokens, follow these steps:
-1. Sign in to your account with the Signer. 
+1. Sign in to your account with the Signer. For detailed instructions, see the [Signer Guide](signer-guide.md).
 2. Click **Wallet** on the top menu bar and select **Transfer CSPR** from the drop-down menu. 
 3. Enter the recipient’s wallet address, the amount you wish to transfer, and an optional Transfer ID for reference. 
     If you do not provide an ID, the system will auto-generate one.
@@ -71,16 +29,13 @@ To transfer tokens, follow these steps:
 <img src={useBaseUrl("/image/workflow/CSPR-third-step.png")} width="500" />
 
 7. Next, you will see a pop-up window with a Signature Request and all the various transaction details, including:
-    -   The Signing Key which approves the transaction
-    -   Your Account address
-    -   The Recipient (Key), which is the recipient's address
-8. Click **Sign** at the bottom of the window to complete the transaction. 
+    -   Signing key which approves the transaction
+    -   Your public key
+    -   Recipient's account hash
+8. Click **Sign with Casper Signer** at the bottom of the window to complete the transaction. 
     You completed the transaction, and successfully transferred tokens.
 
     <img src={useBaseUrl("/image/workflow/transfer-confirm.png")} width="500" />
 
-##  3.  Logging out of your Account
+9.  Next, you can view your CSPR balance, for more information, see the [Viewing Account Details](signer-guide#6-viewing-account-details).
 
-To logout from the Signer, do the following:
-1. On the home page, click the option in the top-right corner of the screen that displays a few digits of your public key. A menu with your public key is displayed.
-2. Click **Logout**. You will be logged out of your account.


### PR DESCRIPTION
### Related links

Card #136 and #138 

### Changes

- Reworded references to cspr.live
- Updated capitalization of commonly used terms to be consistent with other topics
- Split topic "Transferring Tokens on the Casper Testnet" to generalize transfer instructions and created separate topic for testnet faucet feature "Funding Testnet Accounts"
- Updated references to UI elements in Transferring Tokens to match the actual UI
- Added references to the signer guide and removed steps repeated from the signer guide

#### Latest commits 
- Added a new topic for block explorers
- Updated references of block explorers to point to the block explorers topic

### Notes

Testnet is available only on the cspr.live block explorer, so added a separate reference to this in the Funding Testnet Accounts topic. 