### PR TITLE
New page added

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -9,13 +9,13 @@ module.exports = {
         "workflow/querying",
         "workflow/account-hash",
         "workflow/two-party-multi-sig",
-    {
-        type: "category",
+        {
+            type: "category",
             label: "Transferring Tokens",
             collapsible: true,
             collapsed: true,
             items: ["workflow/transfers", "workflow/transfer-workflow", "workflow/deploy-transfer", "workflow/verify-transfer"],
-    },
+        },
         "workflow/delegate",
         "workflow/undelegate",
         {
@@ -35,6 +35,7 @@ module.exports = {
     ],
     "dapp-dev-guide": [
         "dapp-dev-guide/index",
+        "dapp-dev-guide/why-build-on-casper",
         "dapp-dev-guide/getting-started",
         {
             type: "category",
@@ -55,7 +56,13 @@ module.exports = {
             label: "SDK Client Libraries",
             collapsible: true,
             collapsed: true,
-            items: ["dapp-dev-guide/sdk/index", "dapp-dev-guide/sdk/script-sdk", "dapp-dev-guide/sdk/csharp-sdk", "dapp-dev-guide/sdk/go-sdk", "dapp-dev-guide/sdk/python-sdk"],
+            items: [
+                "dapp-dev-guide/sdk/index",
+                "dapp-dev-guide/sdk/script-sdk",
+                "dapp-dev-guide/sdk/csharp-sdk",
+                "dapp-dev-guide/sdk/go-sdk",
+                "dapp-dev-guide/sdk/python-sdk",
+            ],
         },
         {
             type: "category",

--- a/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
+++ b/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
@@ -1,0 +1,57 @@
+# Why Build on Casper
+
+This guide intends to briefly show you the current features and advantages of building on the Casper Network.
+
+- [Developer-Friendly Language](#developer-friendly-language)
+- [Advanced Account Management](#advanced-account-management)
+- [Contract Upgrades](#contract-upgrades)
+- [Development Tools](#development-tools)
+   - [IDE Integration](#ide-integration)
+   - [CI/CD](ci/cd)
+   - [Local Network Testing](#local-network-testing)
+   - [AWS](#aws)
+- [SDK Client Libraries](#sdk-client-libraries)
+- [Low Gas Fees](#low-gas-fees)
+
+## Developer-Friendly Language
+Casper Network's development ecosystem is designed to support WebAssembly, rather than being written in proprietary languages like Solidity. This feature simplifies the development path for enterprises and development teams that want to build on the Casper Network.
+
+Rust is a beloved programming language for its safety and performance. We offer a Rust experience and a runtime environment for developing smart contracts . The Rust smart contracts are compiled to WebAssembly (WASM), which is an [open standard](https://en.wikipedia.org/wiki/Open_standard) for performance and portability of modern web applications. 
+
+:::note
+
+WASM can support any language compiled or interpreted on any operating system with the help of appropriate tools. Therefore, we can support more languages for smart contracts as compilation targets for WebAssembly become available.  
+
+:::
+
+## Advanced Account Management
+The Casper Network offers advanced account management with weighted keys for separating permissions and account actions, supporting delegation, weighted multi-signatures, and more. Other essential features include an account permissions model that allows the recovery of lost keys and a permissions model to securely share state between accounts and contracts (without expensive cryptographic checks). Refer to the [Casper Permissions Model](https://casper.network/docs/design/accounts#accounts-permissions) for more details.
+
+## Contract Upgrades
+Casper allows the direct upgrading of on-chain smart contracts, eliminating the need for complex migration processes and making it easy for developers to correct smart contract vulnerabilities. Contracts can be upgradable or immutable,  and organizations can version their contracts, deprecate old versions, and set permissions around who can perform contract upgrades. 
+
+## Development Tools
+
+### IDE Integration
+
+The Casper development process is designed to be familiar to all developers. You can run and build code locally within an IDE and use assertions and tests to verify the functionality of your application. You can set the contract's starting state and create and run tests on your development machine. 
+
+
+### CI/CD
+
+Casper also provides the instrumentation and tooling that seamlessly integrates existing Continuous Integration/Continuous Deployment pipelines. Build servers can run the Casper Virtual Machine without the overhead of a full node, tracking the blockchain internal state and running assertions, thus enabling a solid development pipeline.
+
+### Local Network Testing
+We also offer a tool to run a [local Casper Network](https://casper.network/docs/dapp-dev-guide/setup-nctl). Even though you don't need a stand-alone node for smart contract development, you can configure your local network to test your deployments and estimate gas costs. A local network is helpful when integrating your dApp into a mobile or web interface.
+
+### Public Mainnet and Testnet
+The Casper [Mainnet](https://cspr.live) is a public, open-source, community-driven ecosystem. You can also explore the [Testnet](https://testnet.cspr.live) to test drive your applications and estimate gas costs.
+
+### AWS
+We also offer several tools to run AWS instances of Casper nodes.
+
+## SDK Client Libraries
+In addition to the default [command-line Rust client](https://casper.network/docs/workflow/setup#the-casper-command-line-client), the Casper community is building [other clients](https://casper.network/docs/sdk) in JavaScript, Java, Golang, Python, C#, and other languages. 
+
+## Low Gas Fees 
+Casper seeks to eliminate volatility and improve developer and enterprise experiences by establishing transparent, consistent, and low gas prices. This feature seeks to promote active and diverse network behaviour and we are researching innovative pricing models that will favor dApp developers as the ecosystem grows.

--- a/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
+++ b/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
@@ -7,7 +7,7 @@ This guide intends to briefly show you the current features and advantages of bu
 - [Contract Upgrades](#contract-upgrades)
 - [Development Tools](#development-tools)
    - [IDE Integration](#ide-integration)
-   - [CI/CD](ci/cd)
+   - [CI/CD](#ci-cd)
    - [Local Network Testing](#local-network-testing)
    - [AWS](#aws)
 - [SDK Client Libraries](#sdk-client-libraries)

--- a/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
+++ b/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
@@ -13,7 +13,7 @@ This guide intends to briefly show you the current features and advantages of bu
 - [SDK Client Libraries](#sdk-client-libraries)
 - [Low Gas Fees](#low-gas-fees)
 
-## Developer-Friendly Language
+## Developer-Friendly Language {#developer-friendly-language}
 Casper Network's development ecosystem is designed to support WebAssembly, rather than being written in proprietary languages like Solidity. This feature simplifies the development path for enterprises and development teams that want to build on the Casper Network.
 
 Rust is a beloved programming language for its safety and performance. We offer a Rust experience and a runtime environment for developing smart contracts . The Rust smart contracts are compiled to WebAssembly (WASM), which is an [open standard](https://en.wikipedia.org/wiki/Open_standard) for performance and portability of modern web applications. 
@@ -24,34 +24,34 @@ WASM can support any language compiled or interpreted on any operating system wi
 
 :::
 
-## Advanced Account Management
+## Advanced Account Management {#advanced-account-management}
 The Casper Network offers advanced account management with weighted keys for separating permissions and account actions, supporting delegation, weighted multi-signatures, and more. Other essential features include an account permissions model that allows the recovery of lost keys and a permissions model to securely share state between accounts and contracts (without expensive cryptographic checks). Refer to the [Casper Permissions Model](https://casper.network/docs/design/accounts#accounts-permissions) for more details.
 
-## Contract Upgrades
+## Contract Upgrades {#contract-upgrades}
 Casper allows the direct upgrading of on-chain smart contracts, eliminating the need for complex migration processes and making it easy for developers to correct smart contract vulnerabilities. Contracts can be upgradable or immutable,  and organizations can version their contracts, deprecate old versions, and set permissions around who can perform contract upgrades. 
 
-## Development Tools
+## Development Tools {#development-tools}
 
-### IDE Integration
+### IDE Integration {#ide-integration}
 
 The Casper development process is designed to be familiar to all developers. You can run and build code locally within an IDE and use assertions and tests to verify the functionality of your application. You can set the contract's starting state and create and run tests on your development machine. 
 
 
-### CI/CD
+### CI/CD {#ci-cd}
 
 Casper also provides the instrumentation and tooling that seamlessly integrates existing Continuous Integration/Continuous Deployment pipelines. Build servers can run the Casper Virtual Machine without the overhead of a full node, tracking the blockchain internal state and running assertions, thus enabling a solid development pipeline.
 
-### Local Network Testing
+### Local Network Testing {#local-network-testing}
 We also offer a tool to run a [local Casper Network](https://casper.network/docs/dapp-dev-guide/setup-nctl). Even though you don't need a stand-alone node for smart contract development, you can configure your local network to test your deployments and estimate gas costs. A local network is helpful when integrating your dApp into a mobile or web interface.
 
-### Public Mainnet and Testnet
+### Public Mainnet and Testnet {#public-mainnet-and-testnet}
 The Casper [Mainnet](https://cspr.live) is a public, open-source, community-driven ecosystem. You can also explore the [Testnet](https://testnet.cspr.live) to test drive your applications and estimate gas costs.
 
-### AWS
+### AWS {#aws}
 We also offer several tools to run AWS instances of Casper nodes.
 
-## SDK Client Libraries
+## SDK Client Libraries {#sdk-client-libraries}
 In addition to the default [command-line Rust client](https://casper.network/docs/workflow/setup#the-casper-command-line-client), the Casper community is building [other clients](https://casper.network/docs/sdk) in JavaScript, Java, Golang, Python, C#, and other languages. 
 
-## Low Gas Fees 
+## Low Gas Fees {#low-gas-fees}
 Casper seeks to eliminate volatility and improve developer and enterprise experiences by establishing transparent, consistent, and low gas prices. This feature seeks to promote active and diverse network behaviour and we are researching innovative pricing models that will favor dApp developers as the ecosystem grows.

--- a/source/docs/casper/index.md
+++ b/source/docs/casper/index.md
@@ -14,35 +14,9 @@ Casper is a new [Turing-complete](glossary/T#turing-complete-blockchain) smart-c
 
 The network's consensus protocol is called [Highway](https://arxiv.org/pdf/2101.02159.pdf), and it has several benefits over classic Byzantine Fault Tolerant (BFT) consensus protocols. First, Highway allows networks to reach higher thresholds of _finality_, meaning that more blocks are finalized, and validators agree to add them to the blockchain. Second, the protocol achieves flexibility by expressing block finality in ways not possible in BFT models. This protocol is built on the [correct-by-construction (CBC) Casper](https://github.com/cbc-casper/cbc-casper-paper) research.
 
-Additionally, the Casper Network is optimized for enterprise and developer adoption. While leveraging blockchain technology, the network seeks to accelerate business operations via unique features like predictable network fees, upgradeable contracts, on-chain governance, privacy flexibility, and developer-friendly languages.
+Additionally, the Casper Network is optimized for enterprise and developer adoption. While leveraging blockchain technology, the network seeks to accelerate business operations via unique features like predictable network fees, upgradeable contracts, on-chain governance, privacy flexibility, and developer-friendly languages. Casper's [core features and strengths](dapp-dev-guide/why-build-on-casper.md) enable developers and enterprises to reap the benefits of blockchain technology.
 
 Casper also solves the scalability trilemma. Notably, the network is optimized for security, decentralization, and high throughput. All this is achieved while evolving to provide leading solutions for open-source projects and enterprises.
-
-## Why choose Casper? {#why-choose-casper}
-
-Casper has core features and strengths that enable developers and enterprises to reap the benefits of blockchain technology.
-
-### Upgradeable Contracts {#upgradeable-contracts}
-
-Casper allows the direct upgrading of on-chain smart contracts, eliminating the need for complex migration processes and making it easy for developers to correct smart contract vulnerabilities.
-
-### Developer-Friendly Language {#developer-friendly-language}
-
-Casper Network's development ecosystem is designed to support WebAssembly, rather than being written in proprietary languages like Solidity. This feature simplifies the development path for enterprises and development teams that want to build on the Casper Network.
-
-:::note
-
-Rust is the primary programming language for smart contracts on the Casper blockchain because of its good support for compilation to wasm. However, the platform does not make assumptions about the source language and supports libraries facilitating contract development in other programming languages having wasm as a compile target.
-
-:::
-
-### Account Management {#account-management}
-
-Other essential features include an account permissions model that allows the recovery of lost keys and a permissions model to securely share state between accounts and contracts (without expensive cryptographic checks).
-
-### Predictable Network Fees {#predictable-network-fees}
-
-Casper seeks to eliminate volatility and improve developer and enterprise experiences by establishing transparent, consistent, and predictable gas prices. This feature seeks to promote active and diverse network behaviour.
 
 ## How does Casper work? {#how-does-casper-work}
 


### PR DESCRIPTION
### Related links

Card #71 

### Changes

Changes:
Casper Network Document Landing Page: 
- Removed the section, "Why Choose Casper" and added relevant contents to the "Why-Build-on-Casper" page.  
-The newly designed page for "Why-Build-on-Casper" has been linked to the landing page - in the third paragraph under "What is Casper?" 
  Link: https://casper.network/docs/.  (ref. as landing page later)

Why-Build-on-Casper Page: 
- Content adopted as per Card #71 
- Changes made in Rust and Web Assembly Section - Header updated to reflect new contents taken from the landing page.
- Changes made to Advanced Account Management, Contract Upgrades and Low Gas fee sections to add new information, updated to select contents from the landing page . 


### Notes

// Paste any other notes if any
