### PR TITLE
Updating Casper SDK Information

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdk/index.md
+++ b/source/docs/casper/dapp-dev-guide/sdk/index.md
@@ -11,11 +11,11 @@ The following table provides links to the SDK documentation, in addition to the 
 
 | SDK Documentation      | GitHub Location      | Maintainer |
 | ---------------------- | -------------------- | ---------- |
-|[TypeScript](./script-sdk.md) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Jan Hoffman](jan@hfmn.pl) |
-|Java SDK (work in progress) | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Carl Norburn](carl.norburn@gmail.com)|
+|[TypeScript](./script-sdk.md) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Jan Hoffman](mailto:jan@hfmn.pl) |
+|Java SDK (work in progress) | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Carl Norburn](mailto:carl.norburn@gmail.com)|
 |[C# SDK](/docs/dapp-dev-guide/sdk/csharp-sdk) (work in progress)|[Casper-net-sdk](https://github.com/make-software/casper-net-sdk)||
-|[Golang SDK](/docs/dapp-dev-guide/sdk/go-sdk) (work in progress)|[Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)|[Yaroslav Panasenko](yar.panasenko@gmail.com)|
-|[Python SDK](/docs/dapp-dev-guide/sdk/python-sdk) (work in progress)|[Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)|[Mark A. Greenslade](mark@casperlabs.io)|
-|Java SDK by SyntiFi|[Casper-sdk](https://github.com/syntifi/casper-sdk)|[Remo Stieger](remo@syntifi.com)/[Andre Bertolace](andre@syntifi.com)|
+|[Golang SDK](/docs/dapp-dev-guide/sdk/go-sdk) (work in progress)|[Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)|[Yaroslav Panasenko](mailto:yar.panasenko@gmail.com)|
+|[Python SDK](/docs/dapp-dev-guide/sdk/python-sdk) (work in progress)|[Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)|[Mark A. Greenslade](mailto:mark@casperlabs.io)|
+|Java SDK by SyntiFi|[Casper-sdk](https://github.com/syntifi/casper-sdk)|[Remo Stieger](mailto:remo@syntifi.com)/[Andre Bertolace](mailto:andre@syntifi.com)|
 |PHP SDK|[Casper-php-sdk](https://github.com/make-software/casper-php-sdk)|Roman Bylbas, Ihor Burlachenko, Michael Steuer|
 |Erlang SDK| In Development|Robert Carbone (Telegram: [@ophiucan](https://t.me/ophiucan))|

--- a/source/docs/casper/dapp-dev-guide/sdk/index.md
+++ b/source/docs/casper/dapp-dev-guide/sdk/index.md
@@ -7,12 +7,15 @@ slug: /sdk
 
 This section covers the software development kits (SDKs) available for interacting with the Casper blockchain. These SDKs are client-side libraries providing functions or methods (depending on the language) to interact with the Casper Network. You can use them as a model to develop your application and accomplish tasks such as generating account keys, sending transfers, or other blockchain transactions.
 
-The following table provides links to the SDK documentation, in addition to the corresponding GitHub repositories.
+The following table provides links to the SDK documentation, in addition to the corresponding GitHub repositories and pertinent contact information.
 
-| SDK Documentation             | GitHub Location                                        |
-| ----------------------------- | ------------------------------------------------------ |
-| [TypeScript](./script-sdk.md) | https://github.com/casper-ecosystem/casper-js-sdk/     |
-| Java SDK (work in progress)   | https://github.com/casper-network/casper-java-sdk/     |
-| [Golang SDK](/docs/dapp-dev-guide/sdk/go-sdk) (work in progress) | https://github.com/casper-ecosystem/casper-golang-sdk/ |
-| [Python SDK](/docs/dapp-dev-guide/sdk/python-sdk) (work in progress) | https://github.com/casper-network/casper-python-sdk/   |
-| [C# SDK](/docs/dapp-dev-guide/sdk/csharp-sdk) (work in progress) | https://github.com/make-software/casper-net-sdk |
+| SDK Documentation      | GitHub Location      | Maintainer |
+| ---------------------- | -------------------- | ---------- |
+|[TypeScript](./script-sdk.md) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Jan Hoffman](jan@hfmn.pl) |
+|Java SDK (work in progress) | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Carl Norburn](carl.norburn@gmail.com)|
+|[C# SDK](/docs/dapp-dev-guide/sdk/csharp-sdk) (work in progress)|[Casper-net-sdk](https://github.com/make-software/casper-net-sdk)||
+|[Golang SDK](/docs/dapp-dev-guide/sdk/go-sdk) (work in progress)|[Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)|[Yaroslav Panasenko](yar.panasenko@gmail.com)|
+|[Python SDK](/docs/dapp-dev-guide/sdk/python-sdk) (work in progress)|[Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)|[Mark A. Greenslade](mark@casperlabs.io)|
+|Java SDK by SyntiFi|[Casper-sdk](https://github.com/syntifi/casper-sdk)|[Remo Stieger](remo@syntifi.com)/[Andre Bertolace](andre@syntifi.com)|
+|PHP SDK|[Casper-php-sdk](https://github.com/make-software/casper-php-sdk)|Roman Bylbas, Ihor Burlachenko, Michael Steuer|
+|Erlang SDK| In Development|Robert Carbone (Telegram: [@ophiucan](https://t.me/ophiucan))|


### PR DESCRIPTION
### Related links

Requirement Card:
[Add info about Casper SDKs #106](https://github.com/casper-network/docs/issues/106)

### Changes

Added several additional SDKs as requested, as well as adding a 'Maintainer' column with available contact information.

### Notes

Ran locally with no issues.
