### PR TITLE
Remove old videos

### DIFF
--- a/source/docs/casper/dapp-dev-guide/tutorials/counter/index.md
+++ b/source/docs/casper/dapp-dev-guide/tutorials/counter/index.md
@@ -7,8 +7,15 @@ slug: /counter
 
 In this tutorial, we introduce an application on the chain -- the counter contract. This tutorial is a straightforward contract that maintains a counter variable. The goal is to introduce you to the process of deploying and using a contract on Testnet, the test network. Once you are familiar with this process, the next step will be to write your smart contracts.
 
+- [Tutorial Overview](overview.md)
+- [Important Commands](commands.md)
+- [Casper Client Setup](setup.md)
+- [Tutorial Walkthrough](walkthrough.md)
+
+<!-- The videos need to be updated. Add this back once we upload the new videos. 
 ## Video Tutorial {#video-tutorial}
 
 If you prefer a video walkthrough of this guide, you can check out this video.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed?v=rWaUiFFEyaY&list=PL8oWxbJ-csEogSV-M0IPiofWP5I_dLji6&index=6" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+-->

--- a/source/docs/casper/dapp-dev-guide/tutorials/multi-sig/index.md
+++ b/source/docs/casper/dapp-dev-guide/tutorials/multi-sig/index.md
@@ -7,6 +7,12 @@ slug: /multi-sig
 
 In this tutorial, you will learn to use [Casper's permissions model](../../../design/accounts.md#permissions-model) to sign transactions with multiple keys. The code for this tutorial is available in [GitHub](https://github.com/casper-ecosystem/keys-manager). The sample code creates a smart contract and a sample client that invokes the multi-signature feature on a local Casper network.
 
+- [Account Management Concepts](concepts.md)
+- [Smart Contract Example](contract.md)
+- [Client Example](client.md)
+- [Additional Scenarios](additional.md)
+
+<!-- The videos need to be updated. Add this back once we upload the new videos. 
 ## Video Tutorials {#video-tutorials}
 
 If you prefer a video walkthrough of this guide, you can check out the videos below.
@@ -18,3 +24,4 @@ If you prefer a video walkthrough of this guide, you can check out the videos be
 **Local network testing with a JavaScript client**
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed?v=URCd4bwenLU&list=PL8oWxbJ-csEogSV-M0IPiofWP5I_dLji6&index=5" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+-->

--- a/source/docs/casper/workflow/staking.md
+++ b/source/docs/casper/workflow/staking.md
@@ -6,9 +6,11 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 Casper and other Proof-of-Stake protocols allow token holders to earn rewards and participate in the protocol through a mechanism called **staking**. This tutorial shows you how to stake your Casper tokens with a validator on the network. This process is also called **delegation**. We will use these terms interchangeably in this guide, but we will explain the technical difference for clarity.
 
+<!-- Removing the video until we have time to refresh it.
 This video guide covers the process at a high level, but we recommend following the written tutorial to go through the process step by step.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/4C7L5lS284c" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+ -->
 
 **Staking**
 


### PR DESCRIPTION
### Related links

No corresponding link or card; requirement coming from internal discussions.

### Changes

- I commented out the videos that I know need to be updated:
   - The counter tutorial
   - The multi-sig tutorial
   - The staking tutorial

### Notes

- The corresponding write-ups have been updated, but the videos need more time for editing.
- We have separate cards in our backlog for updating the videos.