### PR TITLE
28 Fixing broken and inaccurate links

### DIFF
--- a/source/docs/casper/dapp-dev-guide/deploying-contracts.md
+++ b/source/docs/casper/dapp-dev-guide/deploying-contracts.md
@@ -71,7 +71,7 @@ The easiest way to deploy a contract is to use an existing public network. The T
 
 ### Obtain Token {#obtain-token}
 
-To send a deploy to the network, create keys and obtain token. Token can be obtained via a faucet or by a participant that has token. Connect to our [Discord](https://discordapp.com/invite/Q38s3Vh) to get token via an existing participant.
+To send a deploy to the network, create keys and obtain token. Token can be obtained via a faucet or by a participant that has token. Connect to our [Discord](https://discord.com/invite/Q38s3Vh) to get token via an existing participant.
 
 ### A Basic Deployment using the Command Line (Rust Client) {#a-basic-deployment-using-the-command-line-rust-client}
 

--- a/source/docs/casper/dapp-dev-guide/keys.md
+++ b/source/docs/casper/dapp-dev-guide/keys.md
@@ -140,7 +140,7 @@ casper-client transfer \
 
 The Casper command-line client requires the secret key in *PEM* format to send a transaction from this account. If you want to use existing Ethereum keys with the command-line client, a conversion to *PEM* format is needed.
 
-The following example is a JS script that generates a *PEM* file, using a [key encoder](https://github.com/blockstack/key-encoder-js) and Node.js. To install these components, do the following:
+The following example is a JS script that generates a *PEM* file, using a [key encoder](https://github.com/stacks-network/key-encoder-js) and Node.js. To install these components, do the following:
 
 ```bash
 sudo apt install nodejs

--- a/source/docs/casper/dapp-dev-guide/sdk/csharp-sdk.md
+++ b/source/docs/casper/dapp-dev-guide/sdk/csharp-sdk.md
@@ -1,7 +1,7 @@
 # C Sharp SDK (NetCasperSDK)
 
 
-The [C# SDK](https://github.com/davidatwhiletrue/netcaspersdk) allows developers to interact with the Casper Network using C#. This page covers different examples of using the SDK.
+The [C# SDK](https://github.com/make-software/casper-net-sdk) allows developers to interact with the Casper Network using C#. This page covers different examples of using the SDK.
 
 ## Build
 
@@ -38,4 +38,4 @@ There are also available C# versions of the following tutorials:
 * Counter Tutorial [CasperLabs docs](/counter/index.html): C# version [here](https://hackmd.io/@K48d9TN9T2q7ERX4H27ysw/SJBnPCdVt).
 * Key-value storage Tutorial [CasperLabs docs](/dapp-dev-guide/tutorials/kv-storage-tutorial): C# version [here](https://hackmd.io/@K48d9TN9T2q7ERX4H27ysw/HyX8i0WBt) .
 
-NOTE: Examples can be added to this site after the hackaton.
+NOTE: Examples can be added to this site after the hackathon.

--- a/source/docs/casper/dapp-dev-guide/tutorials/erc20/tests.md
+++ b/source/docs/casper/dapp-dev-guide/tutorials/erc20/tests.md
@@ -111,7 +111,7 @@ This code snippet builds the context and includes the compiled contract _.wasm_ 
 
 **Note**: These accounts have a positive initial balance.
 
-The full and most recent code implementation is available on [GitHub](https://github.com/casper-ecosystem/erc20/blob/master/example/erc20-tests/src/test_fixture.rs>).
+The full and most recent code implementation is available on [GitHub](https://github.com/casper-ecosystem/erc20/blob/master/example/erc20-tests/src/test_fixture.rs).
 
 ```rust
 

--- a/source/docs/casper/design/serialization-standard.md
+++ b/source/docs/casper/design/serialization-standard.md
@@ -399,7 +399,7 @@ A complete `CLValue`, including both the data and the type, can also be serializ
 
 Contracts are a special value type because they contain the on-chain logic of the applications running on the Casper network. A _contract_ contains the following data:
 
--   a [wasm module](https://webassembly.org/docs/modules/)
+-   a [wasm module](https://webassembly.github.io/spec/core/syntax/modules.html)
 -   a collection of named keys
 -   a protocol version
 

--- a/source/docs/casper/economics/delegation.md
+++ b/source/docs/casper/economics/delegation.md
@@ -1,6 +1,6 @@
-import useBaseUrl from '@docusaurus/useBaseUrl';
-
 # Delegation Details
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This section provides a detailed explanation of the delegation cost mechanism, how the gas cost relates with delegations, where to find the details etc. Please note that the cost amounts are likely to change with time and you may have to check the latest release details to get the most up-to-date and accurate details.
 
@@ -26,7 +26,7 @@ For example, the chainspec file in release 1.3.2 will contain the following info
 
 Delegation fees may change over time, so, it is essential to stay up to date. To do so, select the latest release in [Github](https://github.com/casper-network/casper-node), and navigate to the chainspec.toml file.
 
-If you are unsure about anything, please join the [Discord channel](https://discord.gg/PjAQVXRx4Y) to ask us questions.
+If you are unsure about anything, please join the [Discord channel](https://discord.com/invite/PjAQVXRx4Y) to ask us questions.
 
 ### First-time Delegation
 

--- a/source/docs/casper/faq/faq-developer.md
+++ b/source/docs/casper/faq/faq-developer.md
@@ -67,7 +67,7 @@ rustup update
 rustup self update
 ```
 
-Refer to the [Rust toolchain installer](https://reposhub.com/rust/development-tools/rust-lang-rustup.html) for more details.
+Refer to the [Rust toolchain installer](https://openprojectrepo.com/project/rust-lang-rustup-rust-development-tools) for more details.
 
 </details>
 

--- a/source/docs/casper/faq/faq-validator.md
+++ b/source/docs/casper/faq/faq-validator.md
@@ -64,7 +64,7 @@ If you are running a node, you can use `localhost:7777` for RPC requests like de
 <details>
 <summary><b>Does Casper run on ARM?</b></summary>
 
-Casper-node does not work with ARM type servers. You can see our hardware specifications [here](https://docs.casperlabs.io/en/latest/node-operator/hardware.html).
+Casper-node does not work with ARM type servers. You can see our hardware specifications [here](../operators/hardware).
 
 </details>
 

--- a/source/docs/casper/operators/index.md
+++ b/source/docs/casper/operators/index.md
@@ -7,4 +7,4 @@ slug: /operators
 
 Operators who wish to run node infrastructure on the Casper network, either as a standalone private network, or as part of the public network should explore this guide.
 
-It is recommended that you have prior knowledge of Unix-based operating systems and proficiency with systemd and bash scripting. If you are unfamiliar with systemd, the [Arch Linux page on systemd](https://wiki.archlinux.org/index.php/systemd) is a good introduction to using it.
+It is recommended that you have prior knowledge of Unix-based operating systems and proficiency with systemd and bash scripting. If you are unfamiliar with systemd, the [Arch Linux page on systemd](https://wiki.archlinux.org/title/systemd) is a good introduction to using it.


### PR DESCRIPTION
### Related links

[28 infra integrate markdown link checkin #220](https://github.com/casper-network/docs/pull/220)

### Changes

I went through and updated broken or incorrect links that showed up in the new external link checker created by @sd-ditoy

I did not change any links within the /i18n/ directory, as it does not appear up to date and likely requires further changes before maintenance.

### Notes

All changes ran locally and new links were checked for validity.
