### PR TITLE
99 Including info about additional languages

### DIFF
--- a/source/docs/casper/dapp-dev-guide/getting-started.md
+++ b/source/docs/casper/dapp-dev-guide/getting-started.md
@@ -98,6 +98,8 @@ If you look inside the newly-created _my-project_ folder, you will find two crat
 
 The Casper blockchain uses WebAssembly (WASM) in its runtime environment. Compilation targets for WASM are available for Rust, giving developers access to all the Rust ecosystem tools when developing smart contracts.
 
+* Note: WASM allows for the use of other languages, including but not limited to: C/C++, C#, Go, Julia, Lobster and ZIG.
+
 To compile the smart contract into WASM, go into the _my-project_ folder, and run the following commands:
 
 ```bash


### PR DESCRIPTION
### Related links

[Extend the mentioned list of wasm compatible languages #99](https://github.com/casper-network/docs/issues/99)

### Changes

Added a note about languages other than Rust that are compatible with WASM.

I went through the documentation and looked for other instances where this note would be applicable - but this is the only document that has that degree of specificity.

### Notes

Page ran locally without issue.
