### PR TITLE
Publish the latest counter video

### DIFF
--- a/source/docs/casper/dapp-dev-guide/tutorials/counter/index.md
+++ b/source/docs/casper/dapp-dev-guide/tutorials/counter/index.md
@@ -12,10 +12,8 @@ In this tutorial, we introduce an application on the chain -- the counter contra
 - [Casper Client Setup](setup.md)
 - [Tutorial Walkthrough](walkthrough.md)
 
-<!-- The videos need to be updated. Add this back once we upload the new videos. 
 ## Video Tutorial {#video-tutorial}
 
 If you prefer a video walkthrough of this guide, you can check out this video.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed?v=rWaUiFFEyaY&list=PL8oWxbJ-csEogSV-M0IPiofWP5I_dLji6&index=6" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
--->


### PR DESCRIPTION
### Related links

Backlog://github.com/casper-network/Governance/issues/188.

### Changes

- Updated content for the counter tutorial to use the Testnet instead of NCTL
- Updated video, which has been uploaded to YouTube (Module 4 - Application, index=6)

<img width="374" alt="Screen Shot 2022-03-09 at 1 44 07 PM" src="https://user-images.githubusercontent.com/4185994/157444702-7dc9a138-ac7f-49fe-a3b7-e4c196177723.png">

