### PR TITLE
Fix for issue 276/272

### DIFF
--- a/source/docs/casper/workflow/erc20-token-deployment-guide.md
+++ b/source/docs/casper/workflow/erc20-token-deployment-guide.md
@@ -4,8 +4,6 @@ On the Casper Network, it is possible to create smart contracts that emulate ERC
 
 ## Prerequisites
 
-- Set up your machine as per the [prerequisites](https://casper.network/docs/workflow/setup).
-
 - [Set up an account](https://casper.network/docs/workflow/setup#setting-up-an-account).
 - [Fund your account](https://casper.network/docs/workflow/setup#fund-your-account).
 
@@ -62,7 +60,7 @@ Let's take a look at what these constants refer to.
 As long as you generated the keys with the aforementioned command within your project's root folder, the paths to your keys should be the same as already written in the code. Otherwise, you'll need to put in the alternate path to your keys in the `KEYS` constant.
 
 ```javascript
-const KEYS = Keys.Ed25519.parseKeyFiles(
+const KEYS = Keys.Ed25519.loadKeyPairFromPrivateFile(
   "./keys/secret_key.pem"
 );
 ```


### PR DESCRIPTION
### Related links

https://github.com/casper-network/docs/pull/276
https://github.com/casper-network/docs/pull/272

### Changes

Fixed the following issues:

• Keys.Ed25519.parseKeyFiles() does not work only with the secret key. Keys.Ed25519.loadKeyPairFromPrivateFile()can.
• The repo casper-erc20-js-interface has not been updated. Now there's a mismatch between the code in the README and the code in the repo.
• To follow this tutorial someone doesn't need to have rust or casper-client. I'd remove this: Set up your machine as per the prerequisites.