### PR TITLE
Clarified known_addresses section

### DIFF
--- a/source/docs/casper/operators/joining.md
+++ b/source/docs/casper/operators/joining.md
@@ -59,7 +59,12 @@ casper-client get-block --node-address http://<NODE_IP_ADDRESS>:7777 -b 20
 casper-client get-block --node-address http://<NODE_IP_ADDRESS>:7777 -b 20 | jq -r .result.block.hash
 ```
 
-A good IP to use above are those listed in your `config.toml` as `known_addresses`. For more information on trusted hash, see [Trusted Hash for Synchronizing](../setup/#trusted-hash-for-synchronizing).
+For more information on trusted hash, see [Trusted Hash for Synchronizing](../setup/#trusted-hash-for-synchronizing).
+
+### Known Addresses {#known-addresses}
+
+In order for the node to connect to a network, the node needs a set of trusted peers for that network. For mainnet, 
+these are listed in the `config.toml` as `known_addresses`. For other networks, locate and update the list to include at least 2 trusted IP addresses for peers in that network. 
 
 ### Updating `config.toml` file {#updating-config-file}
 

--- a/source/docs/casper/operators/joining.md
+++ b/source/docs/casper/operators/joining.md
@@ -63,8 +63,7 @@ For more information on trusted hash, see [Trusted Hash for Synchronizing](../se
 
 ### Known Addresses {#known-addresses}
 
-In order for the node to connect to a network, the node needs a set of trusted peers for that network. For mainnet, 
-these are listed in the `config.toml` as `known_addresses`. For other networks, locate and update the list to include at least 2 trusted IP addresses for peers in that network. 
+For the node to connect to a network, the node needs a set of trusted peers for that network. For [Mainnet](https://cspr.live/), these are listed in the `config.toml` as `known_addresses`. For other networks, locate and update the list to include at least two trusted IP addresses for peers in that network. Here is an [example configuration](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml). The [casper-protocol-release](https://github.com/casper-network/casper-protocol-release) repository stores configurations for various environments, which you can also use as examples.
 
 ### Updating `config.toml` file {#updating-config-file}
 


### PR DESCRIPTION
Created a separate sub-section and clarified that the default in config.toml point to mainnet.

### Related links

// Paste links to Github tasks or links to related PRs.

### Changes

// Paste brief description what has changed.

// Paste [loom](https://www.loom.com/), screenshots, or gifs([record](https://giphy.com/apps/giphycapture), [compress](https://gifcompressor.com/)) here.

### Notes

// Paste any other notes if any
