### PR TITLE
Bradjohnl fix cname generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Docusaurus CICD
 
+env:
+  prod_pages_fqdn: ${{ secrets.PROD_PAGES_FQDN }}
+
 on:
   push:
     branches: "*"
@@ -20,7 +23,6 @@ jobs:
         with:
           name: gh-pages-backup
           path: .
-
 
   build:
     runs-on: ubuntu-latest
@@ -67,6 +69,7 @@ jobs:
         run: |
           yarn build --out-dir ./docs
 
+      # Add CNAME file to the build output payload to keep the custom domain settings of GitHub Pages enabled
       - name: Add CNAME file to the build output payload to keep the custom domain settings of GitHub Pages enabled
         run: |
           echo "$prod_pages_fqdn" > ./docs/CNAME
@@ -152,22 +155,19 @@ jobs:
     needs: deploy-prod
     runs-on: ubuntu-latest
 
-    env:
-      prod_pages_url: ${{ secrets.PROD_PAGES_URL }}
-
     steps:
       - name: Test home page
         run: |
           echo "Testing if homepage responds correctly"
-          curl --fail $prod_pages_url
+          curl --fail https://$prod_pages_fqdn
       - name: Test a random page
         run: |
           echo "Testing if a page responds correctly"
-          curl --fail $prod_pages_url/operators/create
+          curl --fail https://$prod_pages_fqdn/operators/create
       - name: Test another random page
         run: |
           echo "Testing if a page responds correctly"
-          curl --fail $prod_pages_url/design/serialization-standard
+          curl --fail https://$prod_pages_fqdn/design/serialization-standard
 
   rollback-if-tests-fail:
     if: ${{ always() && (needs.system-tests-postdeployment.result=='failure') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           yarn build --out-dir ./docs
 
+      - name: Add CNAME file to the build output payload to keep the custom domain settings of GitHub Pages enabled
+        run: |
+          echo "$prod_pages_fqdn" > ./docs/CNAME
+
       - uses: actions/upload-artifact@v2
         with:
           name: gh-pages-depl-payload

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,6 @@ jobs:
         run: |
           yarn build --out-dir ./docs
 
-      # Add CNAME file to the build output payload to keep the custom domain settings of GitHub Pages enabled
       - name: Add CNAME file to the build output payload to keep the custom domain settings of GitHub Pages enabled
         run: |
           echo "$prod_pages_fqdn" > ./docs/CNAME


### PR DESCRIPTION
I found out an issue that causes the custom domain setting to be removed from the GitHub Pages site at every deployment, causing the site to revert back to the [github.io](http://github.io/) domain. 
When this happens the site does not work.
It is because the CNAME file that is necessary for Github to use the [docs.casperlabs.io](http://docs.casperlabs.io/) domain does not get automatically pushed to the gh-pages branch at every deployment.

This PR fixes this issue.