### PR TITLE
Updated the links to erc-20 tutorial

### DIFF
--- a/source/docs/casper/workflow/erc-20-sample-guide/index.md
+++ b/source/docs/casper/workflow/erc-20-sample-guide/index.md
@@ -18,7 +18,7 @@ We will employ the following test accounts to demonstrate the use of an ERC-20 c
 
 To execute transactions on the Casper Network (involving ERC-20 tokens), you will need some CSPR tokens to pay for the transactions.
 
-To understand the implementation of a Casper ERC-20 contract, see the [ERC-20 Tutorial](/erc20).
+To understand the implementation of a Casper ERC-20 contract, see the [ERC-20 Tutorial](https://github.com/casper-ecosystem/erc20/blob/master/TUTORIAL.md).
 
 ## Prerequisites
 

--- a/source/docs/casper/workflow/erc20-token-deployment-guide.md
+++ b/source/docs/casper/workflow/erc20-token-deployment-guide.md
@@ -95,5 +95,5 @@ To send tokens from the address you just funded, just change the `KEYS` constant
 
 ## Conclusion
 
-Thank you for reading Casper's ERC-20 deployment guide. Next, you can learn how to write your own [ERC-20 smart contracts](https://docs.casperlabs.io/erc20), and use [Casper's JavaScript SDK](https://docs.casperlabs.io/dapp-dev-guide/sdk/script-sdk).
+Thank you for reading Casper's ERC-20 deployment guide. Next, you can learn how to write your own [ERC-20 smart contracts](https://github.com/casper-ecosystem/erc20/blob/master/TUTORIAL.md), and use [Casper's JavaScript SDK](https://docs.casperlabs.io/dapp-dev-guide/sdk/script-sdk).
 


### PR DESCRIPTION
### Related links

Card - [318](https://github.com/casper-network/docs/issues/318)

### Changes

Updated the existing links to the new ERC-20 tutorial location.

### Notes
-
