### PR TITLE
Changing PR bot strategy

### DIFF
--- a/.github/workflows/dev_main_sync.yml
+++ b/.github/workflows/dev_main_sync.yml
@@ -21,13 +21,25 @@ jobs:
           app_id: ${{ secrets.PRBOT_APP_ID }}
           private_key: ${{ secrets.PRBOT_APP_PRIVATE_KEY }}
 
-
-      - name: Create pull request to merge into main
-        uses: peter-evans/create-pull-request@v4
+      #Sync dev branch to the main branch to keep it updated
+      - name: Set up Node
+        uses: actions/setup-node@v1
         with:
-          title: Merge ${{ github.ref }} into main
-          base: main
-          body: Merge ${{ github.ref }} into main. Please approve if you agree to sync dev site to main, otherwise reject.
-          token: ${{ steps.generate-token.outputs.token }}
-          branch: dev
-          
+          node-version: 12
+
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          FROM_BRANCH: "dev"
+          TO_BRANCH: "main"
+          REVIEWERS: '["bradjohnl"]'
+          CONTENT_COMPARISON: true
+          PULL_REQUEST_BODY: "This PR is created by the PR Bot to sync the dev branch to the main branch."
+          PULL_REQUEST_TITLE: "Sync dev to main"
+
+      #Display the pull request URL:
+      - name: Display the pull request URL
+        run: | 
+          echo "The pull request URL is: ${{ steps.pull.outputs.PULL_REQUEST_URL }}"


### PR DESCRIPTION
The current strategy used is not working to successfully submit the PR to sync dev to main.
This is using another approach.