### PR TITLE
Add back the tutorials index page

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -91,6 +91,7 @@ module.exports = {
             collapsible: true,
             collapsed: true,
             items: [
+                "dapp-dev-guide/tutorials/index",
                 "dapp-dev-guide/tutorials/casper-signer",
                 {
                     type: "category",


### PR DESCRIPTION
### Related links

With PR #348 we deleted the index page:
 
<img width="434" alt="Screen Shot 2022-04-14 at 12 13 44 AM" src="https://user-images.githubusercontent.com/4185994/163279235-70e7716d-2456-4b9a-87f9-fbd1d0b06292.png">


Adding it back:

<img width="1149" alt="Screen Shot 2022-04-14 at 12 13 24 AM" src="https://user-images.githubusercontent.com/4185994/163279206-2d42fc68-7d20-4ec0-a09a-85d84d0ec813.png">

