### PR TITLE
285 Updated Basic Smart Contract Draft

### DIFF
--- a/source/docs/casper/dapp-dev-guide/writing-contracts/rust.md
+++ b/source/docs/casper/dapp-dev-guide/writing-contracts/rust.md
@@ -1,113 +1,334 @@
-# A Basic Smart Contract in Rust
+# Writing a Basic Smart Contract in Rust
 
-This section explains step by step how to write a new smart contract on Casper. Start with `main.rs` from the previous section.
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-## A Basic Smart Contract in Rust {#a-basic-smart-contract-in-rust}
+## What is a Smart Contract?
 
-The Casper VM executes a smart contract by calling the `call` function specified in the contract. If the function is missing, the smart contract is not valid. The simplest possible example is an empty `call` function.
+A smart contract is a self-contained program installed on a blockchain. In the context of a Casper Network, a smart contract consists of contract code installed on [global state](../../glossary/g#global-state) through the use of a [deploy](../../design/execution-semantics/#execution-semantics-deploys).
 
-```rust
-#[no_mangle]
-pub extern "C" fn call() {}
+Before writing smart contracts on a Casper Network, developers should be familiar with the difference between contract code and session code. Session code executes entirely within the context of the initiating account, while contract code executes within the context of its own state. Any action undertaken by a contract must initiate through an outside call, usually via session code.
+
+## Why Do You Want to Use a Smart Contract?
+
+Smart contracts exist as means to install programs to global state, thereby allowing disparate users to call the included entry points. These contracts can, in turn, call one another to perform interconnected operations and create more complex programs. The decentralized nature of blockchain technology means that these smart contracts do not suffer from any single point of failure. Even if a Casper node leaves the network, other nodes will continue to allow the contract to operate as intended.
+
+Further, the Casper platform allows for upgradeable contracts and implementation through a variety of developer-friendly programming languages. 
+
+## Smart Contracts on Casper
+
+Casper smart contracts are programs that run on a Casper Network. They interact with accounts and other contracts through entry points and allow for various triggers, conditions and logic.
+
+On the Casper platform, developers may write smart contracts in any language that compiles to Wasm binaries. In this tutorial, we will focus specifically on writing a smart contract in the Rust language. The Rust compiler will compile the contract code into Wasm binary. After that, we will send the Wasm binary to a node on a Casper Network through the use of a `put_deploy`. When the node executes the Wasm, it is added to [global state](./glossary/G/#global-state), and [gossips](./design/p2p/#communications-gossiping) that deploy to other nodes. Finally, all nodes within a network will repeat this process.
+
+A ContractPackage is created through the `new_contract` or `new_locked_contract` methods. Through these methods, the Casper execution engine creates the new contract package automatically and assigns a [`ContractPackageHash`](/dapp-dev-guide/understanding-hash-types#hash-and-key-explanations). The new contract is added to this contract package with a `ContractHash` key. The execution engine stores the new contract within the contract package, alongside any previously installed versions of the contract, if applicable.
+
+The contract contains required metadata and is primarily identified by its hash known as the contract hash.
+
+## Writing a Basic Smart Contract
+
+As stated, this tutorial covers the process of writing a smart contract in the Rust programming language. Casper maintains a Rust SDK as a first-party entity, while also providing an [SDK Specification](../../dapp-dev-guide/sdkspec/introduction.md) for third-parties wishing to develop additional language SDKs.
+
+This tutorial creates a simple smart contract that allows callers to donate funds to a central purse, as well as track the total funds received and individual contributions.
+
+-------
+
+### Step 1. Creating the directory structure
+
+First, create the directory for the new contract. This folder should have two sub-directories named `contract` and `test`.
+
+- `Contract` -  This directory contains the code that becomes the Wasm which is eventually sent to the network.    
+- `test` -  This directory contains all the tests that you will send to the network.
+
+Use the below command to create a new contract folder. This creates the `contract` folder with */src/main.rs* file and *cargo.toml* file
+
+```bash
+
+cargo new [CONTRACT_NAME]
+
+```
+--------
+
+
+### Step 2. Configuring the main.rs file
+
+1) Remove the auto-generated main function and add file configurations 
+
+2) Adjust the file attributes to support the Wasm execution environment
+
+- `#![no_main]` - This attribute tells the program not to use the standard main function as its entry point.
+- `#![no_std]` - This attribute tells the program not to import the standard libraries.
+
+3) Import the required dependencies
+
+- `contract_api` - This is a command-line tool for creating a Wasm smart contract and tests for use on the Casper network.
+- `typescript` - These are the types shared by many Casper crates for use on the Casper network.
+
+Add these dependencies to the *Cargo.toml* file
+
+```typescript
+
+[dependencies]
+// A library for developing Casper network smart contracts.
+casper-contract = "1.4.4"
+// Types shared by many Casper crates for use on the Casper Network.
+casper-types = "1.4.6"
+
 ```
 
-The `#[no_mangle]` attribute prevents the compiler from changing (mangling) the function name when converting to the binary format of Wasm. Without it, the VM exits with the error message: `Module doesn't have export call`.
-
-## Arguments {#arguments}
-
-It's possible to pass arguments to smart contracts. To leverage this feature, use [runtime::get_named_arg](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_named_arg.html).
+Then, add your imports in the main.rs file along with other imports
 
 ```rust
-use casperlabs_contract::contract_api::runtime;
 
+// This code imports necessary aspects of external crates that we will use in our contract code.
+
+extern crate alloc;
+
+// Importing Rust types.
+use alloc::string::{String, ToString};
+use alloc::vec;
+// Importing aspects of the Casper platform.
+use casper_contract::contract_api::storage::dictionary_get;
+use casper_contract::contract_api::{runtime, storage, system};
+use casper_contract::unwrap_or_revert::UnwrapOrRevert;
+// Importing specific Casper types.
+use casper_types::account::AccountHash;
+use casper_types::contracts::NamedKeys;
+use casper_types::{runtime_args, CLType, CLValue, EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Key, Parameter, ApiError, RuntimeArgs};
+
+```
+
+### Step 3. Defining the Global Constants
+
+After importing the necessary dependencies, you should define the constants that you will use within the contract itself. This includes both entry points and values. The following example outlines the necessary constants for a 
+
+```rust
+
+// Creating constants for the various contract entry points.
+const ENTRY_POINT_INIT: &str = "init";
+const ENTRY_POINT_DONATE: &str = "donate";
+const ENTRY_POINT_GET_DONATION_COUNT: &str = "get_donation_count";
+const ENTRY_POINT_GET_FUNDS_RAISED: &str = "get_funds_raised";
+
+// Creating constants for values within the contract.
+const DONATING_ACCOUNT_KEY: &str = "donating_account_key";
+const LEDGER: &str = "ledger";
+const FUNDRAISING_PURSE: &str = "fundraising_purse";
+
+```
+
+### Step 4. Defining the Contract Entry Points
+
+Entry points serve as a means to access contract code installed on global state. These functions may be called by either session code or another instance of contract code. When creating contract code, you should clearly define entry point functions through the use of meaningful names that describe the actions that they perform.
+
+When defining entry points, begin with a `#[no_mangle]` line to ensure that the system does not change critical syntax within the method names. Each entry point should contain the contract code that drives the action you wish the function to accomplish. Finally, include any storage or return values needed as applicable.
+
+```rust
+
+// This entry point initializes the donation system, setting up the fundraising purse
+// and creating a dictionary to track the account hashes and the number of donations
+// made.
+#[no_mangle]
+pub extern "C" fn init() {
+    let fundraising_purse = system::create_purse();
+    runtime::put_key(FUNDRAISING_PURSE, fundraising_purse.into());
+    // Create a dictionary to track the mapping of account hashes to number of donations made.
+    storage::new_dictionary(LEDGER).unwrap_or_revert();
+}
+
+// This is the main donation entry point. When called, it records the caller's account
+// hash and returns the donation purse, with add access, to the immediate caller.
+#[no_mangle]
+pub extern "C" fn donate() {
+    let donating_account_key: Key = runtime::get_named_arg(DONATING_ACCOUNT_KEY);
+    if let Key::Account(donating_account_hash) = donating_account_key {
+        update_ledger_record(donating_account_hash.to_string())
+    } else {
+        runtime::revert(FundRaisingError::InvalidKeyVariant)
+    }
+    let donation_purse = *runtime::get_key(FUNDRAISING_PURSE)
+        .unwrap_or_revert_with(FundRaisingError::MissingFundRaisingPurseURef)
+        .as_uref()
+        .unwrap_or_revert();
+    let value = CLValue::from_t(donation_purse.into_add()).unwrap_or_revert();
+    runtime::ret(value)
+}
+
+// This entry point returns the amount of donations from the caller.
+#[no_mangle]
+pub extern "C" fn get_donation_count() {
+    let donating_account_key: Key = runtime::get_named_arg(DONATING_ACCOUNT_KEY);
+    if let Key::Account(donating_account_hash) = donating_account_key {
+        let ledger_seed_uref = *runtime::get_key(LEDGER)
+            .unwrap_or_revert_with(FundRaisingError::MissingLedgerSeedURef)
+            .as_uref()
+            .unwrap_or_revert();
+        let donation_count = if let Some(donation_count) =
+            storage::dictionary_get::<u64>(ledger_seed_uref, &donating_account_hash.to_string())
+                .unwrap_or_revert()
+        {
+            donation_count
+        } else {
+            0u64
+        };
+        runtime::ret(CLValue::from_t(donation_count).unwrap_or_revert())
+    } else {
+        runtime::revert(FundRaisingError::InvalidKeyVariant)
+    }
+}
+
+// This entry point returns the total funds raised.
+#[no_mangle]
+pub extern "C" fn get_funds_raised() {
+    let donation_purse = *runtime::get_key(FUNDRAISING_PURSE)
+        .unwrap_or_revert_with(FundRaisingError::MissingFundRaisingPurseURef)
+        .as_uref()
+        .unwrap_or_revert();
+    let funds_raised = system::get_purse_balance(donation_purse)
+        .unwrap_or_revert();
+    runtime::ret(CLValue::from_t(funds_raised).unwrap_or_revert())
+}
+
+```
+
+### Step 5. Defining the Call Function
+
+This is the function that starts the code execution and will be the function responsible for installing the contract. In this case, it also initializes the contract by creating a donation purse and ledger for record keeping.
+
+1) Defining the Runtime Arguments
+
+These parameters will be passed in as runtime arguments at the time of installation. Use this pattern of variable definition to collect any type of sentinel values that dictate the behavior of the contract. If the entry point takes in arguments then you must declare those as part of the definition of the entry point.
+
+In the donation contract example, the only variable parameter is the `DONATING_ACCOUNT_KEY`.
+
+2) Inserting the Entry Points in to the Call Function
+
+The `call` function replaces a traditional `main` function and executes automatically when a caller interacts with the contract code. Within the `call` function, we define entry points that the caller can access using another instance of code. The calling code may be an instance of session or contract code. When writing code that will call an entry point, there must be a one-to-one mapping of the entry point name. Otherwise, the execution engine will return an error that the entry point does not exist.
+
+```rust
+
+//This is the full `call` function as defined within the donation contract.
 #[no_mangle]
 pub extern "C" fn call() {
-    let value: String = runtime::get_named_arg("value");
+    // This establishes the `init` entry point for initializing the contract's infrastructure.
+    let init_entry_point = EntryPoint::new(
+        ENTRY_POINT_INIT,
+        vec![],
+        CLType::Unit,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    );
+
+    // This establishes the `donate` entry point for callers looking to donate.
+    let donate_entry_point = EntryPoint::new(
+        ENTRY_POINT_DONATE,
+        vec![Parameter::new(DONATING_ACCOUNT_KEY, CLType::Key)],
+        CLType::URef,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    );
+
+    // This establishes an entry point called `donation_count` that returns the amount of
+    // donations from a specific account.
+    let get_donation_count_entry_point = EntryPoint::new(
+        ENTRY_POINT_GET_DONATION_COUNT,
+        vec![Parameter::new(DONATING_ACCOUNT_KEY, CLType::Key)],
+        CLType::U64,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    );
+
+    // This establishes an entry point called `funds_raised` that returns the total amount
+    // donated by all participants.
+    let funds_raised_entry_point = EntryPoint::new(
+        ENTRY_POINT_GET_FUNDS_RAISED,
+        vec![],
+        CLType::U512,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    );
 }
+
 ```
 
-## Storage {#storage}
+The entry point should have the below arguments:
 
-Saving and reading values to and from the blockchain is a manual process in Casper. It requires more code to be written, but also provides a lot of flexibility. The storage system works similarly to a file system in an operating system. Let's say we have a string `"Hello Casper!"` that needs to be saved. To do this, use the text editor, create a new file, paste the string in and save it under a name in some directory. The pattern is similar on the Casper blockchain. First you have to save your value to the memory using [storage::new_uref](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_uref.html). This returns a reference to the memory object that holds the `"Hello Casper!"` value. You could use this reference to update the value to something else. It's like a file. Secondly you have to save the reference under a human-readable string using [runtime::put_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html). It's like giving a name to the file. The following function implements this scenario:
+- `name` - Name of the entry point, this should be the same as the initial definition.
+
+- `arguments` - A list of runtime arguments declared as part of the definition of the entry point.
+
+- `return type` - CLType that is returned by the entry point. Use type *Unit* for empty return types.
+
+- `access level` - Accessibility of the entry point.
+
+- `entry point type` - This can be `contract` or `session` code.
+
+3) Adding the Entry Points
+
+This step adds the individual entry points using `add_entry_point` method to one object and returns it to the `new_contract` method.
 
 ```rust
-const KEY: &str = "special_value";
 
-fn store(value: String) {
-    // Store `value` under a new unforgeable reference.
-    let value_ref = storage::new_uref(value);
+    let mut entry_points = EntryPoints::new();
+    entry_points.add_entry_point(init_entry_point);
+    entry_points.add_entry_point(donate_entry_point);
+    entry_points.add_entry_point(get_donation_count_entry_point);
+    entry_points.add_entry_point(funds_raised_entry_point);
 
-    // Wrap the unforgeable reference in a `Key`.
-    let value_key: Key = value_ref.into();
-
-    // Store this key under the name "special_value" in context-local storage.
-    runtime::put_key(KEY, value_key);
-}
 ```
 
-After this function is executed, the context (Account or Smart Contract) will have the content of the `value` stored under `KEY` in its named keys space. The named keys space is a key-value storage that every context has. It's like a home directory.
+4) Creating the Contract
 
-## Final Smart Contract {#final-smart-contract}
-
-The code below is the simple contract generated by [cargo-casper](https://crates.io/crates/cargo-casper) (found in `contract/src/main.rs` of a project created by the tool). It reads an argument and stores it in the memory under a key named `"special_value"`.
+Use the `new_contract` method to create the contract, with its named keys and entry points. This creates the contract object and will save the access_uref and the contract package hash in the context of the caller. The contract package will be created automatically with the contractPackageHash and the contract is added to the package later with the contractHash.
 
 ```rust
-#![cfg_attr(
-    not(target_arch = "wasm32"),
-    crate_type = "target arch should be wasm32"
-)]
-#![no_main]
 
-use casperlabs_contract::{
-    contract_api::{runtime, storage},
-};
-use casperlabs_types::{Key, URef};
+let (contract_hash, _contract_version) = storage::new_contract(
+        entry_points,
+        None,
+        Some("fundraiser_package_hash".to_string()),
+        Some("fundraiser_access_uref".to_string()),
+    );
 
-const KEY: &str = "special_value";
-const ARG_MESSAGE: &str = "message";
+    runtime::put_key("fundraiser_contract_hash", contract_hash.into());
+    // Call the init entry point to setup and create the fundraising purse
+    // and the ledger to track donations made.
+    runtime::call_contract::<()>(contract_hash, ENTRY_POINT_INIT, runtime_args! {})
 
-fn store(value: String) {
-    // Store `value` under a new unforgeable reference.
-    let value_ref: URef = storage::new_uref(value);
-
-    // Wrap the unforgeable reference in a value of type `Key`.
-    let value_key: Key = value_ref.into();
-
-    // Store this key under the name "special_value" in context-local storage.
-    runtime::put_key(KEY, value_key);
-}
-
-// All session code must have a `call` entrypoint.
-#[no_mangle]
-pub extern "C" fn call() {
-    // Get the optional first argument supplied to the argument.
-    let value: String = runtime::get_named_arg(ARG_MESSAGE);
-    store(value);
-}
 ```
 
-## Using Error Codes {#using-error-codes}
+This section explains the creation of a basic smart contract. Usually, these contracts are upgradable with the ability to add new versions. if you want to prevent any upgrades to a contract use the `new_locked_contract` method to create the contract inside the call function.
 
-The Casper VM supports error codes in smart contracts. A contract can stop execution and exit with a given error via the [runtime::revert](https://docs.rs/casper-contract) function:
+#### Locked Contracts
+
+Locked contracts cannot contain other versions in the same contract package, thus, they cannot be upgraded. In this scenario, the Casper execution engine will create a contract package, add a contract to that package and prevent any further upgrades to the contract. Use locked contracts when you need to ensure high security will not require updates to your contract. 
 
 ```rust
-use casperlabs_contract::contract_api::runtime;
-use casperlabs_types::ApiError;
 
-#[no_mangle]
-pub extern "C" fn call() {
-    runtime::revert(ApiError::PermissionDenied)
+pub fn new_locked_contract(
+    entry_points: EntryPoints,
+    named_keys: Option<NamedKeys>,
+    hash_name: Option<String>,
+    uref_name: Option<String>,
+) -> (ContractHash, ContractVersion) {
+    create_contract(entry_points, named_keys, hash_name, uref_name, true)
 }
+
 ```
 
-<!-- Casper has [several built-in error variants](https://crates.io/crates/casper-types/latest/casper_types/) , but it's possible to create a custom set of error codes for your smart contract. These can be passed to [runtime::revert](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.revert.html) via [ApiError::User(\<your error code>) \<https://docs.rs/casper-types/latest/casper_types/enum.ApiError.html#variant.User>](). -->
+- `entry_points`: The set of entry points defined inside the smart contract.
+- `named_keys`: Any named-key pairs for the contract.
+- `hash_name`: Contract hash value. Puts contract hash in current context's named keys under `hash_name`. 
+- `uref_name`: Access URef value. Puts access_uref in current context's named keys under `uref_name`.
 
-When a contract exits with an error code, the exit code is visible in the Block Explorer.
+* The current context is the context of the person who initiated the `call` function. Usually, it will be an account.
 
-### Tests {#tests}
+5) Creating the `NamedKeys`
 
-Refer to the [Testing Contract](/dapp-dev-guide/testing) section to view more details about the smart contract testing procedure.
+You can create `NamedKeys` as the last step to store any record or value as needed. Generally, `Contract_Hash` and `Contract_Version` are saved as `NamedKeys`, but you are not limited to these values.
 
-### WASM File Size {#wasm-file-size}
+```rust
 
-We encourage shrinking the WASM file size as much as possible. Smaller deploys cost less and save the network bandwidth. We recommend reading [Shrinking .wasm Code Size](https://rustwasm.github.io/docs/book/reference/code-size.html) chapter of [The Rust Wasm Book](https://rustwasm.github.io/docs/book/).
+    runtime::put_key("toggle_contract_hash", toggle_contract.into());
+    runtime::put_key("toggle_contract_version", storage::new_uref(toggle_contract_version).into());
+
+```


### PR DESCRIPTION
### Related links

[Documentation on how-to-write a basic smart contract #285](https://github.com/casper-network/docs/issues/285)

### Changes

An updated draft of the basic smart contract writing document. I've incorporated the `donation` contract as an example with intrinsic value to the reader.

I believe that this serves the same purpose/supersedes the [A Basic Smart Contract in Rust](https://docs.casperlabs.io/dapp-dev-guide/writing-contracts/rust/) document and should thus replace it.

Ideally, I'd like to make a version of this document that follows the same flow and uses the same mechanics as a demonstration of AssemblyScript, to satisfy the needs of docs#361.

### Notes

Ran locally without issue.
