### PR TITLE
Correcting info on deprecated script using node_util command

### DIFF
--- a/source/docs/casper/operators/setup.md
+++ b/source/docs/casper/operators/setup.md
@@ -31,7 +31,7 @@ Multiple versioned folders will exist on a system when upgrades are set up.
 
 :::
 
-The following is the state of the filesystem after installing the `casper-client` and `casper-node-launcher` Debian packages, and also after running the script `/etc/casper/pull_casper_node_version.sh`:
+The following is the state of the filesystem after installing the `casper-client` and `casper-node-launcher` Debian packages, and also after running the command `sudo -u casper /etc/casper/node_util.py stage_protocols casper.conf` (Use casper-test.conf if on testnet).
 
 ### `/usr/bin/` {#usrbin}
 


### PR DESCRIPTION
This PR fixes the issue https://github.com/casper-network/docs/issues/280 by correcting the part on the documentation referencing a deprecated script. See linked issue for more info.