### PR TITLE
Use commit hash also for the tretuna/sync-branches action

### DIFF
--- a/.github/workflows/dev_main_sync.yml
+++ b/.github/workflows/dev_main_sync.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Opening pull request
         id: pull
-        uses: tretuna/sync-branches@1.4.0
+        uses: tretuna/sync-branches@ea58ab6e406fd3ad016a064b31270bbb41127f41
         with:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           FROM_BRANCH: "dev"


### PR DESCRIPTION
Adding the hash to the tretuna/sync-branches action too.