### PR TITLE
Added known node note to JSON RPC transaction documentation

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
@@ -10,7 +10,7 @@ This is the only means by which users can send their compiled Wasm (as part of a
 |---------|----|-----------|
 |[deploy](../../sdkspec/types_chain#deploy)|Object|A Deploy consists of an item containing a smart contract along with the requester's signature(s).|
 
-> **Note**: You can find a list of trusted peers in network's configuration file, `config.toml`. Here is an [example](https://github.com/casper-network/casper-node/blob/dev/resources/production/config-example.toml#L131). You may send deploys to one of the trusted nodes or use them to query other online nodes.
+> **Note**: You can find a list of [trusted peers](https://docs.casperlabs.io/operators/joining/#known-addresses) in the network's configuration file, `config.toml`. Here is an [example config.toml](https://github.com/casper-network/casper-node/blob/dev/resources/production/config-example.toml#L131). You may send deploys to one of the trusted nodes or use them to query other online nodes.
 
 ### `account_put_deploy_result`
 

--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
@@ -10,6 +10,8 @@ This is the only means by which users can send their compiled Wasm (as part of a
 |---------|----|-----------|
 |[deploy](../../sdkspec/types_chain#deploy)|Object|A Deploy consists of an item containing a smart contract along with the requester's signature(s).|
 
+> **Note**: You can find a list of trusted peers in network's configuration file, `config.toml`. Here is an [example](https://github.com/casper-network/casper-node/blob/dev/resources/production/config-example.toml#L131). You may send deploys to one of the trusted nodes or use them to query other online nodes.
+
 ### `account_put_deploy_result`
 
 The result contains the [deploy_hash](../../sdkspec/types_chain#deployhash), which is the primary identifier of a Deploy within a Casper network.


### PR DESCRIPTION
### Related links

[#383](https://github.com/casper-network/docs/issues/383)

### Changes

Added known nodes note to JSON RPC Transactional Methods document.

### Notes

This addition was made for those who are building Casper SDKs and need reliable nodes to push deploys to.
