### PR TITLE
Adding the correct link for writing session code

### DIFF
--- a/source/docs/casper/dapp-dev-guide/writing-contracts/testing-session-code.md
+++ b/source/docs/casper/dapp-dev-guide/writing-contracts/testing-session-code.md
@@ -1,7 +1,7 @@
 # Unit Testing Session Code
 
 
-This section describes how to test a session code based on the unit testing mechanism. It's recommended to follow the [understanding session code](/dapp-dev-guide/writing-contracts/rust/#what-is-a-smart-contract) section before starting this tutorial. Here, we will cover how to test a successful session code execution and how to verify the success of the test program by asserting the return value.
+This section describes how to test a session code based on the unit testing mechanism. It's recommended to follow the [writing session code](/dapp-dev-guide/writing-contracts/session-code/) section before starting this tutorial. Here, we will cover how to test a successful session code execution and how to verify the success of the test program by asserting the return value.
 
 The session code executes in the context of the account which sent the deploy. In this scenario, since the session code is executing in the corresponding account's contexts, it has the same access permissions as the corresponding account. 
 


### PR DESCRIPTION
### Related links

- Adding a minor change related to [415](https://github.com/casper-network/docs/pull/415)
- Related cards - https://github.com/casper-network/docs/issues/330 and https://github.com/casper-network/docs/issues/331

### Changes
- Added a new link to the 'writing session code' section
### Notes

// Paste any other notes if any
