### PR TITLE
361 Getting Started Inconsistencies, Rust vs AS

### DIFF
--- a/source/docs/casper/dapp-dev-guide/writing-contracts/assembly-script.md
+++ b/source/docs/casper/dapp-dev-guide/writing-contracts/assembly-script.md
@@ -1,8 +1,34 @@
-# AssemblyScript
+# Getting Started with AssemblyScript
 
 CasperLabs maintains the [casper-contract](https://www.npmjs.com/package/casper-contract) to allow developers to create smart contracts using [AssemblyScript](https://www.npmjs.com/package/assemblyscript). The package source is hosted in the [main Casper Network repository](https://github.com/casper-network/casper-node/tree/master/smart_contracts/contract_as/assembly).
 
-## Installation {#installation}
+## Prerequisites {#prerequisites}
+
+### Installing AssemblyScript {#installing-assemblyscript}
+
+Installation of AssemblyScript requires [Node.js](https://nodejs.org/).
+
+After installation of Node.js, the following command will install AssemblyScript:
+
+```
+npm i assemblyscript
+```
+
+Full instructions and details for installing AssemblyScript can be found [here](https://www.npmjs.com/package/assemblyscript).
+
+## Development Environment Setup {#development-environment-setup}
+
+### Installing the Casper Package {#installing-the-casper-package}
+
+The `casper-contract` package can be installed using the following command:
+
+```
+npm i casper-contract
+```
+
+The Assemblyscript contract API documentation can be found at <https://www.npmjs.com/package/casper-contract>.
+
+### Creating a Project {#creating-a-project}
 
 For each smart contract, it is necessary to create a project directory and initialize it.
 
@@ -21,11 +47,7 @@ npm install --save-dev assemblyscript@0.9.1
 npm install --save casper-contract
 ```
 
-## Contract API Documentation {#contract-api-documentation}
-
-The Assemblyscript contract API documentation can be found at <https://www.npmjs.com/package/casper-contract>.
-
-## Usage {#usage}
+### Script Entries {#script-entries}
 
 Add script entries for AssemblyScript to your project's `package.json`. Note that your contract name is used for the name of the Wasm file. Replace _your-contract-name_ with the name of your contract.
 
@@ -71,7 +93,7 @@ Next, create a directory called `assembly`, and in that directory, create a file
 }
 ```
 
-## Sample smart contract {#sample-smart-contract}
+### Sample Smart Contract {#sample-smart-contract}
 
 In the `assembly` directory, also create an `index.ts` file, where the code for the contract needs to go.
 
@@ -89,7 +111,7 @@ export function call(): void {
 
 If you prefer a more complicated first contract, you can look at example contracts on the [Casper Ecosystem GitHub](https://github.com/casper-ecosystem) repository for inspiration.
 
-## Compile to Wasm {#compile-to-wasm}
+### Compile to Wasm {#compile-to-wasm}
 
 To compile the contract to Wasm, use _npm_ to run the _asbuild_ script from the project root:
 

--- a/source/docs/casper/dapp-dev-guide/writing-contracts/index.md
+++ b/source/docs/casper/dapp-dev-guide/writing-contracts/index.md
@@ -17,7 +17,7 @@ This section shows you how to write smart contracts in Rust and WebAssembly (Was
 |[Installing Contracts](installing-contracts.md)| A guide on installing contracts and querying global state        |
 |[Calling Contracts](calling-contracts.md)| Steps to call a contract with the Rust command-line client|
 |[Upgrading Contracts](upgrading-contracts.md)| An introduction to versioning contracts|
-|[A Basic Smart Contract in AssemblyScript](assembly-script.md) | An example of a smart contract built in AssemblyScript |
+|[Getting Started with AssemblyScript](assembly-script.md) | An introduction to using AssemblyScript with the Casper Platform |
 
 Additionally, the following tutorials outline some aspects of writing smart contracts on the Casper Network.
 


### PR DESCRIPTION
### Related links

[Rust vs AssemblyScript Getting started sections are inconsistent #361](https://github.com/casper-network/docs/issues/361)

### Changes

I've rearranged the AssemblyScript page in Writing Contracts so that it better matches the 'Getting Started with Rust' page. Content remains mostly the same, with small blurb added about installing AssemblyScript to bring it in line.

### Notes

Ran locally without issue.
