### PR TITLE
Bradjohnl gh 416 algolia docsearch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,6 +36,11 @@ module.exports = {
         // metadatas: metadatasConfig,
         navbar: navbarConfig,
         prism: prismConfig,
+        algolia: {
+            appId: "KQNX60E7J5",
+            apiKey: "42e859bcdaa94a6c412d933cbaabe2e2",
+            indexName: "casperlabs",
+        },
     },
     presets: [
         [
@@ -88,6 +93,5 @@ module.exports = {
                 silent: false,
             },
         ],
-        [require.resolve("@cmfcmf/docusaurus-search-local"), algoliaOfflineConfig],
     ],
 };

--- a/source/docs/casper/index.md
+++ b/source/docs/casper/index.md
@@ -2,6 +2,7 @@
 id: welcome
 title: Welcome
 slug: /
+tags: ["Must read", "Legal", "Introduction", "CasperLabs", "CSPR"]
 ---
 
 # Welcome to the Casper Network

--- a/source/docs/casper/staking/index.md
+++ b/source/docs/casper/staking/index.md
@@ -1,6 +1,7 @@
 ---
 title: Overview
 slug: /staking
+tags: ["finance", "staking", "governance"]
 ---
 
 # Staking


### PR DESCRIPTION
I have configured Algolia indexer and crawler to take docusaurus tags into consideration.
I tested the Algolia search locally and could see already a great improvement, with search results being presented in a much more visually pleasing way, with the results divided by headers for example.

To test and confirm the behaviour with tags, I need to update the prod site and have the crawler get the pages with the tags. For this reason I have added some tags to 2 pages.

For the future, I will create a ticket to investigate ways to test Algolia search locally with custom crawlers probably.
For the time being, the indexed content will be what is in the prod site only.

NOTE: It has been confirmed by Algolia that the attributes "indexName", "appId", and "apiKey" are safe to commit. 
The apiKey, is a read-only token named "Search API key" . This is the public API key which can be safely used in frontend code.This key is usable for search queries and it's also able to list the indices you've got access to.
This is different than the "Write API key" which can be used to creating, deleting and updating indices.

NOTE_2: For the sake of protecting the sprint scope and avoid overflowing, I will make use of my admin privileges and bypass our github workflow and protection rules to have this change available in the prod site.
Everybody involved in the maintenance of this repo will be informed accordingly.