### PR TITLE
Update discord server invite

### DIFF
--- a/config/navbar.config.js
+++ b/config/navbar.config.js
@@ -65,7 +65,7 @@ module.exports = {
             position: "left",
         },
         {
-            href: "https://discord.gg/casperblockchain",
+            href: "https://discord.com/invite/Q38s3Vh",
             label: "Chat",
         },
 


### PR DESCRIPTION
### Related links

[Issue 560](https://github.com/casper-network/docs/issues/560)

### Changes

The current discord invite link is no longer valid. Due to the way that discord is engineered as a desktop browser, the link will return as valid as it still points to a discord landing page that then redirects to the discord app. The updated link is the same invite link utilized on casperlabs.io community page, found [here](https://casperlabs.io/community).