### PR TITLE
541 Information on Signing a Deploy

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -80,6 +80,7 @@ module.exports = {
             items: [
                 "dapp-dev-guide/writing-contracts/index",
                 "dapp-dev-guide/writing-contracts/getting-started",
+                "dapp-dev-guide/writing-contracts/signing-a-deploy",
                 "dapp-dev-guide/writing-contracts/session-code",
                 "dapp-dev-guide/writing-contracts/testing-session-code",
                 "dapp-dev-guide/writing-contracts/rust",

--- a/source/docs/casper/dapp-dev-guide/writing-contracts/signing-a-deploy.md
+++ b/source/docs/casper/dapp-dev-guide/writing-contracts/signing-a-deploy.md
@@ -1,0 +1,19 @@
+# Signing a Deploy
+
+When sending a [`Deploy`](/design/serialization-standard/#serialization-standard-deploy) to a Casper network, the sending user must sign the deploy using their account's cryptographic key-pair. This key-pair derives from a combination of the account's secret and public keys. The signing process verifies that the deploy originates from the claimed account, thereby ensuring any actions taken on the network are genuine.
+
+A deploy's signature consists of three parts:
+
+* The [`DeployHash`](/design/serialization-standard/#deploy-hash)
+
+* The sending account's [secret key](/glossary/S/#secret-key)
+
+* Th sending account's [public key](/design/serialization-standard/#publickey)
+
+A sent deploy initially possesses an empty [`Approvals`](/design/serialization-standard/#approval) set. When the account signs the deploy, this constitutes the first `approval`.
+
+As the `DeployHash` contains a hash of the deploy's body within, any variation to any aspect of the deploy or sending account's keys would render the `DeployHash` invalid.
+
+## Public Key Cryptography
+
+Casper networks are compatible with both `Ed25519` and `Secp256k1` public key cryptography. When a signature goes through the process of [serialization](/design/serialization-standard/), an Ed25519 key will come prefixed with a `1`, where an Secp256k1 features a prefixed `2`.

--- a/source/docs/casper/design/serialization-standard.md
+++ b/source/docs/casper/design/serialization-standard.md
@@ -622,7 +622,7 @@ If it is a delegator, it serializes as the delegator's [`PublicKey`](#clvalue-pu
 
 ## Signature {#signature}
 
-Hex-encoded cryptographic signature, which serializes as the byte representation of the `Signature`. The fist byte within the signature is 1 in the case of an `Ed25519` signature or 2 in the case of `Secp256k1`.
+The signature serializes the byte representation of the underlying cryptographic primitive signature. The first byte within the signature is 1 in the case of an `Ed25519` signature or 2 in the case of `Secp256k1`.
 
 ## TimeDiff {#timediff}
 

--- a/source/docs/casper/workflow/deploy-transfer.md
+++ b/source/docs/casper/workflow/deploy-transfer.md
@@ -143,7 +143,7 @@ casper-client make-transfer --amount 2500000000 \
 --payment-amount 10000 > transfer.deploy
 ```
 
-### Signing the Deploy
+### Signing the Deploy using the Casper Client
 
 Once the deploy file is created, you can sign the deploy using the other designated accounts. For this example, we are signing the deploy with the secret_key.pem stored in keys2 folder and saving the output in a transfer2.deploy file.
 


### PR DESCRIPTION
### Related links

[Document the process of signing a deploy #541](https://github.com/casper-network/docs/issues/541)

### Changes

Added a document to the Writing Smart Contracts section, outlining the process for signing a deploy.

### Notes

Ran locally without issue.
