### PR TITLE
533 Speculative Endpoint Documentation

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdkspec/guidance.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/guidance.md
@@ -8,7 +8,7 @@ A compliant Casper JSON-RPC SDK implementation must support all the endpoints an
 
 A Casper JSON-RPC SDK must be consistent in terminology, language, and functionality relative to the Casper platform's architecture and design. Use actual terms such as Account and Deploy, not similar terms such as wallet or transaction.
  
-Care should be taken to maintain a universal language and not obscure the domain concepts of the Casper platform, which could confuse users of the SDK. The goal is to not make it difficult for users of an SDK to understand the documentation of the Casper platform and be able to communicate effectively with technical support personnel that understand the terminology of the Casper platform and not the variant terminology of an SDK.
+Care should be taken to maintain a universal language and not obscure the domain concepts of the Casper platform, which could confuse users of the SDK. The goal is to not make it difficult for users of an SDK to understand the documentation of the Casper platform. Further, they should be able to communicate effectively with technical support personnel who understand the terminology of the Casper platform and not the variant terminology of an SDK.
 
 ## Advanced Functionality
 

--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
@@ -1,4 +1,4 @@
-# Network Informational JSON-RPC Methods {#network-informational}
+# Informational JSON-RPC Methods {#network-informational}
 
 The following methods return information from a node on a Casper network. The response should be identical, regardless of the node queried, as the information in question is objective and common to all nodes within a network.
 

--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
@@ -96,3 +96,24 @@ The result contains the [deploy_hash](../../sdkspec/types_chain#deployhash), whi
 ```
 
 </details>
+
+## speculative_exec {#speculative_exec}
+
+The `speculative_exec` endpoint provides a method to test a `Deploy` without committing it to a Casper network. By default, `speculative_exec` is disabled on a node and must be intentionally enabled within the associated `rpc_server` section of the node's *cargo.toml*. Sending a `speculative_exec` request to a node with the endpoint disabled will result in an error message. It also runs on a separate port from the primary JSON-RPC, using 7778.
+
+`speculative_exec` executes a deploy at a specified block. In the case of this endpoint, the execution is not committed to global state. As such, it can be used for debugging and discovery purposes such as price estimation.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|[block_identifier](../../sdkspec/types_chain#blockidentifier)|Object|The block hash or state root hash on top of which to execute the deploy. If not supplied,the most recent block will be used.|
+|[deploy](../../sdkspec/types_chain#deploy)|Object|A Deploy consists of an item containing a smart contract along with the requester's signature(s).|
+
+### `speculative_exec_result`
+
+The result contains the hash of the targeted block and the results of the execution.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|api_version|String|The RPC API version.|
+|[block_hash](../../sdkspec/types_chain#blockhash)|Object|The Block hash on top of which the deploy was executed.|
+|[execution_results](../../sdkspec/types_chain#jsonexecutionresult)|Object|The map of Block hash to execution result.|


### PR DESCRIPTION
### Related links

[Update 'speculative execution' endpoint details in the SDK Specification #533](https://github.com/casper-network/docs/issues/533)

### Changes

Added `speculative_exec` to the list of methods in the JSON-RPC SDK, alongside some other minor fixes.

### Notes

Ran locally without issue.
