### PR TITLE
Update chain_get_block for 1.5

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
@@ -14,6 +14,8 @@ This method returns the JSON representation of a [Block](../../../design/block-s
 
 ### `chain_get_block_result`
 
+The result from `chain_get_block` depends on block availability from a given node. If `chain_get_block` returns an error message that the node does not have information on the given block, you may attempt to get the information from a different node.
+
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|


### PR DESCRIPTION
### Related links

N/A

### Changes

Updating information on `chain_get_block` to include the 1.5 possibility of a node lacking information on a specific block.

### Notes

Ran locally without issue.
