### PR TITLE
Removing query balance from main

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
@@ -346,7 +346,7 @@ If the `execution_results` field is empty, it means that the network processed t
 
 This method allows for you to query for a value stored under certain keys in global state. You may query using either a [Block hash](/design/block-structure#block_hash) or state root hash.
 
-* Note: Querying a purse's balance requires the use of `state_get_balance` or `query_balance` rather than any iteration of `query_global_state`.
+* Note: Querying a purse's balance requires the use of `state_get_balance` rather than any iteration of `query_global_state`.
 
 |Parameter|Type|Description|
 |---------|----|-----------|   
@@ -453,55 +453,6 @@ This method allows for you to query for a value stored under certain keys in glo
             }
           }
         }
-
-```
-
-</details>
-
-## query_balance {#query-balance}
-
-This method allows you to query for the balance of a purse using a `PurseIdentifier` and `StateIdentifier`.
-
-|Parameter|Type|Description|
-|---------|----|-----------|
-|[purse_identifier](/dapp-dev-guide/sdkspec/types_chain#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
-|[state_identifier](/dapp-dev-guide/sdkspec/types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
-    
-### `query_balance_result`
-
-|Parameter|Type|Description|
-|---------|----|-----------|     
-|api_version|String|The RPC API version.|
-|[balance](/dapp-dev-guide/sdkspec/types_chain#u512)|Object|The balance represented in motes.|
-
-<details>
-
-<summary><b>Example query_balance</b></summary>
-
-```bash
-
-              "name": "query_balance_example",
-              "params": [
-                {
-                  "name": "purse_identifier",
-                  "value": {
-                    "main_purse_under_account_hash": "account-hash-0909090909090909090909090909090909090909090909090909090909090909"
-                  }
-                },
-                {
-                  "name": "state_identifier",
-                  "value": {
-                    "BlockHash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
-                  }
-                }
-              ],
-              "result": {
-                "name": "query_balance_example_result",
-                "value": {
-                  "api_version": "1.4.6",
-                  "balance": "123456"
-                }
-              }
 
 ```
 


### PR DESCRIPTION
### Related links

N/A, discussion during standup.

### Changes

Removing `query_balance` information that unexpectedly showed up on the main site.

### Notes

Ran locally without issue.
