### PR TITLE
Mention Casper.info as a block explorer

### DIFF
--- a/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
+++ b/source/docs/casper/dapp-dev-guide/why-build-on-casper.md
@@ -20,6 +20,7 @@ The Casper Ecosystem is growing every day through the addition of new dApps and 
 
 ### Block Explorers
 - [cspr.live](https://cspr.live)
+- [Casper.info](https://casper-trench.vercel.app/)
 
 ### Developer Tools
 - [casperholders.io](https://casperholders.io)

--- a/source/docs/casper/workflow/block-explorer.md
+++ b/source/docs/casper/workflow/block-explorer.md
@@ -1,6 +1,6 @@
 # Block Explorers on Casper Network
 
-The Casper blockchain is available as the Mainnet and Testnet. The Mainnet is the Casper blockchain that utilizes Casper tokens (CSPR). The Testnet is an alternate Casper blockchain used to test applications without spending CSPR tokens on the Casper Mainnet. You can use block explorers such as [cspr.live](https://cspr.live/) to explore the Casper blockchain.
+The Casper blockchain is available as the Mainnet and Testnet. The Mainnet is the Casper blockchain that utilizes Casper tokens (CSPR). The Testnet is an alternate Casper blockchain used to test applications without spending CSPR tokens on the Casper Mainnet. You can use block explorers such as [cspr.live](https://cspr.live/) and [Casper.info](https://casper-trench.vercel.app/) to explore the Casper blockchain.
 
 ## What is a Block Explorer
 


### PR DESCRIPTION
### Related links

I have recently learned about https://casper-trench.vercel.app/, and I thought we should mention it in our docs. 

### Changes

Updated the list of block explorers to include the link above.

### Notes

Ran locally successfully. 
