### PR TITLE
State root hash and root hash in the glossary

### DIFF
--- a/source/docs/casper/glossary/R.md
+++ b/source/docs/casper/glossary/R.md
@@ -12,7 +12,7 @@ Validators receive rewards for participating in consensus and finalizing blocks.
 
 ## Root hash {#root-hash}
 
-The root node of the hash tree (or [Merkle tree](M.md#merkle-tree)) of all the transactions in a block.
+The root hash, or Merkle Root, is a representation of all the data in a given hash tree. Refer to [Merkle tree](M.md#merkle-tree) if you wish to learn more.
 
 ## Rust {#rust}
 

--- a/source/docs/casper/glossary/S.md
+++ b/source/docs/casper/glossary/S.md
@@ -46,6 +46,10 @@ A person that deposits tokens in the [proof-of-stake](P.md#proof-of-stake) contr
 
 A feature of Proof-of-Stake protocols that allows token holders to actively participate in the protocol, thus securing the network. The [Staking Guide](../staking/index.md) highlights the steps required to stake the CSPR token on the Casper network.
 
+## State root hash {#state-root-hash}
+
+The state root hash is an identifier of the network's [global state](G.md#global-state) at a moment in time. The state root hash changes with each block executed, containing deploys. Normally, empty blocks do not modify global state. But, if the empty block is the last one in an era, it will also change the state root hash due to changes introduced by the auction contract calculating the validators for future eras.
+
 ## Stateful {#stateful}
 
 Stateful execution depends on a previous state, which makes the output differ each time. Such executions are performed with the context of previous executions and the current execution may be affected by what happened during previous executions.


### PR DESCRIPTION
### Related links

No related card. We realized that based on a [slack conversation](https://casperlabs-team.slack.com/archives/CDXBCHB6W/p1661435588982079) the definition of the root hash was incorrect.

### Changes

- Updated the definition of the **root hash** in our glossary.
- Also added details for the **state root hash** in the glossary.

### Notes

- Site ran locally successfully
