### PR TITLE
Remove Ubuntu 18.04 from OS Requirement

### DIFF
--- a/source/docs/casper/operators/hardware.md
+++ b/source/docs/casper/operators/hardware.md
@@ -7,7 +7,7 @@ The following hardware specifications are recommended for the **MainNet** and **
 -   4 Cores
 -   32 GB Ram
 -   2 TB SSD or network SSD backed disk
--   Linux machine running Ubuntu 18.04 or 20.04 (preferred)
+-   Linux machine running Ubuntu 20.04
 
 :::note Notes
 


### PR DESCRIPTION
### Related links

Resolves https://github.com/casper-network/docs/issues/700

### Changes

Removed the mention of Ubuntu 18.04 from the Operator Hardware [System Requirements](https://docs.casperlabs.io/operators/hardware/#system-requirements) documentation section 




