### PR TITLE
Remove Ubuntu 18.04 references

### DIFF
--- a/source/docs/casper/faq/faq-validator.md
+++ b/source/docs/casper/faq/faq-validator.md
@@ -79,7 +79,7 @@ Casper-node does not work with ARM type servers. You can see our hardware specif
 <details>
 <summary><b>What operating systems are supported for casper-node?</b></summary>
 
-Casper is currently tested and packaged for Ubuntu 18.04 or 20.04.
+Casper is currently tested and packaged for Ubuntu 20.04.
 
 </details>
 

--- a/source/docs/casper/operators/setup.md
+++ b/source/docs/casper/operators/setup.md
@@ -69,7 +69,7 @@ This is the default location for configuration files. It can be overwritten with
 This is the location for larger and variable data for the `casper-node`, organized in the following folders and files:
 - `bin/` - The parent folder for storing the versions of `casper-node` executables. This location can be overwritten with the `CASPER_BIN_DIR` environment variable. The paths in this document assume the default of `/var/lib/casper/bin/`.
     - `1_0_0/` - Folder for genesis binary files, containing:
-        - `casper-node` - The node executable - defaults to the Ubuntu 18.04 compatible binary
+        - `casper-node` - The node executable - defaults to the Ubuntu 20.04 compatible binary
         - `README.md` - Information about the repository location and the Git hash used for compilation to allow a rebuild on other platforms
     - `m_n_p/` - Folder for each installed upgrade package, containing:
         - `casper-node` - As per `1_0_0/casper-node`, but the `m.n.p` version of the node


### PR DESCRIPTION
### Related links

Resolves #715 

### Changes

- Updated to Ubuntu 20.04 in this statement _`casper-node` - The node executable - defaults to the Ubuntu 20.04 compatible binary_ in [/var/lib/casper/](https://docs.casperlabs.io/operators/setup/#varlibcasper) section
- Removed Ubuntu 18.04 reference in the [FAQ](https://docs.casperlabs.io/faq/faq-validator/#casper-compatibility) section 

### Notes

NA
