### PR TITLE
Change Session Arguments in example

### DIFF
--- a/source/docs/casper/dapp-dev-guide/tutorials/kv-storage-tutorial.md
+++ b/source/docs/casper/dapp-dev-guide/tutorials/kv-storage-tutorial.md
@@ -255,8 +255,8 @@ The kv-client has four distinct commands to set key-values for U64, string, U512
 casper-client put-deploy \
     --session-name kvstorage_contract \
     --session-entry-point store_string \
-    --session-arg=name:"string='test'" \
-    --session-arg=value:"string='your test string here'" \
+    --session-arg "name:string='test'" \
+    --session-arg "value:string='your test string here'" \
     --payment-amount 100000000000 \
     --chain-name <CHAIN-NAME> \
     --node-address http://<HOST>:<PORT> \


### PR DESCRIPTION
Other pages of the doc state this should be the format for session-arg

--session-arg ["NAME:TYPE='VALUE'" OR "NAME:TYPE=null"]

given arguments do not seem consistent in this tutorial.

Please close PR if not relevant.


