### PR TITLE
Add ruby-sdk

### DIFF
--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/index.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/index.md
@@ -19,4 +19,4 @@ The following table provides links to the SDK documentation, in addition to the 
 |Java SDK by SyntiFi|[Casper-sdk](https://github.com/syntifi/casper-sdk)|[Remo Stieger](mailto:remo@syntifi.com)/[Andre Bertolace](mailto:andre@syntifi.com)|
 |PHP SDK|[Casper-php-sdk](https://github.com/make-software/casper-php-sdk)|Roman Bylbas, Ihor Burlachenko, Michael Steuer|
 | Scala SDK | [Casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](mailto:elmabahma@gmail.com) |
-
+| Ruby SDK | [Casper-ruby-sdk](https://github.com/saitgulmez/casper-ruby-sdk) | [Mehmet Sait Gulmez](mailto:cenggulmez.65@gmail.com) |


### PR DESCRIPTION
### Related links

https://github.com/saitgulmez/casper-ruby-sdk

### Changes

Add ruby-sdk to the list of Casper SDK s : https://docs.casperlabs.io/sdk/