### PR TITLE
787 Gas Limit Reasoning

### DIFF
--- a/source/docs/casper/economics/gas-concepts.md
+++ b/source/docs/casper/economics/gas-concepts.md
@@ -17,7 +17,7 @@ The amount of gas required for a transaction is determined by how much code is e
 Casper is a decentralized network of individual validators supplying their computational resources to keep the network live. As such, computations must be rate-limited and priced for the following reasons:
 
 -   Rate-limiting is used to ensure a secure and live network:
-    -   It prevents a denial-of-service (DoS) attack. In computer networks, rate-limiting is used to control the rate of requests sent or received by a network to prevent DoS attacks. Gas behaves in a similar fashion, because each block permits only a fixed amount of transactions (gas) to be included in the era.
+    -   It prevents a specific kind of denial-of-service (DoS) attack. In computer networks, rate-limiting is used to control the rate of requests sent or received by a network to prevent DoS attacks. Gas behaves in a similar fashion, because each block permits only a fixed amount of transactions (gas) to be included in the era.
     -   It explicitly quantifies the system load. The gas cost helps us evaluate the use of computational resources and measure the amount of computational work that validators need to perform for each transaction. With this knowledge, we can specify minimum system requirements for validators.
 -   Pricing leads to more meaningful transactions:
     -   Issuers of transactions and smart contract writers will be more aware of the limited network resources because there is a cost associated with each transaction. Pricing prevents users from spamming arbitrary amounts of empty transactions because there is a price to pay for each deploy.


### PR DESCRIPTION
### Related links

[Correct Gas Limit Reasoning within the Economics Docs #787](https://github.com/casper-network/docs/issues/787)

### Changes

Added the requested terminology shift.

### Notes

N/A
