### PR TITLE
Show last updated time in docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -55,7 +55,7 @@ module.exports = {
                     exclude: ["./contract-dsl/archived", "./economics/archived", "./theory"],
                     /* Docs config options */
                     // showLastUpdateAuthor: false,
-                    // showLastUpdateTime: true,
+                    showLastUpdateTime: true,
                     // remarkPlugins: [require("@react-native-website/remark-snackplayer")],
                     // editCurrentVersion: true,
                     // onlyIncludeVersions: process.env.PREVIEW_DEPLOY === "true" ? ["current", ...versions.slice(0, 2)] : undefined,


### PR DESCRIPTION
While trying to fix something else, I found a way to show the "last updated time" on our documentation pages. I remember this was an ask coming from @caspersteve a while back.
I ran the site locally, and I got an auto-generated timestamp.
<img width="1051" alt="docs last updated time" src="https://user-images.githubusercontent.com/4185994/210397805-1a701238-075b-43b4-abf9-b58ddf877fff.png">


I expect that the time will be computed for the livesite, and it will look like it does at the bottom of this page: https://docusaurus.io/docs/create-doc. 

<img width="1074" alt="Screen Shot 2023-01-03 at 5 20 07 PM" src="https://user-images.githubusercontent.com/4185994/210397735-a71dc0a4-8463-497e-9766-f5beedb9c43c.png">
