### PR TITLE
Fix invalid casper-client URL

### DIFF
--- a/source/docs/casper/workflow/setup-private-network.md
+++ b/source/docs/casper/workflow/setup-private-network.md
@@ -7,7 +7,7 @@ Casper private networks operate in a similar way to the Casper public network. T
 ## Prerequisites
 Follow these guides to set up the required environment and user accounts.
 - [Setting up the Casper client](/workflow/setup/#the-casper-command-line-client)
-- [Setting up the client for interacting with the network](https://github.com/casper-network/casper-node/blob/master/client/README.md#casper-client)
+- [Setting up the client for interacting with the network](https://github.com/casper-ecosystem/casper-client-rs/tree/main#casper-client)
 - [Setting up an account](/workflow/setup/#setting-up-an-account)
 
 

--- a/source/docs/casper/workflow/setup-private-network.md
+++ b/source/docs/casper/workflow/setup-private-network.md
@@ -7,7 +7,7 @@ Casper private networks operate in a similar way to the Casper public network. T
 ## Prerequisites
 Follow these guides to set up the required environment and user accounts.
 - [Setting up the Casper client](/workflow/setup/#the-casper-command-line-client)
-- [Setting up the client for interacting with the network](https://github.com/casper-ecosystem/casper-client-rs/tree/main#casper-client)
+- [Setting up the client for interacting with the network](https://github.com/casper-ecosystem/casper-client-rs/blob/main/README.md#casper-client)
 - [Setting up an account](/workflow/setup/#setting-up-an-account)
 
 


### PR DESCRIPTION
Client was moved to separate repository, since casper-node v1.4.5.