### PR TITLE
Fix YouTube iframe URL

### DIFF
--- a/source/docs/casper/workflow/setup.md
+++ b/source/docs/casper/workflow/setup.md
@@ -75,7 +75,7 @@ The [Account](/design/casper-design.md/#accounts-head) creation process consists
 The following video complements the instructions below, showing you the expected output.
 
 <p align="center">
-<iframe width="400" height="225" src="https://www.youtube.com/watch?v=sA1HTPjV_bc&list=PL8oWxbJ-csEqi5FP87EJZViE2aLz6X1Mj&index=3" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="400" height="225" src="https://www.youtube.com/embed?v=sA1HTPjV_bc&list=PL8oWxbJ-csEqi5FP87EJZViE2aLz6X1Mj&index=3" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </p>
 
 ## Creating an Account {#creating-an-account}


### PR DESCRIPTION
Wrong URL was used for YouTube embedding:
![image](https://user-images.githubusercontent.com/121791569/210545973-a2305989-cb69-41d5-9684-b5019277c991.png)

 