### PR TITLE
818 Remove /rpc from examples using port 7777

### DIFF
--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/csharp-sdk.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/csharp-sdk.md
@@ -49,7 +49,7 @@ namespace Casper.NET.SDK.Examples
     {
         public static async Task Main(string[] args)
         {
-            string nodeAddress = "http://testnet-node.make.services:7777/rpc";
+            string nodeAddress = "http://testnet-node.make.services:7777";
 
             var hex = "0203914289b334f57366541099a52156b149436fdb0422b3c48fe4115d0578abf690";
             var publicKey = PublicKey.FromHexString(hex);

--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/go-sdk.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/go-sdk.md
@@ -23,7 +23,7 @@ This section includes some examples of how to use Golang SDK:
 ```
 ```bash
     func main() {
-        nodeRpc := "http://159.65.118.250:7777/rpc"
+        nodeRpc := "http://159.65.118.250:7777"
         nodeEvent := "http://159.65.118.250:9999"
         privKeyPath := "/path/to/secret_key.pem"
         
@@ -67,7 +67,7 @@ This section includes some examples of how to use Golang SDK:
 ```
 ```bash
     func main() {
-        nodeRpc := "http://159.65.118.250:7777/rpc"
+        nodeRpc := "http://159.65.118.250:7777"
         nodeEvent := "http://159.65.118.250:9999"
         privKeyPath := "/path/to/secret_key.pem"
         modulePath := "/path/to/contract.wasm"

--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/script-sdk.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/script-sdk.md
@@ -107,7 +107,7 @@ const casperClientSDK = require("casper-js-sdk");
 
 const { Keys, CasperClient, CLPublicKey, DeployUtil } = require("casper-js-sdk");
 
-const RPC_API = "http://159.65.203.12:7777/rpc";
+const RPC_API = "http://159.65.203.12:7777";
 const STATUS_API = "http://159.65.203.12:8888";
 
 const sendTransfer = async ({ from, to, amount }) => {


### PR DESCRIPTION
### Related links

- #818 and [Slack](https://casperlabs-team.slack.com/archives/C0135SDEGUC/p1672854310891859?thread_ts=1672266383.159399&cid=C0135SDEGUC)

### Changes

- This PR removes the "/rpc" instances from the sample code; it is unnecessary.

### Notes

- Site ran locally
