### PR TITLE
Multi-sig transfer updates

### DIFF
--- a/source/docs/casper/workflow/deploy-transfer.md
+++ b/source/docs/casper/workflow/deploy-transfer.md
@@ -2,8 +2,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Transferring Tokens using a Multi-sig Deploy
 
-This topic explores using a deploy file to transfer Casper tokens (CSPR) between accounts on a Casper network. This method of transferring tokens is recommended when you want to implement multi-signature deploys. The `make-transfer` command allows you to create a transfer deploy and save the output to a file. You can then have the deploy signed by other parties using the `sign-deploy` command and send it to the network for execution using the `send-deploy` command. To understand multi-signature deploys, see also [Two-Party Multi-Signature Deploys](two-party-multi-sig.md).
-
+This topic explores using a deploy file to transfer Casper tokens (CSPR) between accounts on a Casper network. This method of transferring tokens is recommended when you want to implement multi-signature deploys. The `make-transfer` command allows you to create a transfer deploy and save the output to a file. You can then have the deploy signed by other parties using the `sign-deploy` command and send it to the network for execution using the `send-deploy` command.
 ## Prerequisites
 
 You must ensure the following prerequisites are met, before using the deploy commands.
@@ -12,8 +11,9 @@ You must ensure the following prerequisites are met, before using the deploy com
     - A funded [account](/workflow/setup/#setting-up-an-account) on Testnet or Mainnet
     - A a valid _node address_ from the [Testnet peers](https://testnet.cspr.live/tools/peers) or [Mainnet peers](https://cspr.live/tools/peers)
     - The Casper [command-line client](/workflow/setup#the-casper-command-line-client)
-2. Get the path of the funded account's _secret key_ file
-3. Get the path of a target account's _public key_ hex file
+2. Set up the source account for multi-signature deploys, as outlined in the [Two-Party Multi-Signature Deploys](two-party-multi-sig.md) workflow
+3. Get the path of the source account's _secret key_ file
+4. Get the path of a target account's _public key_ hex file
 
 ## Token Transfer Workflow
 
@@ -236,7 +236,7 @@ casper-client send-deploy --input transfer2.deploy --node-address http://65.21.2
 Make a note of the *deploy_hash* from the `send-deploy` command output to verify the status of the deploy.
 
 <details>
-<summary>Sample output of the send-deploy command</summary>
+<summary>Successful output of the send-deploy command</summary>
 
 ```json
 {
@@ -250,6 +250,21 @@ Make a note of the *deploy_hash* from the `send-deploy` command output to verify
 ```
 
 </details>
+
+If you get an account authorization error, you must set up the source account to allow multi-signature deploys using session code. The [Two-Party Multi-Signature Deploys](two-party-multi-sig.md) workflow is an example of how to accomplish this.
+
+<details>
+<summary>Example of an account authorization error</summary>
+
+```json
+{
+  "code": -32008,
+  "message": "deploy parameter failure: account authorization invalid at prestate_hash: 5f0392de8ac3512a48a110acfc5bc10d4a6a07109b350ae14cbec0428656c8ac"
+}
+```
+
+</details>
+
 
 ## Verifying the Transfer
 

--- a/source/docs/casper/workflow/deploy-transfer.md
+++ b/source/docs/casper/workflow/deploy-transfer.md
@@ -2,71 +2,67 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Transferring Tokens using a Multi-sig Deploy
 
-This topic explores the use of a deploy file to transfer Casper tokens (CSPR) between accounts on the Casper Network. This method of transferring tokens is useful when you want to implement multi-signature deploys. To understand more about multi-signature deploys, see [Two-Party Multi-Signature Deploys](two-party-multi-sig.md). The `make-transfer` command allows you to create a transfer deploy and save the output to a file. You can then have the deploy signed by other parties using the `sign-deploy` command and send it to the network for execution using the `send-deploy` command.
+This topic explores using a deploy file to transfer Casper tokens (CSPR) between accounts on a Casper network. This method of transferring tokens is recommended when you want to implement multi-signature deploys. The `make-transfer` command allows you to create a transfer deploy and save the output to a file. You can then have the deploy signed by other parties using the `sign-deploy` command and send it to the network for execution using the `send-deploy` command. To understand multi-signature deploys, see also [Two-Party Multi-Signature Deploys](two-party-multi-sig.md).
 
 ## Prerequisites
 
-You must ensure the following prerequisites are met, before you start using the deploy commands:
+You must ensure the following prerequisites are met, before using the deploy commands.
 
-1.  Set up your machine as per the [prerequisites](setup.md)
-2.  Set up accounts on the [Testnet](https://testnet.cspr.live/) or [Mainnet](https://cspr.live/)
-3.  Fund the source account
-4.  Get the source _secret key_ file path and the target _public key_ hex
-5.  Get a valid _node address_ from the [Testnet peers](https://testnet.cspr.live/tools/peers) or [Mainnet peers](https://cspr.live/tools/peers)
-6.  Use the Casper [command-line client](/workflow/setup#the-casper-command-line-client)
+1. Set up all the prerequisites listed [here](setup.md), including:
+    - A funded [account](/workflow/setup/#setting-up-an-account) on Testnet or Mainnet
+    - A a valid _node address_ from the [Testnet peers](https://testnet.cspr.live/tools/peers) or [Mainnet peers](https://cspr.live/tools/peers)
+    - The Casper [command-line client](/workflow/setup#the-casper-command-line-client)
+2. Get the path of the funded account's _secret key_ file
+3. Get the path of a target account's _public key_ hex file
 
 ## Token Transfer Workflow
 
 The high-level flow to transfer tokens using a deploy file is described in the following steps:
 
-1. Use the `make-deploy` command to prepare a transfer
-2. Save the output of the `make-deploy` command in a deploy file
-3. Use the `send-deploy` command to send the deploy to the network through a valid node
+1. Use the `make-deploy` command to prepare a transfer and save the output in a file
+2. Use the `send-deploy` command to send the deploy to the network through a valid node
 
 <img src={useBaseUrl("/image/workflow/deploy-flow.png")} width="600" />
 
 ### Preparing the Transfer
 
-This section explains the `make-transfer` command using an example you can try on the Testnet. For this example, we are transferring 2500000000 motes from the source account with the secret_key.pem stored in keys1 folder to a target account.
+This section explains the `make-transfer` command using an example you can try on the Testnet. For this example, we are transferring 2500000000 motes from the source account (with the secret_key.pem file) to a target account. To use this example on the Mainnet, the _chain-name_ would be `casper` instead of `casper-test`. Note that we are saving the output of the `make-deploy` command in a `transfer.deploy` file.
 
 ```bash
 casper-client make-transfer --amount 2500000000 \
---secret-key keys1/secret_key.pem \
+--secret-key [PATH]/secret_key.pem \
 --chain-name casper-test \
---target-account [PRIMARY KEY HEX] \
+--target-account [PUBLIC_KEY_HEX] \
 --transfer-id 3 \
---payment-amount 10000
+--payment-amount 10000 
+--output transfer.deploy
 ```
 
-:::note 
-
-To use this example on the Mainnet, replace _chain-name_ as casper instead of casper-test.
-
-:::
+The following table explains the parameters used in the `make-transfer` command.
 
 | Parameter | Description |
 | --- | --- |
 | amount | The number of motes you wish to transfer (1 CSPR = 1,000,000,000 motes) |
 | secret-key | The path of the secret key file for the source account |
-| chain-name | The name of the chain, to avoid the deploy from being accidentally or maliciously included in a different chain <ul><li>For Testnet it's **casper-test**</li><li>For Mainnet it's **casper**</li></ul> |
-| target-account | Hex-encoded public key of the account from which the main purse will be used as the target |
+| chain-name | The name of the chain, to avoid the deploy from being accidentally or maliciously included in a different chain <ul><li>For Testnet use **casper-test**</li><li>For Mainnet use **casper**</li></ul> |
+| target-account | Hex-encoded public key of the target account from which the main purse will be used |
 | transfer-id | A user-defined identifier, permanently associated with the transfer |
 | payment-amount | The amount used to pay for executing the code on the network |
 
-### Saving the Output
+In the output, you will see a section named **approvals**. This is where a signature from the source account is added to the deploy.
 
 <details>
 <summary>Sample output of the make-transfer command</summary>
 
 ```json
 {
-  "hash": "2bf18a14c652b2c12668df3c58d4cbb54930b372f25119f620694fa319b7db3e",
+  "hash": "0e17da4c7b6d12984910aa25e397fc85db53e5cd896776d47494cb4a5f2083f1",
   "header": {
-    "account": "013ad94f8932e3d14a715225a4088971c9d551a3d1281cdd5f726063762d932b0e",
-    "timestamp": "2021-11-25T14:30:00.210Z",
+    "account": "0154d828baafa6858b92919c4d78f26747430dcbecb9aa03e8b44077dc6266cabf",
+    "timestamp": "2023-01-05T11:30:05.269Z",
     "ttl": "30m",
     "gas_price": 1,
-    "body_hash": "77a86730a7defd16d30361ef67204dbb302dfd905a98fc094425ac97645978fd",
+    "body_hash": "5d7d30965d503dba0459d5e6b3a0c923059f89e6a7179f76aec0fda1263b7819",
     "dependencies": [],
     "chain_name": "casper-test"
   },
@@ -99,11 +95,9 @@ To use this example on the Mainnet, replace _chain-name_ as casper instead of ca
         [
           "target",
           {
-            "cl_type": {
-              "ByteArray": 32
-            },
-            "bytes": "3039c4b9b7379cedbd666f3a6e08012da0608707cc33c380119485c22e8280f1",
-            "parsed": "3039c4b9b7379cedbd666f3a6e08012da0608707cc33c380119485c22e8280f1"
+            "cl_type": "PublicKey",
+            "bytes": "01f48f5b095518be188286d896921d33e97f9729f5945237d5ff6cf7b077aabf1f",
+            "parsed": "01f48f5b095518be188286d896921d33e97f9729f5945237d5ff6cf7b077aabf1f"
           }
         ],
         [
@@ -112,8 +106,8 @@ To use this example on the Mainnet, replace _chain-name_ as casper instead of ca
             "cl_type": {
               "Option": "U64"
             },
-            "bytes": "010100000000000000",
-            "parsed": 1
+            "bytes": "013930000000000000",
+            "parsed": 3
           }
         ]
       ]
@@ -121,8 +115,8 @@ To use this example on the Mainnet, replace _chain-name_ as casper instead of ca
   },
   "approvals": [
     {
-      "signer": "013ad94f8932e3d14a715225a4088971c9d551a3d1281cdd5f726063762d932b0e",
-      "signature": "016b185d5b424f36c0a0d995067a25fb50a7efef73a23ba070c55a66911ddc9b1e1b2c8964b5253368ca4992b8d856c84844036bc74de344ba23834043714a110a"
+      "signer": "0154d828baafa6858b92919c4d78f26747430dcbecb9aa03e8b44077dc6266cabf",
+      "signature": "016853b69b98434f236ac2eacb053b244f5853f0ec2a1d86b8f8a35601353cebe160f3c57606be9f289da34b7ccd5b7285751d1e6edc9cc76a84c14fb286272702"
     }
   ]
 }
@@ -130,27 +124,14 @@ To use this example on the Mainnet, replace _chain-name_ as casper instead of ca
 
 </details>
 
-In the above example, you can view a section named **approvals**. This is where a signature of the source account is added to the deploy.
-
-Save this output in a _transfer.deploy_ file as shown in the following command.
-
-```bash
-casper-client make-transfer --amount 2500000000 \
---secret-key keys1/secret_key.pem \
---chain-name casper-test \
---target-account [PRIMARY KEY HEX] \
---transfer-id 3 \
---payment-amount 10000 > transfer.deploy
-```
-
 ### Signing the Deploy using the Casper Client
 
-Once the deploy file is created, you can sign the deploy using the other designated accounts. For this example, we are signing the deploy with the secret_key.pem stored in keys2 folder and saving the output in a transfer2.deploy file.
+Once the deploy file is created, you can sign the deploy using other designated accounts. For this example, we are signing the deploy with a second secret key, and saving the output in a `transfer2.deploy` file.
 
 ```bash
 casper-client sign-deploy \
 --input transfer.deploy \
---secret-key keys2/secret_key.pem \
+--secret-key [PATH]/another_secret_key.pem \
 --output transfer2.deploy
 ```
 
@@ -167,13 +148,13 @@ You can observe towards the end of the following output there is an **approvals*
 
 ```json
 {
-  "hash": "6c584812f844e56b6a133e205a03e1eef039e78f93b9dca1f429301f3e17806b",
+  "hash": "959ba7154a58bf3a9ec555b38fb2c96dba81523b49f9a086630d0cf44d74cacc",
   "header": {
-    "account": "013ad94f8732e3d14a715225a4088971c9d551a3d1281cdd5f726063762d932b0e",
-    "timestamp": "2021-11-25T14:30:26.592Z",
+    "account": "0154d828baafa6858b92919c4d78f26747430dcbecb9aa03e8b44077dc6266cabf",
+    "timestamp": "2023-01-05T11:42:23.311Z",
     "ttl": "30m",
     "gas_price": 1,
-    "body_hash": "77a86730a7defd16d30361ef67204dbb302dfd905a98fc094425ac97645978fd",
+    "body_hash": "5d7d30965d503dba0459d5e6b3a0c923059f89e6a7179f76aec0fda1263b7819",
     "dependencies": [],
     "chain_name": "casper-test"
   },
@@ -206,11 +187,9 @@ You can observe towards the end of the following output there is an **approvals*
         [
           "target",
           {
-            "cl_type": {
-              "ByteArray": 32
-            },
-            "bytes": "3039c4b9b7379cedbd666f3a6e08012da0608707cc33c380119485c22e8280f1",
-            "parsed": "3039c4b9b7379cedbd666f3a6e08012da0608707cc33c380119485c22e8280f1"
+            "cl_type": "PublicKey",
+            "bytes": "01f48f5b095518be188286d896921d33e97f9729f5945237d5ff6cf7b077aabf1f",
+            "parsed": "01f48f5b095518be188286d896921d33e97f9729f5945237d5ff6cf7b077aabf1f"
           }
         ],
         [
@@ -219,8 +198,8 @@ You can observe towards the end of the following output there is an **approvals*
             "cl_type": {
               "Option": "U64"
             },
-            "bytes": "010100000000000000",
-            "parsed": 1
+            "bytes": "013930000000000000",
+            "parsed": 3
           }
         ]
       ]
@@ -228,12 +207,12 @@ You can observe towards the end of the following output there is an **approvals*
   },
   "approvals": [
     {
-      "signer": "013ad94f8732e3d14a715225a4088971c9d551a3d1281cdd5f726063762d932b0e",
-      "signature": "0102680af44588d79d30c3403edd22a715fd988fea00fd1bafbb1e67cc48c07752645861df440d74f7a6a19949019b63f776d7d00b2867db3f1b4a6ffb5551870d"
+      "signer": "01360af61b50cdcb7b92cffe2c99315d413d34ef77fadee0c105cc4f1d4120f986",
+      "signature": "014c2dc520a1d7f2b7cc18fe704899dd158c02448a4c575bc5214bad3384cb4fff6e32ece196768a8d21b5644c96850fea8b980bd2f6c1fe3c717c1c45a6b75508"
     },
     {
-      "signer": "019a33f123ae936ccd29d8fa5438f03a86b6e34fe4346219e571d5ac42cbff5be6",
-      "signature": "01553d9c8ffb1b499b6ca7c79a9c1a0f8044030aadec4228c4f18a971c57632e001b3c94051af9667c99bc369f71afde4042ff5857cb965048c40230d53571ad0a"
+      "signer": "0154d828baafa6858b92919c4d78f26747430dcbecb9aa03e8b44077dc6266cabf",
+      "signature": "0107b684e395879fed81d8387b0b4422301c1e4fcbd76672cf3fb7ab2ea8a2ef1429622a999fbbb56bcb79d871bfaeeb107415d67c78a57e8f67987e7f4368980c"
     }
   ]
 }
@@ -243,18 +222,18 @@ You can observe towards the end of the following output there is an **approvals*
 
 ### Sending the Deploy
 
-The next step is to send the deploy for execution on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node http://80.92.204.108 from the Testnet, replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
+The next step is to send the deploy for processing on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node http://80.92.204.108 from the Testnet; replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
 
 ```bash
-casper-client send-deploy --input transfer2.deploy --node-address http://80.92.204.108:7777
+casper-client send-deploy --input transfer2.deploy --node-address http://65.21.235.219:7777
 ```
 
 | Parameter    | Description                                                          |
 | ------------ | -------------------------------------------------------------------- |
 | input        | The path of the deploy file, which is used as the input              |
-| node-address | The Hostname or IP and port of node on which HTTP service is running |
+| node-address | The Hostname or IP and port of the node                              |
 
-Make a note of the *deploy_hash* from the send-deploy command output. This will be required to verify the status of the deploy.
+Make a note of the *deploy_hash* from the `send-deploy` command output to verify the status of the deploy.
 
 <details>
 <summary>Sample output of the send-deploy command</summary>
@@ -274,7 +253,7 @@ Make a note of the *deploy_hash* from the send-deploy command output. This will 
 
 ## Verifying the Transfer
 
-To verify the status of your transfer, see [Verifying a Transfer](verify-transfer.md).
+To verify the transfer status, see [Verifying a Transfer](verify-transfer.md).
 
 :::tip 
 

--- a/source/docs/casper/workflow/index.md
+++ b/source/docs/casper/workflow/index.md
@@ -30,7 +30,7 @@ These developer guides highlight key features and capabilities of the Casper sys
 -   [Prerequisites](setup.md): setup needed for various workflows
 -   [Querying the Casper Network](querying.md): querying information on a Casper blockchain
 -   [Account Hash](account-hash.md): generating account hash for an account on the Casper Network
--   [Two-Party Multi-Signatures for Deployment](two-party-multi-sig.md): setting up an account for two-party signature deploys
+-   [Two-Party Multi-Signatures for Deploys](two-party-multi-sig.md): setting up an account for two-party signature deploys
 -   [Transferring Tokens using the Command-line](transfers.md): transferring CSPR tokens from one account to another using the command-line
 -   [Delegating Tokens](delegate.md): delegating tokens to a Validator on a Casper Network
 -   [Undelegating Tokens](undelegate.md): undelegating tokens from a validator on a Casper Network

--- a/source/docs/casper/workflow/transfers.md
+++ b/source/docs/casper/workflow/transfers.md
@@ -8,7 +8,7 @@ You can use the direct method to transfer tokens when you have an account with a
 
 **Transferring Tokens using Multi-sig Deploy**
 
-When the account used to initiate the transfer has multiple associated keys that need to sign the deploy, you can use a multi-sig deploy transfer. To use a multi-sig deploy transfer, see [Transferring Tokens using Multi-sig Account](deploy-transfer.md). To setup the account's associated keys, see the [Two-Party Multi-Signature Deploys](two-party-multi-sig.md) workflow.
+When the account used to initiate the transfer has multiple associated keys that need to sign the deploy, you can use a multi-sig deploy transfer. To set up the account's associated keys, see the [Two-Party Multi-Signature Deploys](two-party-multi-sig.md) workflow. To use a multi-sig deploy transfer, see [Transferring Tokens using Multi-sig Account](deploy-transfer.md).
 
 **Verifying a Transfer using the Command-line Client**
 

--- a/source/docs/casper/workflow/transfers.md
+++ b/source/docs/casper/workflow/transfers.md
@@ -12,5 +12,5 @@ When the account used to initiate the transfer has multiple associated keys that
 
 **Verifying a Transfer using the Command-line Client**
 
-Once you have transferred the tokens, you might want to verify that the transfer was successful. To verify the status of the transfer, see [Verifying a Transfer](verify-transfer.md)
+To verify the status of a transfer, see [Verifying a Transfer](verify-transfer.md)
 

--- a/source/docs/casper/workflow/transfers.md
+++ b/source/docs/casper/workflow/transfers.md
@@ -1,16 +1,16 @@
 # Introduction
 
-The following topics describe how to use the Casper command-line client to transfer tokens between accounts on the Casper Network. Depending on the type of accounts, you can choose a direct transfer or a multiple signature (multi-sig) deploy transfer.  
+The following topics describe how to use the Casper command-line client to transfer tokens between accounts on the Casper Network. Depending on the type of accounts, you can choose a direct transfer or a multiple-signature (multi-sig) deploy transfer.  
 
 **Transferring Tokens using Direct Transfer**
 
-You can use the direct method to transfer tokens when you have an account with a single primary key and it is capable of signing a transaction. To use a direct transfer, see [Transferring Tokens using Direct Transfer](transfer-workflow.md)
+You can use the direct method to transfer tokens when you have an account with a single primary key, and it is capable of signing a transaction. To use a direct transfer, see [Transferring Tokens using Direct Transfer](transfer-workflow.md).
 
 **Transferring Tokens using Multi-sig Deploy**
 
-When the account used to initiate the transfer has multiple associated keys that need to sign the deploy, you can use a multi-sig deploy transfer. To use a multi-sig deploy transfer, see [Transferring Tokens using Multi-sig Account](deploy-transfer.md)
+When the account used to initiate the transfer has multiple associated keys that need to sign the deploy, you can use a multi-sig deploy transfer. To use a multi-sig deploy transfer, see [Transferring Tokens using Multi-sig Account](deploy-transfer.md). To setup the account's associated keys, see the [Two-Party Multi-Signature Deploys](two-party-multi-sig.md) workflow.
 
 **Verifying a Transfer using the Command-line Client**
 
-To verify the status of a transfer, see [Verifying a Transfer](verify-transfer.md)
+To verify the status of a transfer, see [Verifying a Transfer](verify-transfer.md).
 

--- a/source/docs/casper/workflow/two-party-multi-sig.md
+++ b/source/docs/casper/workflow/two-party-multi-sig.md
@@ -1,86 +1,46 @@
 # Two-Party Multi-Signature Deploys
 
-[Accounts](/design/casper-design.md/#accounts-head) on a Casper Network can associate other accounts to allow or require a multiple signature scheme for deploys.
+[Accounts](/design/casper-design.md/#accounts-head) on a Casper network can associate other accounts to allow or require a multiple-signature scheme for deploys.
 
-This workflow describes how a trivial two-party multi-signature scheme for signing and sending deploys can be enforced for an account on a Casper Network.
+This workflow describes how a trivial two-party multi-signature scheme for signing and sending deploys can be enforced for an account on a Casper network. This workflow assumes:
 
-This workflow assumes:
-
-1.  You meet the [prerequisites](setup.md)
-2.  You are using the Casper command-line client
-3.  You have a main `PublicKey` hex (**MA**) and a `PublicKey` hex to associate (**AA**)
-4.  You have a valid `node-address`
-5.  You have previously [deployed a smart contract](/dapp-dev-guide/building-dapps/sending-deploys.md) to a Casper Network
+1. You meet the [prerequisites](setup.md), including having the Casper command-line client and a valid node address
+2. You have the main account's `PublicKey` hex (**MA**) and another `PublicKey` hex to associate (**AA**)
+3.  You have previously [sent deploys](/dapp-dev-guide/building-dapps/sending-deploys.md) to a Casper network
 
 ## Configuring the Main Account {#configuring-the-main-account}
 
-**CAUTION**: Incorrect account configurations could render accounts defunct and unusable. It is highly recommended to first execute any changes to an account in a test environment like Testnet, before performing them in a live environment like Mainnet.
+**CAUTION**: Incorrect account configurations could render accounts defunct and unusable. We highly recommend executing any changes to an account in a test environment like Testnet before performing them in a live environment like Mainnet.
 
-Each account has an `associated_keys` field which is a list containing the account address and its weight for every associated account. Accounts can be associated by adding the account address to the `associated_keys` field.
+Each account has an `associated_keys` field, a list containing the account address, and its weight for every associated account. Accounts can be associated by adding the account address to the `associated_keys` field.
 
-An account on a Casper Network assigns weights to keys associated with it. For a single key to sign a deploy or edit the state of the account, its weight must be greater than or equal to a set threshold. The thresholds are labeled as the `action_thresholds` for the account.
+An account on a Casper network assigns weights to keys associated with it. For a single key to sign a deploy, or edit the state of the account, its weight must be greater than or equal to a set threshold. The thresholds are labeled as the `action_thresholds` for the account.
 
-Each account within a Casper Network has two action thresholds that manage the permissions to send deploys or manage the account. Each threshold defines the minimum weight that a single key or a combination of keys must have, to either:
+Each account within a Casper network has two action thresholds that manage the permissions to send deploys or manage the account. Each threshold defines the minimum weight that a single key or a combination of keys must have to either:
 
-1.  Send a deploy to the network; determined by the `deployment` threshold
-2.  Edit the `associated keys` and the `action_thresholds`; determined by the `key_management` threshold
+1. Send a deploy to the network; determined by the `deployment` threshold
+2. Edit the `associated keys` and the `action_thresholds`; determined by the `key_management` threshold
 
-To enforce the multi-signature (multi-sig) feature for an account on a Casper Network, the _main key_ and _associated key_'s combined weight must be greater than or equal to the `deployment` threshold. This can be achieved by having each key's weight equal to half of the `deployment` threshold.
+To enforce the multi-signature (multi-sig) feature for an account on a Casper network, the _main key_ and _associated key_'s combined weight must be greater than or equal to the `deployment` threshold. This can be achieved by having each key's weight equal to half of the `deployment` threshold.
 
-## Code Description {#code-description}
+### Running session code to set up associated keys
 
-You can run session code that will execute within the context of your main account. Below is the code that will be compiled to Wasm and then sent to the network as part of a deploy.
-
-**Note**: The following contract example will set up a specific account configuration and is not a general-purpose contract.
-
-```rust
-#![no_main]
-use casper_contract::{
-    contract_api::{account, runtime},
-    unwrap_or_revert::UnwrapOrRevert,
-};
-use casper_types::account::{AccountHash, ActionType, Weight};
-
-const ASSOCIATED_ACCOUNT: &str = "deployment-account";
-
-#[no_mangle]
-pub extern "C" fn call() {
-    // Account hash for the account to be associated.
-    let deployment_account: AccountHash = runtime::get_named_arg(ASSOCIATED_ACCOUNT);
-
-    // Add the CA key to half the deployment threshold (i.e 1)
-    account::add_associated_key(deployment_account, Weight::new(1)).unwrap_or_revert();
-
-    // Deployment threshold <= Key management threshold.
-    // Therefore update the key management threshold value.
-    account::set_action_threshold(ActionType::KeyManagement, Weight::new(2)).unwrap_or_revert();
-
-    // Set the deployment threshold to 2, enforcing multi-sig to send deploys.
-    account::set_action_threshold(ActionType::Deployment, Weight::new(2)).unwrap_or_revert();
-}
-```
-
-The contract will execute **2 crucial steps** to enforce the multi-sig scheme for your main account:
-
-1.  Add the associated key **AA** to the account
-2.  Raise the `deployment` threshold to `2`, such that the weight required to send a deploy is split equally between the keys associated with the account
-
-The action thresholds for deploys cannot be greater than the action threshold for key management. By default, action thresholds are set to `1`.
-
-## Code Execution {#code-execution}
-
-The state of the account can be altered by sending a deploy which executes the Wasm that will associate the **AA** account address.
-
-For this guide, a smart contract has been written and is stored in its [Github Repository](https://github.com/casper-ecosystem/two-party-multi-sig). The repository contains a _Makefile_ with the build commands necessary to compile the contract to generate the necessary Wasm.
+To set up the associated keys for an account, you must run session code that executes within the account's context. You will find an example of such session code on [GitHub](https://github.com/casper-ecosystem/two-party-multi-sig/). Note that this session code is not a general-purpose program and needs to be modified for each use case.
 
 ```bash
 git clone https://github.com/casper-ecosystem/two-party-multi-sig
-cd two-party-multi-sig
 ```
 
-To build the contract, run the following command:
+The [session code](https://github.com/casper-ecosystem/two-party-multi-sig/blob/main/contract/src/main.rs) executes **3 crucial steps** to enforce the multi-sig scheme for the main account:
+
+1. Adds an associated key to the account; we will refer to this key as **AA**
+2. Raises the `action` threshold to `2`, because action thresholds for deploys cannot be greater than the action threshold for key management. By default, all action thresholds are set to `1`
+3. Raises the `deployment` threshold to `2`, such that the weight required to send a deploy is split equally between the keys associated with the account
+
+The repository contains a _Makefile_ with the build commands necessary to compile the contract and generate the necessary Wasm.
 
 ```bash
+cd two-party-multi-sig
 make build-contract
 ```
 
@@ -100,12 +60,12 @@ casper-client put-deploy \
 --session-arg "deployment-account:account_hash='account-hash-<hash-AA>'"
 ```
 
-1.  `node-address` - An IP address of a node on the network
-2.  `secret-key` - The file name containing the secret key of the Main Account
-3.  `chain-name` - The chain-name to the network where you wish to send the deploy (this example uses the Testnet)
-4.  `payment-amount` - The cost of the deploy
-5.  `session-path` - The path to the contract Wasm
-6.  `session-arg` - The contract takes the account hash of the Associated account as an argument labeled `deployment-account`. You can pass this argument using the `--session-arg` flag in the command line client
+1. `node-address` - An IP address of a node on the network
+2. `secret-key` - The file name containing the secret key of the main account
+3. `chain-name` - The chain-name to the network where you wish to send the deploy (this example uses the Testnet)
+4. `payment-amount` - The cost of the deploy
+5. `session-path` - The path to the contract Wasm
+6. `session-arg` - The contract takes the account hash of the associated account as an argument labeled `deployment-account`. You can pass this argument using the `--session-arg` flag in the command line client
 
 **Important response fields:**
 
@@ -113,16 +73,16 @@ casper-client put-deploy \
 
 **Note**: Save the returned `deploy_hash` from the output to query information about execution status.
 
-### Confirming Execution and Account Status {#confirming-execution-and-account-status}
+### Confirming Processing and Account Status {#confirming-execution-and-account-status}
 
 Account configuration on a Casper blockchain is stored in a [Merkle Tree](../glossary/M.md#merkle-tree) and is a snapshot of the blockchain's [Global State](../design/casper-design.md/#global-state-head). The representation of global state for a given block can be computed by executing the deploys (including transfers) within the block and its ancestors. The root node of the Merkle Tree identifying a particular state is called the `state-root-hash` and is stored in every executed block.
 
-To check that your account was configured correctly, you need the `state-root-hash` corresponding to the block that contains your deploy. To obtain the `state-root-hash`, you need to:
+To check that the account was configured correctly, you need the `state-root-hash` corresponding to the block that contains your deploy. To obtain the `state-root-hash`, you need to:
 
 1.  [Confirm the execution status of the deploy](querying.md#querying-deploys) and obtain the hash of the block containing it
 2.  [Query the block containing the deploy](querying.md#querying-blocks) to obtain the corresponding `state_root_hash`
 
-Use the `state_root_hash` and the `hex-encoded-public-key` of the main account to query the network for the account and check its configuration.
+Using the `state_root_hash` and the `hex-encoded-public-key` of the main account, query the network and check the account's configuration.
 
 ```bash
 casper-client query-global-state \
@@ -131,7 +91,8 @@ casper-client query-global-state \
 --key <hex-encoded-public-key-MA>
 ```
 
-**Example Output**
+<details>
+<summary>Example output</summary>
 
 ```json
 {
@@ -164,7 +125,6 @@ casper-client query-global-state \
     }
 }
 ```
+</details>
 
-In the above example, you can see the account addresses listed within the `associated_keys` section. Each key has a weight of `1`, since the action threshold for `deployment` is set to `2`, neither account is able to sign and send a deploy individually. Thus to send the deploy from the Main account, the deploy needs to be signed by the secret keys of each account to reach the required threshold.
-
-Details about various scenarios in which multiple associated keys can be setup is discussed in [the examples section of the Multi-Signature Tutorial](/dapp-dev-guide/tutorials/multi-sig/additional.md).
+In the example output, you can see the account addresses listed within the `associated_keys` section. Each key has weight `1`; since the action threshold for `deployment` is `2`, neither account can sign and send a deploy individually. Thus, the deploy needs to be signed by the secret keys of each account to reach the required threshold.

--- a/source/docs/casper/workflow/verify-transfer.md
+++ b/source/docs/casper/workflow/verify-transfer.md
@@ -2,28 +2,29 @@
 
 ## Prerequisite
 
-You need to ensure the following prerequisites are met, before verifying a transfer:
+Before verifying a transfer, make sure you have:
+1. Initiated a [Direct Transfer](transfer-workflow.md) or [Multi-sig Deploy Transfer](deploy-transfer.md)
+2. The *deploy_hash* of the transfer you want to verify
+3. The *public key* hex for the source and target accounts
 
-1.  Set up your machine as per the [prerequisites](setup.md)
-2.  Use the Casper [command-line client](/workflow/setup#the-casper-command-line-client)
-3.  Initiate a transfer using [Direct Transfer](transfer-workflow.md) or [Multi-sig Deploy Transfer](deploy-transfer.md)
-4.  Get the *public key* hex for the source and target accounts
-5.  Get the *deploy_hash* of the transfer you want to verify
 
 ## State State Root Hash
 
-The state root hash is an identifier of the current network state. It gives a snapshot of the blockchain state at a moment in time. You can use the state-root-hash to query the network state after deployments. 
+The state root hash is an identifier of the current network state. It gives a snapshot of the blockchain state at a moment in time. You can use the state root hash to query the network state after deployments. 
 
 ```
 casper-client get-state-root-hash --node-address [NODE_SERVER_ADDRESS]
 ```
-**Note**
 
->   After any deploys to the network, you must get the new state root hash to see the new changes reflected. Otherwise, you will be looking at events in the past.
+:::note
+
+After any deploys to the network, you must get the new state root hash to see the new changes reflected. Otherwise, you will be looking at events in the past.
+
+:::
 
 ## Query the Source Account {#query-the-source-account}
 
-Next, we will query for information about the _Source_ account, using the `state-root-hash` of the block containing our transfer and the public key of the _Target_ account.
+Here, we will query for information about the _Source_ account using the `state-root-hash` of the block containing the transfer and the public key of the _Target_ account.
 
 ```bash
 casper-client query-global-state \
@@ -36,13 +37,13 @@ casper-client query-global-state \
 **Request fields:**
 
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - Hostname or IP and port of node on which HTTP service is running \[default:<http://localhost:7777>\]
--   `state-root-hash` - Hex-encoded hash of the state root
+-   `node-address` - An IP address of a node on the network
+-   `state-root-hash` - Hex-encoded hash of the network state
 -   `key` - The base key for the query. This must be a properly formatted public key, account hash, contract address hash, URef, transfer hash or deploy-info hash.
 
 **Important response fields:**
 
--   `"result"."stored_value"."Account"."main_purse"` - the address of the main purse containing the sender's tokens. This purse is the source of the tokens transferred in this example
+-   `"result"."stored_value"."Account"."main_purse"` - the address of the main purse containing the sender's tokens. In this example, this purse is the source of the tokens transferred
 
 <details>
 <summary>Explore the JSON-RPC request and response generated.</summary>
@@ -109,7 +110,7 @@ casper-client query-global-state \
 **Request fields:**
 
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - Hostname or IP and port of node on which HTTP service is running \[default:<http://localhost:7777>\]
+-   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
 -   `key` - The base key for the query. This must be a properly formatted public key, account hash, contract address hash, URef, transfer hash, or deploy-info hash.
 
@@ -165,9 +166,9 @@ casper-client query-global-state \
 
 ## Get Source Account Balance {#get-source-account-balance}
 
-All accounts on a Casper system have a purse associated with the Casper system mint, which we call the _main purse_. The balance associated with a given purse is recorded in the global state, and the value can be queried using the `URef` associated with the purse.
+All accounts on a Casper system have a purse associated with the Casper system mint, which we call the _main purse_. The balance associated with a given purse is recorded in global state, and the value can be queried using the `URef` associated with the purse.
 
-Now that we have the source purse address, we can get its balance using the `get-balance` command:
+Now that we have the source purse address, we can verify its balance using the `get-balance` command:
 
 ```bash
 casper-client get-balance \
@@ -180,7 +181,7 @@ casper-client get-balance \
 **Request fields:**
 
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - Hostname or IP and port of node on which HTTP service is running \[default:<http://localhost:7777>\]
+-   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
 -   `purse-uref` - The URef under which the purse is stored. This must be a properly formatted URef "uref-\-"
 
@@ -232,7 +233,7 @@ casper-client get-balance \
 **Request fields:**
 
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - Hostname or IP and port of node on which HTTP service is running \[default:<http://localhost:7777>\]
+-   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
 -   `purse-uref` - The URef under which the purse is stored. This must be a properly formatted URef "uref-\-"
 
@@ -286,7 +287,7 @@ casper-client query-global-state \
 **Request fields:**
 
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - Hostname or IP and port of node on which HTTP service is running \[default:<http://localhost:7777>\]
+-   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
 -   `key` - The base key for the query. This must be a properly formatted transfer address; "transfer-"
 
@@ -335,4 +336,4 @@ casper-client query-global-state \
 
 </details>
 
-The query responds with more information about the transfer we conducted: its deploy hash, the account which executed the transfer, the source, and target purses, and the target account. Using this additional information, we can verify that our transfer was executed successfully.
+The query responds with more information about the transfer we conducted: its deploy hash, the account which executed the transfer, the source and target purses, and the target account. We can verify that our transfer was processed successfully using this additional information.

--- a/source/docs/casper/workflow/verify-transfer.md
+++ b/source/docs/casper/workflow/verify-transfer.md
@@ -166,7 +166,7 @@ casper-client query-global-state \
 
 ## Get Source Account Balance {#get-source-account-balance}
 
-All accounts on a Casper system have a purse associated with the Casper system mint, which we call the _main purse_. The balance associated with a given purse is recorded in global state, and the value can be queried using the `URef` associated with the purse.
+All accounts on a Casper network have a purse associated with the Casper system mint, which we call the _main purse_. The balance associated with a given purse is recorded in global state, and the value can be queried using the `URef` associated with the purse.
 
 Now that we have the source purse address, we can verify its balance using the `get-balance` command:
 


### PR DESCRIPTION
### Related links

- #703 

### Changes

I ran through the following workflows and improved the flow and instructions. The "minor updates" became more extensive, but the technical content remained the same.

- https://docs.casperlabs.io/workflow/two-party-multi-sig/ - link to the repo and remove code that is copy/pasted
- https://docs.casperlabs.io/workflow/deploy-transfer/ - the most important change here is to mention the two-party-multi-sig as a prerequisite
- https://docs.casperlabs.io/workflow/verify-transfer/ - simplified prerequisites and node-address explanation

The other changes mentioned in card #703 were addressed in a previous PR.

### Notes

- Ran locally

### Reviewers

- @ACStoneCL
- only FYI @darthsiroftardis 
