### PR TITLE
Add Rust highlighting in transfer-token-to-contract.md

### DIFF
--- a/source/docs/casper/dapp-dev-guide/tutorials/transfer-token-to-contract.md
+++ b/source/docs/casper/dapp-dev-guide/tutorials/transfer-token-to-contract.md
@@ -12,8 +12,7 @@ This scenario is less complex, but more wasteful than the second scenario. Any p
 
 Please note that the creation of a purse costs 2.5 CSPR on the Casper Mainnet.
 
-```
-
+```rust
 #[no_mangle]
 pub extern "C" fn call() {
     let amount: U512 = runtime::get_named_arg("amount");
@@ -60,8 +59,7 @@ In [Scenario 1](#scenario1), the newly created purse is a pure means of transfer
 
 Scenario 2 offers a less wasteful means of transferring tokens to a contract but comes with the added burden of internal complexity. When choosing between the two scenarios, you must evaluate the scope and needs of your project and choose accordingly.
 
-```
-
+```rust
 // Scenario 2: with this style, the contract being called has some internal accounting
 // to keep track of a reusable purse associated to the calling account; this avoids
 // wasteful creation of one time purses but requires the smart contract being called


### PR DESCRIPTION
Please highlight the Rust code in 
https://docs.casperlabs.io/dapp-dev-guide/tutorials/transfer-token-to-contract/