### PR TITLE
fix typo in casper-signer docs

### DIFF
--- a/source/docs/casper/dapp-dev-guide/building-dapps/casper-signer.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/casper-signer.md
@@ -205,6 +205,6 @@ With the Signer connected to the website, it is possible to sign a transaction. 
 
 ## External links
 
-* The [Vita JavaScript guide](https://vitejs.dev/guide/)
+* The [Vite JavaScript guide](https://vitejs.dev/guide/)
 * The [Casper Java SDK](https://github.com/casper-ecosystem/casper-js-sdk)  source code
 * The [Casper Signer user guide](https://docs.cspr.community/docs/user-guides/SignerGuide.html)


### PR DESCRIPTION
### Related links

none

### Changes

Fixed a typo in a hyperlink to ViteJS

### Notes

none
