### PR TITLE
852/853 SDK Disclaimer & Change of Maintainer List to Organization

### DIFF
--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/index.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/index.md
@@ -5,18 +5,19 @@ slug: /sdk
 
 # SDK Client Libraries
 
-This section covers the software development kits (SDKs) available for interacting with the Casper blockchain. These SDKs are client-side libraries providing functions or methods (depending on the language) to interact with the Casper Network. You can use them as a model to develop your application and accomplish tasks such as generating account keys, sending transfers, or other blockchain transactions.
+This section covers the software development kits (SDKs) published by third parties available for interacting with the Casper blockchain. These SDKs are client-side libraries providing functions or methods (depending on the language) to interact with a Casper network. You can use them as a model to develop your application and accomplish tasks such as generating account keys, sending transfers, or other blockchain transactions.
 
-The following table provides links to the SDK documentation, in addition to the corresponding GitHub repositories and pertinent contact information.
+Each such third party is solely responsible for the SDK it provides, any warranties (to the extent that such warranties have not been disclaimed), and for any claims you may have relating to your access or use thereof. We do not approve or endorse any such SDKs by providing a link thereto, and assume no responsibility for your access or use thereof. The SDKs may be subject to additional licenses and disclaimers as set out in the relevant GitHub repositories.
 
-| SDK Documentation      | GitHub Location      | Maintainer |
+The following table provides links to the SDK documentation, in addition to the corresponding GitHub repositories and its owner contact information.
+
+| SDK Documentation      | GitHub Location      | Organization |
 | ---------------------- | -------------------- | ---------- |
-|[JavaScript/TypeScript](/dapp-dev-guide/building-dapps/sdk/script-sdk) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Jan Hoffman](mailto:jan@hfmn.pl) |
-|Java SDK | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Carl Norburn](mailto:carl.norburn@gmail.com)|
-|[C# SDK](/dapp-dev-guide/building-dapps/sdk/csharp-sdk)|[Casper-net-sdk](https://github.com/make-software/casper-net-sdk)|David Hernando, Ihor Burlachenko, Muhammet Kara, Michael Steuer|
-|[Golang SDK](/dapp-dev-guide/building-dapps/sdk/go-sdk) |[Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)|[Yaroslav Panasenko](mailto:yar.panasenko@gmail.com)|
-|[Python SDK](/dapp-dev-guide/building-dapps/sdk/python-sdk) |[Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)|[Mark A. Greenslade](mailto:mark@casper.network)|
-|Java SDK by SyntiFi|[Casper-sdk](https://github.com/syntifi/casper-sdk)|[Remo Stieger](mailto:remo@syntifi.com)/[Andre Bertolace](mailto:andre@syntifi.com)|
-|PHP SDK|[Casper-php-sdk](https://github.com/make-software/casper-php-sdk)|Roman Bylbas, Ihor Burlachenko, Michael Steuer|
-| Scala SDK | [Casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](mailto:elmabahma@gmail.com) |
-
+|[JavaScript/TypeScript](/dapp-dev-guide/building-dapps/sdk/script-sdk) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
+|Java SDK | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Casper Association](https://github.com/casper-network)|
+|[C# SDK](/dapp-dev-guide/building-dapps/sdk/csharp-sdk)|[Casper-net-sdk](https://github.com/make-software/casper-net-sdk)| [MAKE](https://github.com/make-software) |
+|[Golang SDK](/dapp-dev-guide/building-dapps/sdk/go-sdk) |[Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
+|[Python SDK](/dapp-dev-guide/building-dapps/sdk/python-sdk) |[Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)| [Casper Association](https://github.com/casper-network) |
+|Java SDK by SyntiFi|[Casper-sdk](https://github.com/syntifi/casper-sdk)| [SyntiFi](https://github.com/syntifi) |
+|PHP SDK|[Casper-php-sdk](https://github.com/make-software/casper-php-sdk)| [MAKE](https://github.com/make-software) |
+| Scala SDK | [Casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem) |


### PR DESCRIPTION
### Related links

[Add disclaimer info to SDK listing #853](https://github.com/casper-network/docs/issues/853)
[Change "Maintainer" to "Organization" #852](https://github.com/casper-network/docs/issues/852)

### Changes

Added the listed disclaimer and changed "Maintainer" to "Organization" as requested. Links changed to reflect the organization hosting the SDKs in question rather than the maintainer specifically.

### Notes

Ran locally without issue.
