### PR TITLE
404 - Terminology updates part 2: delegation rate, account hash usage

### DIFF
--- a/source/docs/casper/dapp-dev-guide/building-dapps/casper-signer.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/casper-signer.md
@@ -48,18 +48,18 @@ Next, create a minimal user interface (UI) to interact with the Casper Signer. O
 	<h1>Transer</h1>
 
 	<!-- The amount to send in the transaction. -->
-	<!-- Minimal amount is 2.5CSPR so 2.5 * 10000 (1CSPR = 10.000 motes)  -->
+	<!-- Minimal amount is 2.5 CSPR (1 CSPR = 1,000,000,000 motes)  -->
 	<label for="Amount">Amount - min amount 25000000000</label>
 	<input id="Amount" type="number">
 
-	<!-- The address that will receive the coins. -->
+	<!-- The public key that will receive the coins. -->
 	<label for="Recipient">Recipient</label>
 	<input id="Recipient" type="text">
 
 	<!--The button that when clicked will send the transaction. -->
 	<button id="btnSend" >Send</button>
 
-	<!--The address of your transaction. -->
+	<!--The ID of your transaction. -->
 	<h1 id="tx"></h1>
 	</div>
 ```
@@ -145,7 +145,7 @@ Add the `AccountInformation` function inside the `btnConnect` to display the inf
 	})
 ``` 
 
-Using the Signer window, select the account you wish to display in the web app. Once selected, the account public key hex and balance should be displayed like this:
+Using the Signer window, select the account you wish to display in the web app. Once selected, the account public key and balance should be displayed like this:
 
 <img src={useBaseUrl("/image/tutorials/signer/casper-signer-balance.png")} alt="Image showing account balance" width="800"/>
 
@@ -155,7 +155,7 @@ With the Signer connected to the website, it is possible to sign a transaction. 
 
 ```javascript
 	async function sendTransaction(){
-	// get address to send from input.
+	// get the recipient's public key from input.
 	const to = document.getElementById("Recipient").value;
 	// get amount to send from input.
 	const amount = document.getElementById("Amount").value
@@ -176,7 +176,7 @@ With the Signer connected to the website, it is possible to sign a transaction. 
 
 	let deployParams = new DeployUtil.DeployParams(publicKey,"casper-test",gasPrice,ttl );
 	
-	// We create a public key from account-address (it is the hex representation of the public-key with an added prefix).
+	// We create a hex representation of the public key with an added prefix.
 	const toPublicKey = CLPublicKey.fromHex(to);
 
 	const session = DeployUtil.ExecutableDeployItem.newTransfer( amount,toPublicKey,null,id);

--- a/source/docs/casper/dapp-dev-guide/building-dapps/monitoring-events.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/monitoring-events.md
@@ -129,7 +129,7 @@ id:696
 - [block_hash](/design/serialization-standard/#block-hash) - A cryptographic hash that is used to identify a Block.
 - [era_id](/design/serialization-standard/#eraid) - The period of time used to specify when specific events in a blockchain network occur.
 - [signature](/design/serialization-standard/#signature) - A serialized byte representation of a cryptographic signature.
-- [public_key](/design/serialization-standard/#publickey) - A unique personal address that is shared in the network.
+- [public_key](/design/serialization-standard/#publickey) - A hexadecimal-encoded cryptographic public key.
 
 ## Monitoring Other Events
 All the events apart from `DeployAccepted` and `FinalitySignature` are emitted on the endpoint `main` with the URL `http://<HOST>:9999/events/main`.
@@ -413,7 +413,7 @@ data:
 </details>
 
 - [era_id](/design/serialization-standard/#eraid) - The period of time used to specify when specific events in a blockchain network occur.
-- [public_key](/design/serialization-standard/#publickey) - A unique personal address that is shared in the network.
+- [public_key](/design/serialization-standard/#publickey) - A hexadecimal-encoded cryptographic public key.
 - [timestamp](/design/serialization-standard/#timestamp) - A timestamp type, representing a concrete moment in time.
 
 ### Step event

--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/python-sdk.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/python-sdk.md
@@ -37,7 +37,7 @@ For further examples, take a look at the [How-tos](https://github.com/casper-net
 
 ### Sending a transfer
 
-This example shows you how to define and transfer funds between purses on a Casper network. Replace the *path_to_cp2_account_key* in the code below with the receiver's account address.
+This example shows you how to define and transfer funds between purses on a Casper network. Replace the *path_to_cp2_account_key* in the code below with the receiver's account public key.
 
 ```python
     import os

--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/script-sdk.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/script-sdk.md
@@ -66,10 +66,10 @@ const createAccountKeys = () => {
     const edKeyPair = Keys.Ed25519.new();
     const { publicKey, privateKey } = edKeyPair;
 
-    // Get account-address from public key
+    // Create a hexadecimal representation of the public key
     const accountAddress = publicKey.toHex();
 
-    // Get account-hash (Uint8Array) from public key
+    // Get the account hash (Uint8Array) from the public key
     const accountHash = publicKey.toAccountHash();
 
     // Store keys as PEM files
@@ -95,7 +95,7 @@ After generating the keys with this code, you can add them to the [Casper Signer
 
 ### Sending a Transfer {#sending-a-transfer}
 
-This code block shows you how to define and send a transfer on a Casper network. Replace the `account-address` in the code below with the sender's account address.
+This code block shows you how to define and send a transfer on a Casper network. Replace the `sender-public-key` and `recipient-public-key` in the code below.
 
 The `sendTransfer` function below will return a `transfer-hash` which you can check on https://testnet.cspr.live/.
 
@@ -142,7 +142,7 @@ const sendTransfer = async ({ from, to, amount }) => {
 
     let deployParams = new DeployUtil.DeployParams(signKeyPair.publicKey, networkName, gasPrice, ttl);
 
-    // We create a public key from account-address (it is the hex representation of the public-key with an added prefix)
+    // We create a hex representation of the public key with an added prefix
     const toPublicKey = CLPublicKey.fromHex(to);
 
     const session = DeployUtil.ExecutableDeployItem.newTransfer(amount, toPublicKey, null, id);
@@ -156,13 +156,13 @@ const sendTransfer = async ({ from, to, amount }) => {
 };
 
 sendTransfer({
-    // Put here the account-address of the sender's main purse. Note that it needs to have a balance greater than 2.5CSPR
-    from: "<account-address>",
+    // Put here the public key of the sender's main purse. Note that it needs to have a balance greater than 2.5 CSPR
+    from: "<sender-public-key>",
 
-    // Put here the account-address of the receiver's main purse. This account doesn't need to exist. If the key is correct, the network will create it when the deploy is sent
-    to: "<account-address>",
+    // Put here the public key of the recipient's main purse. This account doesn't need to exist. If the key is correctly formatted, the network will create the account when the deploy is sent
+    to: "<recipient-public-key>",
 
-    // Minimal amount is 2.5CSPR so 2.5 * 10000 (1CSPR = 10.000 motes)
+    // Minimal amount is 2.5 CSPR (1 CSPR = 1,000,000,000 motes)
     amount: 25000000000,
 });
 ```

--- a/source/docs/casper/dapp-dev-guide/setup.md
+++ b/source/docs/casper/dapp-dev-guide/setup.md
@@ -111,7 +111,7 @@ The above command will create three files in the current working directory:
 
 After generating keys for the account, you may add funds to the account's purse to finish the account creation process.
 
-**Note**: Responses from the node contain `AccountHashes` instead of the direct hexadecimal-encoded public key. To view the account hash for a public key, use the account-address option of the client:
+**Note**: Responses from the node contain `AccountHashes` instead of the direct hexadecimal-encoded public key. To view the account hash for a public key, use the `account-address` option of the client:
 
 ```bash
 casper-client account-address --public-key <path-to-public_key.pem/public-key-hex>

--- a/source/docs/casper/dapp-dev-guide/understanding-hash-types.md
+++ b/source/docs/casper/dapp-dev-guide/understanding-hash-types.md
@@ -28,7 +28,7 @@ For the sake of user convenience and compatibility, we expect the delivery of ha
 
 `PublicKey` is a 32 byte asymmetric public key, preceded by a one-byte prefix that tells whether the key is `ed25519` or `secp256k1`.
 
-`AccountHash` is a 32 byte hash of the `PublicKey`. It serves as the address for user accounts.
+`AccountHash` is a 32 byte hash of the `PublicKey` serving to identify user accounts.
 
 `ContractHash` is the 32 byte hash of specific smart contract versions. You can use this to call specific contract versions.
 

--- a/source/docs/casper/dapp-dev-guide/writing-contracts/getting-started.md
+++ b/source/docs/casper/dapp-dev-guide/writing-contracts/getting-started.md
@@ -33,7 +33,7 @@ We recommend setting up the rust-toolchain in the top level directory of your pr
 We publish three crates on [crates.io](https://crates.io/) to support smart contract development with Rust:
 
 -   [Casper Contract](https://crates.io/crates/casper-contract) - a library supporting communication with the blockchain. This is the main library you will need to write smart contracts.
--   [Casper Test Support](https://crates.io/crates/casper-engine-test-support) - an in-memory virtual machine against which you can test your smart contracts.
+-   [Casper Test Support](https://crates.io/crates/casper-engine-test-support) - a virtual machine against which you can test your smart contracts.
 -   [Casper Types](https://crates.io/crates/casper-types) - a library with types we use across the Rust ecosystem.
 
 A crate is a compilation unit, which can be compiled into a binary or a library.
@@ -109,7 +109,7 @@ make check-lint
 
 In addition to creating the contract, the Casper crate also automatically created sample tests in the _my-project/tests_ folder.
 
-The Casper local environment provides an in-memory virtual machine against which you can run your contract for testing. When you run the test crate, it will automatically build the smart contract in release mode and then run a series of tests against it in the Casper runtime environment. The custom build script is named _build.rs_ if you are interested in looking more into it.
+The Casper local environment provides a virtual machine against which you can run your contract for testing. When you run the test crate, it will automatically build the smart contract in release mode and then run a series of tests against it in the Casper runtime environment. The custom build script is named _build.rs_ if you are interested in looking more into it.
 
 :::note
 

--- a/source/docs/casper/dapp-dev-guide/writing-contracts/testing-contracts.md
+++ b/source/docs/casper/dapp-dev-guide/writing-contracts/testing-contracts.md
@@ -80,7 +80,7 @@ Next, you need to define any global variables or constants for the test.
 
 Each test function installs the contract and calls entry points to assert that the contract's behavior matches expectations. The test uses the `InMemoryWasmTestBuilder` to invoke an instance of the execution engine, effectively simulating the process of installing the contract on the chain.
 
-As part of this process, we use the `DEFAULT_RUN_GENESIS_REQUEST` to install the system contracts necessary for the tests, including the `Mint`, `Auction`, and `HandlePayment`contracts, as well as establishing a default address and funding the associated purse.
+As part of this process, we use the `DEFAULT_RUN_GENESIS_REQUEST` to install the system contracts necessary for the tests, including the `Mint`, `Auction`, and `HandlePayment`contracts, as well as establishing a default account and funding the associated purse.
 
 ```rust
     #[test]

--- a/source/docs/casper/design/casper-design.md
+++ b/source/docs/casper/design/casper-design.md
@@ -1,4 +1,4 @@
-# Overview of a Casper network
+# Overview of a Casper Network
 
 ## Introduction
 

--- a/source/docs/casper/faq/faq-developer.md
+++ b/source/docs/casper/faq/faq-developer.md
@@ -166,7 +166,7 @@ You can monitor a node's event stream on the port specified as the `event_stream
 <details>
  <summary><b>How can I query a deploy for an account?</b></summary>
 
-On-chain accounts are associated with an account address. Deploy data includes account address as a sub-field.
+On-chain accounts are associated with an account public key. Deploy data includes the account's public key as a sub-field.
 
 </details>
 

--- a/source/docs/casper/faq/faq-general.md
+++ b/source/docs/casper/faq/faq-general.md
@@ -82,7 +82,7 @@ Yes. Follow [this guide](https://support.ledger.com/hc/en-us/articles/4416379141
 
 <summary><b>What are the important aspects to consider when delegating tokens to a validator?</b></summary>
 
-Users should consider consistent uptime, prompt upgrades and commission rates when choosing a validator. Offline and out-of-date validators do not generate rewards.
+Users should consider consistent uptime, prompt upgrades and delegation rates when choosing a validator. Offline and out-of-date validators do not generate rewards.
 
 Active engagement in the community is another important aspect.
 

--- a/source/docs/casper/glossary/A.md
+++ b/source/docs/casper/glossary/A.md
@@ -12,7 +12,7 @@ An Account is a structure that represents a user on a Casper network. Informatio
 
 ## Account Hash {#account-hash}
 
-The account hash is a 32-byte hash of the public key and it represents the address of the user account. Information on generating an account hash can be found [here](/faq/faq-general/#accounts).
+The account hash is a 32-byte hash of the public key representing the user account. Information on generating an account hash can be found [here](/faq/faq-general/#accounts).
 
 ## AssemblyScript {#assemblyscript}
 

--- a/source/docs/casper/glossary/D.md
+++ b/source/docs/casper/glossary/D.md
@@ -12,7 +12,7 @@ A decentralized application (dApp) employs [smart contracts](S.md#smart-contract
 
 ## Delegation rate {#delegation-rate}
 
-Node operators ([validators](V.md#validator)) define a commission that they take in exchange for providing staking services. This commission is represented as a percentage of the rewards that the node operator retains for their services.
+Node operators ([validators](V.md#validator)) define a delegation rate that they take in exchange for providing staking services. This delegation rate is a percentage of the rewards that the node operator retains for their services.
 
 ## Delegator {#delegator}
 

--- a/source/docs/casper/glossary/R.md
+++ b/source/docs/casper/glossary/R.md
@@ -8,7 +8,7 @@
 
 ## Reward {#reward}
 
-Validators receive rewards for participating in consensus and finalizing blocks. There is no precise per-block reward. Rewards are split proportionally among stakes within an era. If a validator is offline or cannot vote on many blocks, the rewards earned are also reduced. Delegators can only receive a proportional amount of the validator's rewards minus the validator's commission (Delegation Rate). Rewards are distributed at the end of each era.
+Validators receive rewards for participating in consensus and finalizing blocks. There is no precise per-block reward. Rewards are split proportionally among stakes within an era. If a validator is offline or cannot vote on many blocks, the rewards earned are also reduced. Delegators can only receive a proportional amount of the validator's rewards minus the validator's [delegation rate](D.md#delegation-rate). Rewards are distributed at the end of each era.
 
 ## Root hash {#root-hash}
 

--- a/source/docs/casper/staking/index.md
+++ b/source/docs/casper/staking/index.md
@@ -18,7 +18,7 @@ Here are a few common topics related to staking, but we also encourage you to do
 
 Node operators stake their tokens to earn eligibility to propose and approve blocks on the network. They also run and maintain servers connected to the network. If they win a validator slot, they become validators and help enable the Proof-of-Stake aspect of the network, a process different from mining tokens. Validators thus earn rewards for participating and for securing the network.
 
-Anyone can participate in the protocol to earn rewards without maintaining a Casper node (a server that stores a copy of the blockchain). One can delegate or allocate CSPR tokens to a chosen validator on the network. Validators retain a commission, a percentage of the rewards generated from staked tokens. Participating in the protocol this way, the community can help improve the network's decentralization and security and earn rewards in return. Block explorers connected to the network usually post the base annual reward rate.
+Anyone can participate in the protocol to earn rewards without maintaining a Casper node (a server that stores a copy of the blockchain). One can delegate or allocate CSPR tokens to a chosen validator on the network. Validators retain a percentage of the rewards generated from staked tokens. Participating in the protocol this way, the community can help improve the network's decentralization and security and earn rewards in return. Block explorers connected to the network usually post the base annual reward rate.
 
 Casper does not treat validator stake differently than delegator stake for security reasons.
 
@@ -26,9 +26,9 @@ Casper does not treat validator stake differently than delegator stake for secur
 
 Presently Casper does not slash if a validator equivocates or misbehaves. If a node equivocates, other validators will ignore its messages, and the node will become inactive. The node will terminate once it detects that it has equivocated. 
 
-## Commission or Delegation Rate {#commission}
+## Delegation Rate {#delegation-rate}
 
-Validators define a commission (or delegation rate) that they take in exchange for providing staking services. This commission is represented as a percentage of the rewards that the validator retains for their services.
+Validators define a delegation rate that they take in exchange for providing staking services. This rate is a percentage of the rewards that the validator retains for their services.
 
 ## Delegation Fees {#delegation-fees}
 
@@ -36,7 +36,7 @@ It is important to know that the cost of the delegation process is approximately
 
 ## Rewards {#rewards}
 
-Validators receive rewards proportional to their stake for securing the network and participating in consensus (by voting and finalizing blocks). Delegators receive a portion of the validator's rewards, proportional to what they delegated, minus the validator's commission (or delegation rate). The rewards earned are reduced if a validator is offline or cannot vote on many blocks. 
+Validators receive rewards proportional to their stake for securing the network and participating in consensus (by voting and finalizing blocks). Delegators receive a portion of the validator's rewards, proportional to what they delegated, minus the validator's delegation rate. The rewards earned are reduced if a validator is offline or cannot vote on many blocks. 
 
 There is no precise reward per block. Rewards are split proportionally among stakes within an era and are distributed at the end of each era.
 

--- a/source/docs/casper/workflow/delegate.md
+++ b/source/docs/casper/workflow/delegate.md
@@ -45,7 +45,7 @@ You will see a list of validators present on the network and their total stake (
 
 You can click on any validator listed to see more information about the validator, including the validator's personal stake.
 
-As a prospective delegator, selecting a trustworthy validator with a favorable rate is essential. Each validator shows the delegation rate (commission), which represents the percentage of **your** reward share that the validator will retain. Thus, a 10% rate implies that the validator will retain 10% of your reward share. Please do your due diligence before staking your tokens with a validator.
+As a prospective delegator, selecting a trustworthy validator with a favorable rate is essential. Each validator shows the delegation rate, which is a percentage of **your** reward share that the validator will retain. Thus, a 10% rate implies that the validator will retain 10% of your reward share. Please do your due diligence before staking your tokens with a validator.
 
 Note the `PublicKey` of the validator you have selected to delegate your tokens.
 

--- a/source/docs/casper/workflow/ledger-setup.md
+++ b/source/docs/casper/workflow/ledger-setup.md
@@ -49,7 +49,7 @@ You can now use the Ledger device with the [cspr.live](https://cspr.live/) block
 ### View account details {#view-account-details}
 
 1.  Go to [cspr.live](https://cspr.live).
-2.  Click on the account address in the upper-right corner of the page.
+2.  Click on the account in the upper-right corner of the page.
 
 <img src={useBaseUrl("/image/tutorials/ledger/flow/3-view-account.png")} alt="3-view-account" width="750" />
 

--- a/source/docs/casper/workflow/two-party-multi-sig.md
+++ b/source/docs/casper/workflow/two-party-multi-sig.md
@@ -12,7 +12,7 @@ This workflow describes how a trivial two-party multi-signature scheme for signi
 
 **CAUTION**: Incorrect account configurations could render accounts defunct and unusable. We highly recommend executing any changes to an account in a test environment like Testnet before performing them in a live environment like Mainnet.
 
-Each Account has an `associated_keys` field, a list containing the account address, and its weight for every associated account. Accounts can be associated by adding the account address to the `associated_keys` field.
+Each Account has an `associated_keys` field, which is a list containing account hashes and their corresponding weights. Accounts can be associated by adding the account hash to the `associated_keys` field.
 
 An Account on a Casper network assigns weights to keys associated with it. For a single key to sign a deploy, or edit the state of the account, its weight must be greater than or equal to a set threshold. The thresholds are labeled as the `action_thresholds` for the account.
 
@@ -127,4 +127,4 @@ casper-client query-global-state \
 ```
 </details>
 
-In the example output, you can see the account addresses listed within the `associated_keys` section. Each key has weight `1`; since the action threshold for `deployment` is `2`, neither account can sign and send a deploy individually. Thus, the deploy needs to be signed by the secret keys of each account to reach the required threshold.
+In the example output, you can see the account hashes listed within the `associated_keys` section. Each key has weight `1`; since the action threshold for `deployment` is `2`, neither account can sign and send a deploy individually. Thus, the deploy needs to be signed by the secret keys of each account to reach the required threshold.


### PR DESCRIPTION
### Related links

- Card #404 

### Changes

* Replaced **commission** with **delegation rate** as appropriate 
* Removed **in-memory** from all virtual machine references, except in the i18 translated files
* I fixed some incorrect comments in the SDK sample code
* Reviewed and updated "**account hash**" usage vs "**account address**"
    * No updates to the obsolete multi-sig tutorial
    * No updates to the disclaimer. If we need to update this, please let me know. 
> "The` Recipient understands and accepts that CSPR, if and when created and/or issued, will only be accessed by using a wallet technically compatible with CSPR and with a combination of the Recipient’s account information (address) and private key, seed or password. The Recipient understands and accepts that if its private key or password gets lost or stolen, the CSPR associated with the Recipient’s account (address) will be unrecoverable and will be permanently lost."


### Notes

I ran the site locally.

Definitions:

- "The current or prospective validator responsible for the bid receives a portion of the delegator rewards set by the delegation rate."
- "A commission: a fee paid to an agent or employee for transacting a piece of business or performing a service; especially: a percentage of the money received from a total paid to the agent responsible for the business."
