### PR TITLE
646 - Add info on why the TrieStore uses account hashes

### DIFF
--- a/source/docs/casper/dapp-dev-guide/keys.md
+++ b/source/docs/casper/dapp-dev-guide/keys.md
@@ -5,8 +5,8 @@ The Casper blockchain uses an on-chain [account-based model](/design/casper-desi
 By default, a transactional interaction with the blockchain takes the form of a `Deploy` cryptographically signed by the key-pair corresponding to the `PublicKey` used to create the account.
 
 The Casper platform supports two types of keys for creating accounts and signing transactions: 
-- [ed25519](#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66-byte long
-- [secp256k1](#ethereum-keys) keys, commonly known as Ethereum keys, which are 68-byte long
+- [ed25519](#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66 bytes long
+- [secp256k1](#ethereum-keys) keys, commonly known as Ethereum keys, which are 68 bytes long
 
 You can generate keys using both formats, and it is also possible to [work with existing Ethereum keys](#working-with-existing-ethereum-keys).
 
@@ -51,7 +51,7 @@ Here are some details about the files generated:
 2. `public_key_hex` is a hexadecimal-encoded string of the public key
 3. `secret_key.pem` is the *PEM*-encoded secret key
 
-The public-key-hex for `ed25519` keys starts with 01 and is 66-bytes long:
+The public-key-hex for `ed25519` keys starts with 01 and is 66 bytes long:
 
 ```bash
 cat ed25519-keys/public_key_hex
@@ -78,7 +78,7 @@ secp256k1-keys/
 0 directories, 3 files
 ```
 
-The public-key-hex for `secp256k1` keys starts with 02 and is 68-bytes long:
+The public-key-hex for `secp256k1` keys starts with 02 and is 68 bytes long:
 
 ```bash
 cat secp256k1-keys/public_key_hex

--- a/source/docs/casper/dapp-dev-guide/keys.md
+++ b/source/docs/casper/dapp-dev-guide/keys.md
@@ -1,14 +1,16 @@
 # Accounts and Cryptographic Keys
 
-The Casper blockchain uses an on-chain [account-based model](/design/casper-design.md/#accounts-head), uniquely identified by an `AccountHash` derived from a specific `PublicKey`.
+The Casper blockchain uses an on-chain [account-based model](/design/casper-design.md/#accounts-head), uniquely identified by an `AccountHash` derived from a specific `PublicKey`. The `AccountHash` is a 32-byte hash derived from any of the supported `PublicKey` variants below to standardize keys that can vary in length.
 
 By default, a transactional interaction with the blockchain takes the form of a `Deploy` cryptographically signed by the key-pair corresponding to the `PublicKey` used to create the account.
 
 The Casper platform supports two types of keys for creating accounts and signing transactions: 
-- [ed25519](#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA)
-- [secp256k1](#ethereum-keys) keys, commonly known as Ethereum keys
+- [ed25519](#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66-byte long
+- [secp256k1](#ethereum-keys) keys, commonly known as Ethereum keys, which are 68-byte long
 
 You can generate keys using both formats, and it is also possible to [work with existing Ethereum keys](#working-with-existing-ethereum-keys).
+
+You can also [generate an account hash](#generating-an-account-hash) from a public key with the Casper command-line client.
 
 ## Creating Accounts and Keys {#creating-accounts-and-keys}
 
@@ -49,7 +51,7 @@ Here are some details about the files generated:
 2. `public_key_hex` is a hexadecimal-encoded string of the public key
 3. `secret_key.pem` is the *PEM*-encoded secret key
 
-The public-key-hex for `ed25519` keys starts with 01:
+The public-key-hex for `ed25519` keys starts with 01 and is 66-bytes long:
 
 ```bash
 cat ed25519-keys/public_key_hex
@@ -76,20 +78,14 @@ secp256k1-keys/
 0 directories, 3 files
 ```
 
-The public-key-hex for `secp256k1` keys starts with 02:
+The public-key-hex for `secp256k1` keys starts with 02 and is 68-bytes long:
 
 ```bash
 cat secp256k1-keys/public_key_hex
 020287e1a79d0d9f3196391808a8b3e5007895f43cde679e4c960e7e9b92841bb98d
 ```
 
-#### Account Hash
 
-Responses from the node contain `AccountHashes` instead of the direct hexadecimal-encoded public key. To view the account hash for a public key, use the *account-address* option of the client. The argument for the *public-key* must be a properly formatted public key. The public key may also be read from a file, which should be one of the two files generated via the *keygen* command: *public_key_hex* or *public_key.pem*.
-
-```bash
-casper-client account-address --public-key <FORMATTED STRING or PATH>
-```
 
 ### Option 2: Generating Keys using a Block Explorer {#option-2-key-generation-using-a-block-explorer}
 
@@ -177,4 +173,12 @@ MHQCAQEEIBjXY+7xZagzTjL4p8bGWS8FPRcW13mgytdu5c3e556MoAcGBSuBBAAK
 oUQDQgAEpV4dVaPeAEaH0VXrQtLzjpGt1pui1q08311em6wDCchGNjzsnOY7stGF
 tlKF2V5RFQn4rzkwipSYnrqaPf1pTA==
 -----END EC PRIVATE KEY-----
+```
+
+## Generating an Account Hash {#generating-an-account-hash}
+
+To generate the account hash for a public key, use the *account-address* option of the Casper client. The argument for the *public-key* must be a properly formatted public key. The public key may also be read from a file, which should be one of the two files generated via the *keygen* command: *public_key_hex* or *public_key.pem*.
+
+```bash
+casper-client account-address --public-key <FORMATTED STRING or PATH>
 ```

--- a/source/docs/casper/design/casper-design.md
+++ b/source/docs/casper/design/casper-design.md
@@ -164,7 +164,13 @@ All these features are accessible via functions in the [Casper External FFI](htt
 
 ## Accounts {#accounts-head}
 
-The Casper blockchain uses an on-chain account-based model, uniquely identified by an `AccountHash` derived from a specific `PublicKey`. By default, a transactional interaction with the blockchain takes the form of a Deploy cryptographically signed by the key-pair corresponding to the PublicKey used to create the account. All user activity on the Casper blockchain (i.e., "deploys") must originate from an account. Each account has its own context where it can locally store information (e.g., references to useful contracts, metrics, and aggregated data from other parts of the blockchain). Each account also has a "main purse" where it can hold Casper tokens (see [Tokens](#tokens-purses-and-accounts) for more information).
+The Casper blockchain uses an on-chain account-based model, uniquely identified by an `AccountHash` derived from a specific `PublicKey`. The [global state trie store](#global-state-trie) requires all keys to be the same length, so the AccountHash is a 32-byte derivative used to abstract any of the supported public key variants.
+
+The Casper platform supports two types of keys for creating accounts and signing transactions: 
+- [ed25519](/dapp-dev-guide/keys.md#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66-byte long
+- [secp256k1](/dapp-dev-guide/keys.md#ethereum-keys) keys, commonly known as Ethereum keys, which are 68-byte long
+
+By default, a transactional interaction with the blockchain takes the form of a Deploy cryptographically signed by the key-pair corresponding to the PublicKey used to create the account. All user activity on the Casper blockchain (i.e., "deploys") must originate from an account. Each account has its own context where it can locally store information (e.g., references to useful contracts, metrics, and aggregated data from other parts of the blockchain). Each account also has a "main purse" where it can hold Casper tokens (see [Tokens](#tokens-purses-and-accounts) for more information).
 
 This chapter describes the permission model for accounts and their local storage capabilities and briefly mentions some runtime functions for interacting with accounts.
 

--- a/source/docs/casper/design/casper-design.md
+++ b/source/docs/casper/design/casper-design.md
@@ -167,8 +167,8 @@ All these features are accessible via functions in the [Casper External FFI](htt
 The Casper blockchain uses an on-chain account-based model, uniquely identified by an `AccountHash` derived from a specific `PublicKey`. The [global state trie store](#global-state-trie) requires all keys to be the same length, so the AccountHash is a 32-byte derivative used to abstract any of the supported public key variants.
 
 The Casper platform supports two types of keys for creating accounts and signing transactions: 
-- [ed25519](/dapp-dev-guide/keys.md#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66-byte long
-- [secp256k1](/dapp-dev-guide/keys.md#ethereum-keys) keys, commonly known as Ethereum keys, which are 68-byte long
+- [ed25519](/dapp-dev-guide/keys.md#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66 bytes long
+- [secp256k1](/dapp-dev-guide/keys.md#ethereum-keys) keys, commonly known as Ethereum keys, which are 68 bytes long
 
 By default, a transactional interaction with the blockchain takes the form of a Deploy cryptographically signed by the key-pair corresponding to the PublicKey used to create the account. All user activity on the Casper blockchain (i.e., "deploys") must originate from an account. Each account has its own context where it can locally store information (e.g., references to useful contracts, metrics, and aggregated data from other parts of the blockchain). Each account also has a "main purse" where it can hold Casper tokens (see [Tokens](#tokens-purses-and-accounts) for more information).
 


### PR DESCRIPTION
### Related links

- #646 

### Changes

- Updated [design](https://docs.casperlabs.io/design/casper-design/#accounts-head) and [keys](https://docs.casperlabs.io/dapp-dev-guide/keys/) pages as requested in the ticket

### Notes

- Ran the docs site locally
- Since the technical details are clear, I am just adding @ACStoneCL as reviewer