### PR TITLE
Update tor.us link

### DIFF
--- a/source/docs/casper/dapp-dev-guide/build-on-casper/index.md
+++ b/source/docs/casper/dapp-dev-guide/build-on-casper/index.md
@@ -22,7 +22,7 @@ The Casper Ecosystem is growing every day through the addition of new dApps and 
 
 ### Wallets
 - [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?docs=true)
-- [Tor.us](https://app.tor.us/)
+- [Tor.us](https://casper.tor.us)
 - [Casper Signer](https://chrome.google.com/webstore/search/casper?hl=en)
 
 ### Block Explorers


### PR DESCRIPTION
A brief change as discussed in slack to use the https://casper.tor.us/ link.