### PR TITLE
862 - Redelegate documentation

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -46,6 +46,7 @@ module.exports = {
                     ],
                 },
                 "workflow/developers/delegate",
+                "workflow/developers/redelegate",
                 "workflow/developers/undelegate",
             ],
         },

--- a/source/docs/casper/dapp-dev-guide/list-cspr.md
+++ b/source/docs/casper/dapp-dev-guide/list-cspr.md
@@ -170,7 +170,7 @@ Staking operations consists of two parts:
 The staking deploy requires the following information:
 - The delegator's public key
 - The validator's public key
-- The new validator's public key (For re-delegation only)
+- The new validator's public key (For redelegation only)
 - The amount to be delegated
 - The gas cost
 - The auction manager contract's hash

--- a/source/docs/casper/dapp-dev-guide/sdkspec/types_chain.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/types_chain.md
@@ -688,7 +688,7 @@ Required Parameters:
 
 ## NewValidator {#newvalidator}
 
-The public key for the new validator in a re-delegation using [UnbondingPurse](#unbondingpurse).
+The public key for the new validator in a redelegation using [UnbondingPurse](#unbondingpurse).
 
 ## Operation {#operation}
 

--- a/source/docs/casper/dapp-dev-guide/sdkspec/types_chain.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/types_chain.md
@@ -912,7 +912,7 @@ Required Parameters:
 
 * [`validator_public_key`](#publickey) The original validator's public key.
 
-* [`new_validator`](#newvalidator) The re-delegated validator's public key.
+* [`new_validator`](#newvalidator) The redelegated validator's public key.
 
 ## URef {#uref}
 

--- a/source/docs/casper/design/serialization-standard.md
+++ b/source/docs/casper/design/serialization-standard.md
@@ -598,7 +598,7 @@ A purse used for unbonding. The structure consists of the following:
 
 -   `amount` The unbonding amount, serialized as a [`U512`](#clvalue-numeric) value.
 
--   `new_validator` The validator public key to re-delegate to, serialized as an [`Option`](#clvalue-option) containing the public key.
+-   `new_validator` The validator public key to redelegate to, serialized as an [`Option`](#clvalue-option) containing the public key.
 
 ## Values {#serialization-standard-values}
 

--- a/source/docs/casper/workflow/developers/delegate.md
+++ b/source/docs/casper/workflow/developers/delegate.md
@@ -122,7 +122,7 @@ casper-client get-auction-info \
 
 The `get-auction-info` call will return all the bids currently in the auction contract and the list of active validators for `4` future eras from the present era.
 
-Below is a sample output:
+Below is a sample of the `bids` structure:
 
 ```json
 "bids": [
@@ -151,24 +151,13 @@ Below is a sample output:
 },
 ```
 
-The delegation request has been processed successfully if your public key and associated amount appear in the `bid` data structure. However, this does not mean the associated validator is part of the validator set, so you must check the validator status.
+The delegation request has been processed successfully if your public key and associated amount appear in the `bid` data structure. However, this does not mean the associated validator is part of the validator set, so you must check the validator status recorded in the `era_validators` structure.
 
-### Checking Validator Status {#checking-validator-status}
+#### Checking Validator Status {#checking-validator-status}
 
 The auction maintains a field called `era_validators`, which contains the validator information for 4 future eras from the current era. An entry for a specific era lists the `PublicKeys` of the active validators for that era, along with their stake in the network.
 
-If a validator is part of the set, its public key will be in the `era_validators` field as part of the `Auction` data structure. We can use the Casper command-line client to create an RPC request to obtain auction information and assert that the selected validator is part of the active validator set.
-
-```bash
-casper-client get-auction-info \
---node-address http://<peer-ip-address>:7777
-```
-
-**Request fields**:
-
--   `node-address` - An IP address of a node on the network
-
-**Important Response fields**:
+If a validator is part of the set, its public key will be in the `era_validators` field as part of the `Auction` data structure returned by `casper-client get-auction-info`.
 
 In the response, check the `"auction_state"."era_validators"` structure, which should contain the public key of the selected validator for the era in which the validator will be active.
 
@@ -207,3 +196,8 @@ Below is an example of the `era_validators` structure:
 In the above example, we see the public keys of the active validators in Era `9`.
 
 **Note**: Validators earn delegation rewards only when they are part of the active set. This information is time-sensitive; therefore, a validator selected today may not be part of the set tomorrow. Keep this in mind when creating a delegation request.
+
+If your account is on the official Testnet or Mainnet, you can use the block explorer to look up your account balance and see that the tokens have been delegated:
+
+1.  [Testnet explorer](https://testnet.cspr.live/)
+2.  [Mainnet explorer](https://cspr.live/)

--- a/source/docs/casper/workflow/developers/delegate.md
+++ b/source/docs/casper/workflow/developers/delegate.md
@@ -49,9 +49,9 @@ As a prospective delegator, selecting a trustworthy validator with a favorable r
 
 Note the `PublicKey` of the validator you have selected to delegate your tokens.
 
-Suppose you observe your delegation request in the bid structure but do not see the associated validator key in the `era_validators` structure. In that case, the validator you selected is not part of the current validator set. In this event, your tokens will only be earning rewards if you un-delegate, wait through the unbonding period, and re-delegate to another validator.
+Suppose you observe your delegation request in the bid structure but do not see the associated validator key in the `era_validators` structure. In that case, the validator you selected is not part of the current validator set. In this event, your tokens will only be earning rewards if you undelegate, wait through the unbonding period, and redelegate to another validator.
 
-Additionally, any rewards earned are re-delegated by default to the validator from the initial delegation request. Therefore at the time of un-delegation, you should consider un-delegating the initial amount plus any additional rewards earned through the delegation process.
+Additionally, any rewards earned are redelegated by default to the validator from the initial delegation request. Therefore at the time of undelegation, you should consider undelegating the initial amount plus any additional rewards earned through the delegation process.
 
 The active validator set constantly rotates; therefore, when delegating to a validator, remember that the validator you selected may have been rotated out of the set.
 

--- a/source/docs/casper/workflow/developers/delegate.md
+++ b/source/docs/casper/workflow/developers/delegate.md
@@ -25,7 +25,7 @@ Prepare the Rust environment and then build the contracts using the [Makefile](h
 ```bash
 cd casper-node
 make setup-rs
-make build-contracts-rs
+make build-client-contracts-rs
 ```
 
 Once you build the contracts, you can use the `delegate.wasm` to create a deploy that will initiate the delegation process. The Wasm can be found in this directory: `target/wasm32-unknown-unknown/release/`.

--- a/source/docs/casper/workflow/developers/redelegate.md
+++ b/source/docs/casper/workflow/developers/redelegate.md
@@ -61,4 +61,4 @@ The redelegation process includes an unbonding delay before the tokens are redel
 
 Due to this delay, the new validator may become inactive before the redelegation completes. If this happens, the tokens will be returned to the delegator.
 
-Once the redelegation Deploy has been processed, you can query the auction to confirm the redelegation. The process of verifying the redelegation request is the same as [verifying a delegation request](/workflow/developers/delegate.md#confirming-the-delegation) using the `casper-client get-auction-info` command.
+Once the redelegation Deploy has been processed, you can query the auction to confirm the redelegation. This process is the same as [verifying a delegation request](/workflow/developers/delegate.md#confirming-the-delegation) using the `casper-client get-auction-info` command.

--- a/source/docs/casper/workflow/developers/redelegate.md
+++ b/source/docs/casper/workflow/developers/redelegate.md
@@ -1,0 +1,64 @@
+# Redelegating Tokens with the Casper Client
+
+This document details a workflow where tokens delegated to a validator can be redelegated to another validator without sending an [unbonding request](undelegate.md) first. The unbonding process will happen in the background.
+
+## Prerequisites
+
+1. You meet all [prerequisites](/dapp-dev-guide/setup.md), including having a valid `node-address` and the Casper command-line client
+2. You have [delegated tokens](/workflow/developers/delegate) to a validator on a Casper network, and you have the validator's public key
+3. As part of the delegation process, you have [built the casper-node contracts](/workflow/developers/delegate#building-the-delegation-wasm) that produced the redelegation Wasm to execute on the network
+4. You have the public key of the new validator to whom you wish to redelegate tokens. See [Acquiring a Validator's Public Key](/workflow/developers/delegate#acquiring-a-validators-public-key) for more details
+
+## Sending the Redelegation Request {#sending-the-redelegation-deploy}
+
+We recommend testing the following steps on the official Testnet before performing them in a live environment like the Casper Mainnet.
+
+In this example, we use the Casper client to send a deploy containing the `redelegate.wasm` to the network to initiate the redelegation process.
+
+```rust
+casper-client put-deploy \
+--node-address http://<peer-ip-addres>:7777 \
+--chain-name casper-test \
+--session-path <path-to-wasm>/redelegate.wasm \
+--payment-amount 5000000000 \
+--session-arg "validator:public_key='<hex-encoded-validator-public-key>'" \
+--session-arg "amount:u512='<amount-to-delegate>'"
+--session-arg "delegator:public_key='<hex-encoded-public-key>'" \
+--session arg "new_validator:public_key='<hex-encoded-public-key>'" \
+--secret-key <delegator-secret-key>.pem
+```
+
+**Note** The delegator's public key and the secret key that signs the deploy must be part of the same account key pair.
+
+**Request fields:**
+
+-   `node-address` - An IP address of a node on the network
+
+-   `secret-key` - Path to secret key file
+
+-   `chain-name` - Name of the chain, to avoid the deploy from being accidentally or maliciously included in a different chain
+
+    -   The _chain-name_ for Testnet is **casper-test**
+    -   The _chain-name_ for Mainnet is **casper**
+
+-   `session-path` - The path to where the `redelegate.wasm` is located
+
+-   `session-arg` - The arguments to the `redelegate` request
+
+    -   The argument `validator` is the public key of the validator from whom the tokens will be redelegated
+    -   The argument `amount` is the number of tokens to be redelegated
+    -   The argument `delegator` is the public key of the account redelegating tokens from a validator
+
+**Important response fields:**
+
+-   `"result"."deploy_hash"` - The hash of the redelegation Deploy
+
+Save the returned _deploy_hash_ from the output to [query information](querying.md#querying-deploys) about the redelegation Deploy.
+
+## Verifying the Redelegation {#asserting-the-redelegation}
+
+The redelegation process includes an unbonding delay before the tokens are redelegated to a new validator. In contrast, initial delegation occurs as soon as a Casper network finalizes the associated Deploy.
+
+Due to this delay, the new validator may become inactive before the redelegation completes. If this happens, the tokens will be returned to the delegator.
+
+Once the redelegation Deploy has been processed, you can query the auction to confirm the redelegation. The process of verifying the redelegation request is the same as [verifying a delegation request](/workflow/developers/delegate.md#confirming-the-delegation) using the `casper-client get-auction-info` command.

--- a/source/docs/casper/workflow/developers/redelegate.md
+++ b/source/docs/casper/workflow/developers/redelegate.md
@@ -20,7 +20,7 @@ casper-client put-deploy \
 --node-address http://<peer-ip-addres>:7777 \
 --chain-name casper-test \
 --session-path <path-to-wasm>/redelegate.wasm \
---payment-amount 5000000000 \
+--payment-amount 20000000000 \
 --session-arg "validator:public_key='<hex-encoded-validator-public-key>'" \
 --session-arg "amount:u512='<amount-to-delegate>'" \
 --session-arg "delegator:public_key='<hex-encoded-public-key>'" \

--- a/source/docs/casper/workflow/developers/redelegate.md
+++ b/source/docs/casper/workflow/developers/redelegate.md
@@ -22,9 +22,9 @@ casper-client put-deploy \
 --session-path <path-to-wasm>/redelegate.wasm \
 --payment-amount 5000000000 \
 --session-arg "validator:public_key='<hex-encoded-validator-public-key>'" \
---session-arg "amount:u512='<amount-to-delegate>'"
+--session-arg "amount:u512='<amount-to-delegate>'" \
 --session-arg "delegator:public_key='<hex-encoded-public-key>'" \
---session arg "new_validator:public_key='<hex-encoded-public-key>'" \
+--session-arg "new_validator:public_key='<hex-encoded-public-key>'" \
 --secret-key <delegator-secret-key>.pem
 ```
 


### PR DESCRIPTION
### What does this PR fix/introduce?

- A new workflow for redelegating tokens to a new validator.

### Additional context

- We have a new entry point called `redelegate` in the Auction system contract, which allows users to redelegate to another validator without having to unbond. The function signature for the entry point is: `redelegate(delegator: PublicKey, validator: PublicKey, amount: U512, new_validator: PublicKey)`.
- The [old redelegate.md](https://github.com/casper-network/docs/files/10688916/redelegate-old.md) file from branch feat-1.5.0 is attached. I removed the verification section as it was duplicated (exact copy/paste). I pointed to the `delegate.md` verification steps instead. I also did a complete refresh of this file to match the current format of the `delegate.md` file.
- As part of this, I noticed duplicated content in the `delegate.md` file, so I consolidated that section as well.

### Checklist

- [x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).
- [x] All links (internal and external) have been verified.
- [ ] All technical procedures have been tested. (I have been unable to test the command with a dev build of NCTL. I will return to the testing with card https://github.com/casper-network/docs/issues/898 when the dev branch is fixed.)
- [x]  The docs site ran locally.

### Reviewers
 
- @ACStoneCL 
- FYI @darthsiroftardis 

### Notes

We may need to wait on merging this PR until the casper-node repository is updated.
