### PR TITLE
Fix invalid links

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdkspec/types_cl.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/types_cl.md
@@ -1,6 +1,6 @@
 # CLType {#cltype}
 
-Casper types, i.e. types which can be stored and manipulated by smart contracts. Provides a description of the underlying data type of a [`CLValue`](crate::CLValue).
+Casper types, i.e. types which can be stored and manipulated by smart contracts. Provides a description of the underlying data type of a [`CLValue`](#clvalue).
 
         `Bool`
         `I32`

--- a/source/docs/casper/dapp-dev-guide/setup.md
+++ b/source/docs/casper/dapp-dev-guide/setup.md
@@ -68,7 +68,7 @@ sudo dnf install casper-client-x-x-x*.rpm
 
 ## Building the Client from Source {#building-the-client-from-source}
 
-[Instructions]( https://github.com/casper-network/casper-node/tree/master/client)
+[Instructions](https://github.com/casper-network/casper-node/tree/master/client)
 
 ## Setting up an Account {#setting-up-an-account}
 


### PR DESCRIPTION
I am using custom tool to process all the links in docs, and I detected:
- 1 invalid reference,
- 1 external link with trailing space.

This PR fixes them.