### PR TITLE
Remove Speculative_Exec from Current Docs

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
@@ -96,24 +96,3 @@ The result contains the [deploy_hash](../../sdkspec/types_chain/#deployhash), wh
 ```
 
 </details>
-
-## speculative_exec {#speculative_exec}
-
-The `speculative_exec` endpoint provides a method to execute a `Deploy` without committing it to global state. By default, `speculative_exec` is disabled on a node. Sending a request to a node with the endpoint disabled will result in an error message. If enabled, `speculative_exec` operates on a separate port from the primary JSON-RPC, using 7778.
-
-`speculative_exec` executes a deploy at a specified block. In the case of this endpoint, the execution is not committed to global state. As such, it can be used for observing the execution effects of a deploy without associated payment.
-
-|Parameter|Type|Description|
-|---------|----|-----------|
-|[block_identifier](../../sdkspec/types_chain/#blockidentifier)|Object|The block hash or height on top of which to execute the deploy. If not supplied,the most recent block will be used.|
-|[deploy](../../sdkspec/types_chain/#deploy)|Object|A Deploy consists of an item containing a smart contract along with the requester's signature(s).|
-
-### `speculative_exec_result`
-
-The result contains the hash of the targeted block and the results of the execution.
-
-|Parameter|Type|Description|
-|---------|----|-----------|
-|api_version|String|The RPC API version.|
-|[block_hash](../../sdkspec/types_chain/#blockhash)|Object|The Block hash on top of which the deploy was executed.|
-|[execution_results](../../sdkspec/types_chain/#executionresult)|Object|The map of Block hash to execution result.|


### PR DESCRIPTION
### What does this PR fix/introduce?
Speculative_Exec is a 1.5 endpoint and should only be on the feat-1.5 branch.

### Additional context
This PR removes the speculative_exec endpoint from the SDK Spec.

### Checklist
(Delete any that aren't relevant)

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).
- [x] All links (internal and external) have been verified.
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).
- [x] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
@darthsiroftardis 
