### PR TITLE
865 Updating Status Endpoint for 1.5

### DIFF
--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-informational.md
@@ -695,12 +695,16 @@ This method returns the current status of a node.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
+|[available_block_range](/dapp-dev-guide/sdkspec/types_chain#AvailableBlockRange)|Object|The available block range in storage.|
+|[block_sync](/dapp-dev-guide/sdkspec/types_chain#BlockSynchronizerStatus)|Object|The status of the block synchronizer builders.|
 |build_version|String|The compiled node version.|
 |chainspec_name|String|The chainspec name, used to identify the currently connected network.|
 |[last_added_block_info](/dapp-dev-guide/sdkspec/types_chain#minimalblockinfo)|Object|The minimal info of the last Block from the linear chain.|
+|[last_progress](/dapp-dev-guide/sdkspec/types_chain#timestamp)||Timestamp of the last recorded progress in the reactor.|
 |[next_upgrade](/dapp-dev-guide/sdkspec/types_chain#nextupgrade)|Object|Information about the next scheduled upgrade.|
 |[our_public_signing_key](/dapp-dev-guide/sdkspec/types_chain#publickey)|String|Our public signing key.|
 |[peers](/dapp-dev-guide/sdkspec/types_chain#peersmap)|Array|The node ID and network address of each connected peer.|
+|[reactor_state](/dapp-dev-guide/sdkspace/types_chain#reactorstate)]|String|The current state of the node reactor.|
 |[round_length](/dapp-dev-guide/sdkspec/types_chain#timediff)|Integer|The next round length if this node is a validator. A round length is the amount of time it takes to reach consensus on proposing a Block.|
 |[starting_state_root_hash](/dapp-dev-guide/sdkspec/types_chain#digest)|String|The state root hash used at the start of the current session.|
 |[uptime](/dapp-dev-guide/sdkspec/types_chain#timediff)|Integer|Time that passed since the node has started.|

--- a/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/json-rpc-transactional.md
@@ -99,9 +99,9 @@ The result contains the [deploy_hash](../../sdkspec/types_chain#deployhash), whi
 
 ## speculative_exec {#speculative_exec}
 
-The `speculative_exec` endpoint provides a method to execute a `Deploy` without committing it to global state. By default, `speculative_exec` is disabled on a node. Sending a request to a node with the endpoint disabled will result in an error message. If enabled, `speculative_exec` operates on a separate port from the primary JSON-RPC, using 7778.
+The `speculative_exec` endpoint provides a method to execute a `Deploy` without committing its execution effects to global state. By default, `speculative_exec` is disabled on a node. Sending a request to a node with the endpoint disabled will result in an error message. If enabled, `speculative_exec` operates on a separate port from the primary JSON-RPC, using 7778.
 
-`speculative_exec` executes a deploy at a specified block. In the case of this endpoint, the execution is not committed to global state. As such, it can be used for observing the execution effects of a deploy without associated payment.
+`speculative_exec` executes a Deploy at a specified block. In the case of this endpoint, the execution effects are not committed to global state. As such, it can be used for observing the execution effects of a Deploy without paying for the execution of the Deploy.
 
 |Parameter|Type|Description|
 |---------|----|-----------|

--- a/source/docs/casper/dapp-dev-guide/sdkspec/types_chain.md
+++ b/source/docs/casper/dapp-dev-guide/sdkspec/types_chain.md
@@ -74,6 +74,12 @@ Required Parameters:
 
 * [`state_root_hash`](#digest) Global state hash.
 
+## AvailableBlockRange {#availableblockrange}
+
+* `low` The inclusive lower bound of the range.
+
+* `high` The inclusive upper bound of the range.
+
 ## Bid {#bid}
 
 An entry in the validator map.
@@ -107,6 +113,26 @@ Identifier for possible ways to retrieve a Block.
 * [`Hash`](#blockhash) Identify and retrieve the Block with its hash.
 
 * `Height` Identify and retrieve the Block with its height.
+
+## BlockSynchronizerStatus {#blocksynchronizerstatus}
+
+The status of the block synchronizer.
+
+* `Historical` The status of syncing a historical block, if any.
+
+    * [`block_hash`](#blockhash-blockhash) The block hash.
+
+    * `block_height` The height of the block, if known.
+
+    * `acquisition_state` The state of acquisition of hte data associated with the block.
+
+* `Forward` The status of syncing a forward block, if any.
+
+    * [`block_hash`](#blockhash-blockhash) The block hash.
+
+    * `block_height` The height of the block, if known.
+
+    * `acquisition_state` The state of acquisition of hte data associated with the block.
 
 ## Contract {#contract} 
 
@@ -743,6 +769,22 @@ The identifier to obtain the purse corresponding to a balance query. Valid ident
 * `main_purse_under_account_hash` The main purse under a provided [`AccountHash`](/dapp-dev-guide/sdkspec/types_chain#accounthash).
 
 * `purse_uref` A specific purse identified by the associated [`URef`](/dapp-dev-guide/sdkspec/types_chain#uref).
+
+## ReactorState {#reactorstate}
+
+The state of the reactor, which will return one of the following:
+
+* `Initialize`
+
+* `CatchUp`
+
+* `Upgrading`
+
+* `KeepUp`
+
+* `Validate`
+
+* `ShutdownForUpgrade`
 
 ## Reward {#reward}
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR updates information on the `info_get_status` endpoint to include changes from coming in 1.5

### Additional context
[Update docs for status endpoint changes #865](https://github.com/casper-network/docs/issues/865)

### Checklist
(Delete any that aren't relevant)

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).
- [x] All links (internal and external) have been verified.
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@darthsiroftardis @ipopescu 
