### PR TITLE
Remove old Java SDK link

### DIFF
--- a/source/docs/casper/dapp-dev-guide/building-dapps/sdk/index.md
+++ b/source/docs/casper/dapp-dev-guide/building-dapps/sdk/index.md
@@ -13,11 +13,10 @@ The following table provides links to the SDK documentation, in addition to the 
 
 | SDK Documentation      | GitHub Location      | Organization |
 | ---------------------- | -------------------- | ---------- |
-|[JavaScript/TypeScript](/dapp-dev-guide/building-dapps/sdk/script-sdk) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
-|Java SDK | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Casper Association](https://github.com/casper-network)|
-|[C# SDK](/dapp-dev-guide/building-dapps/sdk/csharp-sdk)|[Casper-net-sdk](https://github.com/make-software/casper-net-sdk)| [MAKE](https://github.com/make-software) |
-|[Golang SDK](/dapp-dev-guide/building-dapps/sdk/go-sdk) |[Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
-|[Python SDK](/dapp-dev-guide/building-dapps/sdk/python-sdk) |[Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)| [Casper Association](https://github.com/casper-network) |
-|Java SDK by SyntiFi|[Casper-sdk](https://github.com/syntifi/casper-sdk)| [SyntiFi](https://github.com/syntifi) |
-|PHP SDK|[Casper-php-sdk](https://github.com/make-software/casper-php-sdk)| [MAKE](https://github.com/make-software) |
-| Scala SDK | [Casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem) |
+|[JavaScript/TypeScript](/dapp-dev-guide/building-dapps/sdk/script-sdk) | [casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
+|Java SDK | [casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Casper Association](https://github.com/casper-network)|
+|[C# SDK](/dapp-dev-guide/building-dapps/sdk/csharp-sdk)|[casper-net-sdk](https://github.com/make-software/casper-net-sdk)| [MAKE](https://github.com/make-software) |
+|[Golang SDK](/dapp-dev-guide/building-dapps/sdk/go-sdk) |[casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
+|[Python SDK](/dapp-dev-guide/building-dapps/sdk/python-sdk) |[casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)| [Casper Association](https://github.com/casper-network) |
+|PHP SDK|[casper-php-sdk](https://github.com/make-software/casper-php-sdk)| [MAKE](https://github.com/make-software) |
+| Scala SDK | [casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem) |


### PR DESCRIPTION
### What does this PR fix/introduce?
Removing an old Java SDK link from the list.
I also updated the capitalization to match GitHub repositories.

<img width="624" alt="Screen Shot 2023-02-15 at 10 36 46 AM" src="https://user-images.githubusercontent.com/4185994/218997200-1382419b-3b70-490c-b244-361d63008a3a.png">



### Checklist

Does not apply for a simple link deletion.

### Reviewers
@ACStoneCL 