### PR TITLE
Require NodeJS 16.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ references:
 executors:
   node:
     docker:
-    - image: node:14.15.0
+    - image: node:16.14
   aws:
     docker:
     - image: mesosphere/aws-cli

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      selected_node_version: 14
+      selected_node_version: 16.14
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Follow these steps to run the documentation website locally, displayed in your l
 ### Pre-requisites
 
 -   Install a code editor, such as Visual Studio Code (`vscode`). You may also want to install editing extensions such as `prettier`, `eslint`, and others listed in the `.vscode/extensions.json` file.
--   Install [Node.js](https://nodejs.org/en/download/) (version 14+).
+-   Install [Node.js](https://nodejs.org/en/download/) (version 16.14+).
 -   Install `yarn` via `npm` using this command:
 
     ```

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "typescript": "^4.3.5"
     },
     "engines": {
-        "node": ">=14"
+        "node": ">=16.14"
     },
     "engineStrict": true,
     "browserslist": {


### PR DESCRIPTION
### What does this PR change?

Bump _NodeJS_ requirement to **16.14**, and update both CI/CD configs accordingly (although _CircleCI_ seems not to be used :thinking:).

### Additional context

We are preparing for _Docusaurus_ upgrade to the latest version [v2.3.1](https://github.com/facebook/docusaurus/releases/tag/v2.3.1), and node 16.14 is the minimum required version for it.

### Checklist

- [x] I ran the docs locally using `yarn install` and `yarn build`.
- [x] All technical procedures have been tested.

