### PR TITLE
External links checking - skip closing page when goto() failed

### DIFF
--- a/check-external-urls.js
+++ b/check-external-urls.js
@@ -102,6 +102,7 @@ class MarkdownExternalUrlChecker {
                 await page.goto(url, { waitUntil: "load" });
             } catch (err) {
                 resolve({ error: err.message });
+                return;
             }
             await page.close();
             resolve({ error: "Unknown exception occured" });


### PR DESCRIPTION
This PR fixes an error that sometimes occurs in script that checks external links - https://github.com/casper-network/docs/issues/953.

### Explanation

When `page.goto()` fails within `try..catch` block (it means page was not opened), then `page.close()` should not be called. 
