### PR TITLE
Feature/robots.txt

### DIFF
--- a/config/site.config.js
+++ b/config/site.config.js
@@ -3,7 +3,7 @@ const { cdns, customScripts } = require("./script.config");
 module.exports = {
     title: "Casper",
     tagline: "The best search experience for docs, integrated in minutes, for free",
-    url: "https://operators.casper.network/",
+    url: "https://docs.casperlabs.io/",
     baseUrl: "/docs/",
     trailingSlash: true,
     onBrokenLinks: "throw",

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /CNAME
+Disallow: /opensearch.xml
+Disallow: /.nojekyll
+Sitemap: https://docs.casperlabs.io/sitemap.xml


### PR DESCRIPTION
### What does this PR fix/introduce?

### Additional context
- [80941ee](https://github.com/casper-network/docs/commit/80941eebf6d245bb42e5264897713e3f78b1a5d0) robots.txt pointing to the sitemap
- [a9ec299](https://github.com/casper-network/docs/commit/a9ec29976eb8aa4c406fb1c22b933084388b57d7) operators.casper.network domain was still referenced in the site.config.js. This caused the sitemap.xml to be generated with the wrong addresses.

### Checklist
(Delete any that aren't relevant)

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [ ] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/). ==> Link is broken. Wasn't able to find the new link.
- [x] All links (internal and external) have been verified.
- [ ] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)). --> Not sure which technical procedures.
- [x] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
@ipopescu 
