### PR TITLE
Remove CSS capitalization for collapsible menu items

### DIFF
--- a/src/assets/scss/theme.scss
+++ b/src/assets/scss/theme.scss
@@ -75,7 +75,6 @@ nav.menu {
         .menu__link--sublist {
             letter-spacing: 0;
             font-size: 14px;
-            text-transform: capitalize;
             cursor: pointer;
             padding-left: 20px;
         }


### PR DESCRIPTION
### What does this PR change?

This PR removes text capitalization CSS, that was applied to collapsible menu items. Therefore case of label is preserved now:

![sidebar](https://user-images.githubusercontent.com/121791569/224177994-a013e3da-4cd7-401e-a92d-661987826279.png)

### Additional context

See the following issue for details: #959.
