### PR TITLE
Improve AccountHash explanation

### DIFF
--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -20,7 +20,7 @@ Required Parameters:
 
 ## AccountHash {#accounthash}
 
-The AccountHash is a Hex-encoding of the PublicKey and therefore can be viewed as an address.
+The AccountHash is a 32-byte hash derived from a supported PublicKey. Its role is to standardize keys that can vary in length.
 
 ## ActionThresholds {#actionthresholds}
 

--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -108,7 +108,7 @@ Identifier for possible ways to retrieve a Block.
 
 * `Height` Identify and retrieve the Block with its height.
 
-## Contract {#contract} 
+## Contract {#contract}
 
 A contract struct that can be serialized as a JSON object.
 
@@ -257,7 +257,7 @@ Options for dictionary item lookups.
     `dictionary_name` The named key under which the dictionary seed URef is stored.
 
     `dictionary_item_key` The dictionary item key formatted as a string.
-        
+
 * `URef` Lookup a dictionary item via its seed URef.
 
     `seed_uref` The dictionary's seed URef.
@@ -414,7 +414,7 @@ Required Parameters:
 
 * [`args`](#runtimeargs)
 
-## ExecutionEffect {#executioneffect} 
+## ExecutionEffect {#executioneffect}
 
 The journal of execution transforms from a single Deploy.
 

--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -20,7 +20,7 @@ Required Parameters:
 
 ## AccountHash {#accounthash}
 
-Hex-encoded Account hash.
+The AccountHash is a Hex-encoding of the PublicKey and therefore can be viewed as an address.
 
 ## ActionThresholds {#actionthresholds}
 

--- a/source/docs/casper/developers/json-rpc/types_cl.md
+++ b/source/docs/casper/developers/json-rpc/types_cl.md
@@ -34,7 +34,7 @@ Casper types, i.e. types which can be stored and manipulated by smart contracts.
 
 * `Tuple3` 3-ary tuple of `CLType`s.
 
-## CLValue {#clvalue} 
+## CLValue {#clvalue}
 
 A Casper value, i.e. a value which can be stored and manipulated by smart contracts. It holds the underlying data as a type-erased, serialized `Vec<u8>` and also holds the CLType of the underlying data as a separate member. The `parsed` field, representing the original value, is a convenience only available when a CLValue is encoded to JSON, and can always be set to null if preferred.
 


### PR DESCRIPTION
### What does this PR introduce?

Polished version of types pages, mainly better explanation of _AccountHash_.

### Additional context

These changes are backported from the default branch of [docs-new](https://github.com/casper-network/docs-new) repository.

Original PR authored by @jonas089: https://github.com/casper-network/docs-new/pull/15.

### Checklist

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [x] All links (internal and external) have been verified.
- [x] All technical procedures have been tested.
