### PR TITLE
Polished intro to SDKs

### DIFF
--- a/source/docs/casper/developers/dapps/sdk/index.md
+++ b/source/docs/casper/developers/dapps/sdk/index.md
@@ -3,7 +3,7 @@ title: Introduction to SDKs
 slug: /sdk
 ---
 
-# SDK Client Libraries
+# Introduction to SDKs
 
 This section covers the software development kits (SDKs) published by third parties available for interacting with the Casper blockchain. These SDKs are client-side libraries providing functions or methods (depending on the language) to interact with a Casper network. You can use them as a model to develop your application and accomplish tasks such as generating account keys, sending transfers, or other blockchain transactions.
 

--- a/source/docs/casper/developers/dapps/sdk/index.md
+++ b/source/docs/casper/developers/dapps/sdk/index.md
@@ -3,21 +3,20 @@ title: Introduction to SDKs
 slug: /sdk
 ---
 
-# Introduction to SDKs
+# SDK Client Libraries
 
 This section covers the software development kits (SDKs) published by third parties available for interacting with the Casper blockchain. These SDKs are client-side libraries providing functions or methods (depending on the language) to interact with a Casper network. You can use them as a model to develop your application and accomplish tasks such as generating account keys, sending transfers, or other blockchain transactions.
 
-Each of these SDKs can be used to build dApps. For browser interaction you can use the JavaScript SDK, for desktop applications there is C#, Java, etc. Click the link on your preferred SDK to learn how to use it in dApp development. You may visit the SDKs' Github repositories to delve into the source code.
-
-| SDK Documentation                                            | GitHub Location                                              | Organization                                            |
-| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------- |
-| [JavaScript/TypeScript](./script-sdk.md) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/) | [Casper Ecosystem](https://github.com/casper-ecosystem) |
-| Java SDK                                                     | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/) | [Casper Association](https://github.com/casper-network) |
-| [C# SDK](./csharp-sdk.md)      | [Casper-net-sdk](https://github.com/make-software/casper-net-sdk) | [MAKE](https://github.com/make-software)                |
-| [Golang SDK](./go-sdk.md)      | [Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/) | [Casper Ecosystem](https://github.com/casper-ecosystem) |
-| [Python SDK](./python-sdk.md)  | [Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/) | [Casper Association](https://github.com/casper-network) |
-| Java SDK by SyntiFi                                          | [Casper-sdk](https://github.com/syntifi/casper-sdk)          | [SyntiFi](https://github.com/syntifi)                   |
-| PHP SDK                                                      | [Casper-php-sdk](https://github.com/make-software/casper-php-sdk) | [MAKE](https://github.com/make-software)                |
-| Scala SDK                                                    | [Casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem)             |
+Each of these SDKs can be used to build dApps. For browser interaction, you can use the JavaScript SDK; for desktop applications, there are C# and Java SDKs. Click the link on your preferred SDK to learn how to use it in dApp development. To delve into the source code, you may visit the SDKs' Github repositories.
 
 Each such third party is solely responsible for the SDK it provides, any warranties (to the extent that such warranties have not been disclaimed), and for any claims you may have relating to your access or use thereof. We do not approve or endorse any such SDKs by providing a link thereto, and assume no responsibility for your access or use thereof. The SDKs may be subject to additional licenses and disclaimers as set out in the relevant GitHub repositories.
+
+| SDK Documentation      | GitHub Location      | Organization |
+| ---------------------- | -------------------- | ---------- |
+|[JavaScript/TypeScript](./script-sdk.md) | [casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
+|Java SDK | [casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Casper Association](https://github.com/casper-network)|
+|[C# SDK](./csharp-sdk.md)|[casper-net-sdk](https://github.com/make-software/casper-net-sdk)| [MAKE](https://github.com/make-software) |
+|[Golang SDK](./go-sdk.md) |[casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
+|[Python SDK](./python-sdk.md) |[casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)| [Casper Association](https://github.com/casper-network) |
+|PHP SDK|[casper-php-sdk](https://github.com/make-software/casper-php-sdk)| [MAKE](https://github.com/make-software) |
+| Scala SDK | [casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem) |

--- a/source/docs/casper/developers/dapps/sdk/index.md
+++ b/source/docs/casper/developers/dapps/sdk/index.md
@@ -1,22 +1,23 @@
 ---
-title: SDK Client Libraries
+title: Introduction to SDKs
 slug: /sdk
 ---
 
-# SDK Client Libraries
+# Introduction to SDKs
 
 This section covers the software development kits (SDKs) published by third parties available for interacting with the Casper blockchain. These SDKs are client-side libraries providing functions or methods (depending on the language) to interact with a Casper network. You can use them as a model to develop your application and accomplish tasks such as generating account keys, sending transfers, or other blockchain transactions.
 
+Each of these SDKs can be used to build dApps. For browser interaction you can use the JavaScript SDK, for desktop applications there is C#, Java, etc. Click the link on your preferred SDK to learn how to use it in dApp development. You may visit the SDKs' Github repositories to delve into the source code.
+
+| SDK Documentation                                            | GitHub Location                                              | Organization                                            |
+| ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------- |
+| [JavaScript/TypeScript](./script-sdk.md) | [Casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/) | [Casper Ecosystem](https://github.com/casper-ecosystem) |
+| Java SDK                                                     | [Casper-java-sdk](https://github.com/casper-network/casper-java-sdk/) | [Casper Association](https://github.com/casper-network) |
+| [C# SDK](./csharp-sdk.md)      | [Casper-net-sdk](https://github.com/make-software/casper-net-sdk) | [MAKE](https://github.com/make-software)                |
+| [Golang SDK](./go-sdk.md)      | [Casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/) | [Casper Ecosystem](https://github.com/casper-ecosystem) |
+| [Python SDK](./python-sdk.md)  | [Casper-python-sdk](https://github.com/casper-network/casper-python-sdk/) | [Casper Association](https://github.com/casper-network) |
+| Java SDK by SyntiFi                                          | [Casper-sdk](https://github.com/syntifi/casper-sdk)          | [SyntiFi](https://github.com/syntifi)                   |
+| PHP SDK                                                      | [Casper-php-sdk](https://github.com/make-software/casper-php-sdk) | [MAKE](https://github.com/make-software)                |
+| Scala SDK                                                    | [Casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem)             |
+
 Each such third party is solely responsible for the SDK it provides, any warranties (to the extent that such warranties have not been disclaimed), and for any claims you may have relating to your access or use thereof. We do not approve or endorse any such SDKs by providing a link thereto, and assume no responsibility for your access or use thereof. The SDKs may be subject to additional licenses and disclaimers as set out in the relevant GitHub repositories.
-
-The following table provides links to the SDK documentation, in addition to the corresponding GitHub repositories and its owner contact information.
-
-| SDK Documentation      | GitHub Location      | Organization |
-| ---------------------- | -------------------- | ---------- |
-|[JavaScript/TypeScript](./script-sdk.md) | [casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
-|Java SDK | [casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Casper Association](https://github.com/casper-network)|
-|[C# SDK](./csharp-sdk.md)|[casper-net-sdk](https://github.com/make-software/casper-net-sdk)| [MAKE](https://github.com/make-software) |
-|[Golang SDK](./go-sdk.md) |[casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
-|[Python SDK](./python-sdk.md) |[casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)| [Casper Association](https://github.com/casper-network) |
-|PHP SDK|[casper-php-sdk](https://github.com/make-software/casper-php-sdk)| [MAKE](https://github.com/make-software) |
-| Scala SDK | [casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem) |

--- a/source/docs/casper/developers/dapps/sdk/index.md
+++ b/source/docs/casper/developers/dapps/sdk/index.md
@@ -3,7 +3,7 @@ title: Introduction to SDKs
 slug: /sdk
 ---
 
-# Introduction to SDKs
+# SDK Client Libraries
 
 This section covers the software development kits (SDKs) published by third parties available for interacting with the Casper blockchain. These SDKs are client-side libraries providing functions or methods (depending on the language) to interact with a Casper network. You can use them as a model to develop your application and accomplish tasks such as generating account keys, sending transfers, or other blockchain transactions.
 


### PR DESCRIPTION
### What does this PR fix/introduce?

Polishes existing Building-dApps/Intro to SDKs.

### Additional context

These changes are backported from the default branch of [docs-new](https://github.com/casper-network/docs-new) repository, so you can preview them [live here](https://docs-new.casper.network/sdk/).

Original PR authored by @dylanireland: https://github.com/casper-network/docs-new/pull/148.

### Checklist

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [x] All links (internal and external) have been verified.
- [x] All technical procedures have been tested.
