### PR TITLE
463 additional info for a node's ports

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -185,10 +185,10 @@ module.exports = {
             items: [
                 "operators/setup/hardware",
                 "operators/setup/basic-node-configuration",
+                "operators/setup/node-endpoints",
                 "operators/setup/install-node",
                 "operators/setup/upgrade",
                 "operators/setup/joining",
-                "operators/setup/port-settings",
             ],
         },
         {

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -188,6 +188,7 @@ module.exports = {
                 "operators/setup/install-node",
                 "operators/setup/upgrade",
                 "operators/setup/joining",
+                "operators/setup/port-settings",
             ],
         },
         {

--- a/source/docs/casper/operators/setup-network/create-private.md
+++ b/source/docs/casper/operators/setup-network/create-private.md
@@ -39,8 +39,8 @@ Use the below guides to set up and manage validator nodes.
 - [Set up Mainnet and Testnet validator nodes](https://docs.cspr.community/): A set of guides for Mainnet and Testnet node-operators on setting up and configuring their Casper network validator nodes.
 
 Use these FAQ collections for tips and details for validators.
-- [FAQs for basic validator node ](../../faq/faq-validator.md)
-- [FAQs on Main Net and Test Net validator node setup](https://docs.cspr.community/docs/faq-validator.html)
+- [FAQs for a basic validator node ](../../faq/faq-validator.md)
+- [External FAQs on Mainnet and Testnet validator node setup](https://docs.cspr.community/docs/faq-validator.html)
 
 ## Step 2. Setting up the Directory
 Use these guides to set up your private network directories. You will find several main directories dedicated to different purposes.

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -11,7 +11,7 @@ The following ports are used by the node:
 - 8888 REST endpoint for status and metrics (having this accessible allows your node to be part of network status)
 - 9999 SSE endpoint for event stream
 
-Of these `35000` is the only port required to be open for your node to function, however, opening `8888` will allow others to know general network health. For more details, see the additional information on [Node Endpoints](./port-settings.md).
+Of these `35000` is the only port required to be open for your node to function, however, opening `8888` will allow others to know general network health. For more details, see the additional information on [Node Endpoints](./node-endpoints.md).
 
 ## Operating System Requirements
 

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -11,7 +11,7 @@ The following ports are used by the node:
 - 8888 REST endpoint for status and metrics (having this accessible allows your node to be part of network status)
 - 9999 SSE endpoint for event stream
 
-Of these `35000` is the only port required to be open for your node to function, however, opening `8888` will allow others to know general network health.
+Of these `35000` is the only port required to be open for your node to function, however, opening `8888` will allow others to know general network health. For more details, see the additional information on [Node Endpoints](./port-settings.md).
 
 ## Operating System Requirements
 

--- a/source/docs/casper/operators/setup/node-endpoints.md
+++ b/source/docs/casper/operators/setup/node-endpoints.md
@@ -9,15 +9,12 @@ This document describes in more detail a Casper node's default endpoints:
 - [REST HTTP server port: 8888](#8888)
 - [SSE HTTP event stream server port: 9999](#9999)
 
-
-## Default Endpoints
-
 Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](../setup/basic-node-configuration/#config-file), which is the node's configuration file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
 
 The default endpoints for Mainnet and Testnet are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
 
 
-### Default networking port: 35000 {#35000}
+## Default Networking Port: 35000 {#35000}
 
 The configuration options for networking are under the `network` section of the `config.toml` file. The `bind_address` using port 35000 is the only port required to be open for the node to function. A Casper node taking part in the network should open connections to every other node it is aware of and has not blocked. In the `config.toml` file, the setting is:
 
@@ -28,7 +25,7 @@ bind_address = '0.0.0.0:35000'
 If the networking port is closed, the node becomes unreachable, and the node won't be discoverable in the network. If this is a validator, it will face eviction. A read-only node will be considered to be offline.
 
 
-### Default JSON-RPC HTTP server port: 7777 {#7777}
+## Default JSON-RPC HTTP Server Port: 7777 {#7777}
 
 The configuration options for the JSON-RPC HTTP server are under the `rpc_server` section in the `config.toml` file. The `address` using port 7777 is the listening address for JSON-RPC HTTP server. 
 
@@ -39,7 +36,7 @@ address = '0.0.0.0:7777'
 DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc). Users would use this address to [interact with the network using CLI](../../developers/cli/). Validators would use this address to [bond](../becoming-a-validator/bonding/#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding/). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
 
 
-### Default REST HTTP server port: 8888 {#8888}
+## Default REST HTTP Server Port: 8888 {#8888}
 
 The configuration options for the JSON-RPC HTTP server are under the `rest_server` section in the `config.toml` file. The `address` listing port 8888 is the listening address for the REST HTTP server. 
 
@@ -50,6 +47,8 @@ address = '0.0.0.0:8888'
 Opening port 8888 is recommended but not required. This port allows the node to be included in the general network health metrics, thus giving a more accurate picture of overall network health. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
 
 One may use this port to [get a trusted hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration/#trusted-hash-for-synchronizing), [verify successful staging](https://docs.casperlabs.io/operators/setup/upgrade/#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining/#step-7-confirm-the-node-is-synchronized).
+
+### Example usage
 
 For general health metrics, use this command:
 
@@ -87,7 +86,7 @@ To monitor local block height as well as RPC port status:
 watch -n 15 'curl -s http://<node_address>:8888/status | jq ".peers | length"; curl -s localhost:8888/status | jq .last_added_block_info; casper-client get-block'
 ```
 
-### Default SSE HTTP event stream server port: 9999 {#9999}
+## Default SSE HTTP Event Stream Server Port: 9999 {#9999}
 
 The configuration options for the SSE HTTP event stream server are listed under the `event_stream_server` section of the `config.toml` file. The `address` listing port 9999 is the listening address for the SSE HTTP event stream server. 
 
@@ -100,7 +99,7 @@ If this port is closed, the requests coming to this port will not be served, but
 
 ## Restricting Access for Private Networks
 
-Any node can join Mainnet and Testnet since they are public Casper networks. Private networks may wish to restrict access for new nodes joining the network as described [here](https://docs.casperlabs.io/operators/setup-network/create-private/#network-access-control).
+Any node can join Mainnet and Testnet and communicate with the nodes in the network. Private networks may wish to restrict access for new nodes joining the network as described [here](https://docs.casperlabs.io/operators/setup-network/create-private/#network-access-control).
 
 
 ## Summary of Related Links

--- a/source/docs/casper/operators/setup/node-endpoints.md
+++ b/source/docs/casper/operators/setup/node-endpoints.md
@@ -1,4 +1,4 @@
-# A Node's Port Settings
+# Node Endpoints
 
 As specified in the [Network Requirements](./install-node.md#network-requirements), a Casper node uses specific ports to communicate with client applications and other nodes on the network. This document goes into more detail describing the default port settings and linking to related topics.
 

--- a/source/docs/casper/operators/setup/node-endpoints.md
+++ b/source/docs/casper/operators/setup/node-endpoints.md
@@ -9,7 +9,7 @@ This document describes in more detail a Casper node's default endpoints:
 - [REST HTTP server port: 8888](#8888)
 - [SSE HTTP event stream server port: 9999](#9999)
 
-Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](../setup/basic-node-configuration/#config-file), which is the node's configuration file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
+Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](../setup/basic-node-configuration#config-file), which is the node's configuration file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
 
 The default endpoints for Mainnet and Testnet are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
 
@@ -33,7 +33,7 @@ The configuration options for the JSON-RPC HTTP server are under the `rpc_server
 address = '0.0.0.0:7777'
 ```
 
-DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc). Users would use this address to [interact with the network using CLI](../../developers/cli/). Validators would use this address to [bond](../becoming-a-validator/bonding/#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding/). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
+DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc). Users would use this address to [interact with the network using CLI](../../developers/cli/). Validators would use this address to [bond](../becoming-a-validator/bonding#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding/). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
 
 
 ## Default REST HTTP Server Port: 8888 {#8888}
@@ -46,7 +46,7 @@ address = '0.0.0.0:8888'
 
 Opening port 8888 is recommended but not required. This port allows the node to be included in the general network health metrics, thus giving a more accurate picture of overall network health. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
 
-One may use this port to [get a trusted hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration/#trusted-hash-for-synchronizing), [verify successful staging](https://docs.casperlabs.io/operators/setup/upgrade/#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining/#step-7-confirm-the-node-is-synchronized).
+One may use this port to [get a trusted hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration#trusted-hash-for-synchronizing), [verify successful staging](https://docs.casperlabs.io/operators/setup/upgrade#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining#step-7-confirm-the-node-is-synchronized).
 
 ### Example usage
 
@@ -99,7 +99,7 @@ If this port is closed, the requests coming to this port will not be served, but
 
 ## Restricting Access for Private Networks
 
-Any node can join Mainnet and Testnet and communicate with the nodes in the network. Private networks may wish to restrict access for new nodes joining the network as described [here](https://docs.casperlabs.io/operators/setup-network/create-private/#network-access-control).
+Any node can join Mainnet and Testnet and communicate with the nodes in the network. Private networks may wish to restrict access for new nodes joining the network as described [here](https://docs.casperlabs.io/operators/setup-network/create-private#network-access-control).
 
 
 ## Summary of Related Links
@@ -111,10 +111,10 @@ Here is a summary of the links mentioned on this page:
 - [The node configuration file](../setup/basic-node-configuration.md#config-file)
 - [Interacting with the Casper JSON-RPC API](../../developers/json-rpc)
 - [Interacting with the network using CLI](../../developers/cli/)
-- [Bonding](../becoming-a-validator/bonding/#example-bonding-transaction) or [unbonding](../becoming-a-validator/unbonding/) as a validator
-- [Getting a trusted node hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration/#trusted-hash-for-synchronizing)
-- [Verifying successful staging](https://docs.casperlabs.io/operators/setup/upgrade/#verifying-successful-staging)
-- [Confirming that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining/#step-7-confirm-the-node-is-synchronized)
+- [Bonding](../becoming-a-validator/bonding#example-bonding-transaction) or [unbonding](../becoming-a-validator/unbonding/) as a validator
+- [Getting a trusted node hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration#trusted-hash-for-synchronizing)
+- [Verifying successful staging](https://docs.casperlabs.io/operators/setup/upgrade#verifying-successful-staging)
+- [Confirming that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining#step-7-confirm-the-node-is-synchronized)
 - [Monitoring and consuming events](../../developers/dapps/monitor-and-consume-events/)
 - [Private network access control](../setup-network/create-private.md#network-access-control)
 - [FAQs for a basic validator node ](../../faq/faq-validator.md)

--- a/source/docs/casper/operators/setup/node-endpoints.md
+++ b/source/docs/casper/operators/setup/node-endpoints.md
@@ -1,54 +1,55 @@
 # Node Endpoints
 
-As specified in the [Network Requirements](./install-node.md#network-requirements), a Casper node uses specific ports to communicate with client applications and other nodes on the network. This document goes into more detail describing the default port settings and linking to related topics.
+As specified in the [Network Requirements](./install-node.md#network-requirements), a Casper node uses specific ports to communicate with client applications and other nodes on the network. Each node has an identity linked with an IP and port pair where the node is reachable. This address is also called an endpoint. The [Network Communication](../../concepts/design/p2p.md) page explains how the nodes connect and communicate securely. Node connections are established using TLS, presenting a client certificate to encrypt peer-to-peer communication.
 
-The [Network Communication](../../concepts/design/p2p.md) page explains how the nodes connect and communicate securely. Node connections are established using TLS, presenting a client certificate to encrypt peer-to-peer communication. Each node on the network has an identity linked with an IP and port pair where the node is reachable.
+This document describes in more detail a Casper node's default endpoints:
 
-## Default Port Settings
+- [Networking port: 35000](#35000)
+- [JSON-RPC HTTP server port: 7777](#7777)
+- [REST HTTP server port: 8888](#8888)
+- [SSE HTTP event stream server port: 9999](#9999)
 
-Node operators can modify a node's configuration options, including the port settings, by updating the [node's configuration file (config.toml)](../setup/basic-node-configuration/#config-file). An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
 
-The default port settings for Mainnet and Testnet are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
+## Default Endpoints
 
-### Port for networking
+Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](../setup/basic-node-configuration/#config-file), which is the node's configuration file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
 
-The configuration options for networking are under the `network` section of the `config.toml` file. The `bind_address` using port 35000 is the only port required to be open for the node to function. A Casper node taking part in the network should open connections to every other node it is aware of and has not blocked. 
+The default endpoints for Mainnet and Testnet are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
 
-If the networking port is closed, the node becomes unreachable, and the node won't be discoverable in the network. If this is a validator, it will face eviction. A read-only node will be considered to be offline.
+
+### Default networking port: 35000 {#35000}
+
+The configuration options for networking are under the `network` section of the `config.toml` file. The `bind_address` using port 35000 is the only port required to be open for the node to function. A Casper node taking part in the network should open connections to every other node it is aware of and has not blocked. In the `config.toml` file, the setting is:
 
 ```md
-# Address to bind to for listening.
-# If the port is set to 0, a random port will be used.
 bind_address = '0.0.0.0:35000'
 ```
 
-### Port for the JSON-RPC HTTP server
+If the networking port is closed, the node becomes unreachable, and the node won't be discoverable in the network. If this is a validator, it will face eviction. A read-only node will be considered to be offline.
 
-The configuration options for the JSON-RPC HTTP server are under the `rpc_server` section in the `config.toml` file. The `address` using port 7777 is the listening address for JSON-RPC HTTP server. DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc). Users would use this address to [interact with the network using CLI](../../developers/cli/). Validators would use this address to [bond](../becoming-a-validator/bonding/#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding/). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
+
+### Default JSON-RPC HTTP server port: 7777 {#7777}
+
+The configuration options for the JSON-RPC HTTP server are under the `rpc_server` section in the `config.toml` file. The `address` using port 7777 is the listening address for JSON-RPC HTTP server. 
 
 ```md
-# Listening address for JSON-RPC HTTP server. If the port is set to 0, a random port will be used.
-#
-# If the specified port cannot be bound to, a random port will be tried instead. If binding fails, the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
-#
-# The actual bound address will be reported via a log line if logging is enabled.
 address = '0.0.0.0:7777'
 ```
 
-### Port for the REST HTTP server
+DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc). Users would use this address to [interact with the network using CLI](../../developers/cli/). Validators would use this address to [bond](../becoming-a-validator/bonding/#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding/). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
 
-The configuration options for the JSON-RPC HTTP server are under the `rest_server` section in the `config.toml` file. The `address` listing port 8888 is the listening address for the REST HTTP server. Opening port 8888 is recommended but not required. This port allows the node to be included in the general network health metrics, thus giving a more accurate picture of overall network health. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
+
+### Default REST HTTP server port: 8888 {#8888}
+
+The configuration options for the JSON-RPC HTTP server are under the `rest_server` section in the `config.toml` file. The `address` listing port 8888 is the listening address for the REST HTTP server. 
 
 ```md
-# Listening address for REST HTTP server. If the port is set to 0, a random port will be used.
-#
-# If the specified port cannot be bound to, a random port will be tried instead. If binding fails, the REST HTTP server will not run, but the node will be otherwise unaffected.
-#
-# The actual bound address will be reported via a log line if logging is enabled.
 address = '0.0.0.0:8888'
 ```
 
-You may also use this port to [get a trusted hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration/#trusted-hash-for-synchronizing), [verify successful staging](https://docs.casperlabs.io/operators/setup/upgrade/#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining/#step-7-confirm-the-node-is-synchronized).
+Opening port 8888 is recommended but not required. This port allows the node to be included in the general network health metrics, thus giving a more accurate picture of overall network health. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
+
+One may use this port to [get a trusted hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration/#trusted-hash-for-synchronizing), [verify successful staging](https://docs.casperlabs.io/operators/setup/upgrade/#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining/#step-7-confirm-the-node-is-synchronized).
 
 For general health metrics, use this command:
 
@@ -86,18 +87,16 @@ To monitor local block height as well as RPC port status:
 watch -n 15 'curl -s http://<node_address>:8888/status | jq ".peers | length"; curl -s localhost:8888/status | jq .last_added_block_info; casper-client get-block'
 ```
 
-### Port for the SSE HTTP event stream server
+### Default SSE HTTP event stream server port: 9999 {#9999}
 
-The configuration options for the SSE HTTP event stream server are listed under the `event_stream_server` section of the `config.toml` file. The `address` listing port 9999 is the listening address for the SSE HTTP event stream server. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected. For details and useful commands, see [Monitoring and Consuming Events](../../developers/dapps/monitor-and-consume-events/).
+The configuration options for the SSE HTTP event stream server are listed under the `event_stream_server` section of the `config.toml` file. The `address` listing port 9999 is the listening address for the SSE HTTP event stream server. 
 
 ```md
-# Listening address for SSE HTTP event stream server. If the port is set to 0, a random port will be used.
-#
-# If the specified port cannot be bound to, a random port will be tried instead. If binding fails, the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
-#
-# The actual bound address will be reported via a log line if logging is enabled.
 address = '0.0.0.0:9999'
 ```
+
+If this port is closed, the requests coming to this port will not be served, but the node remains unaffected. For details and useful commands, see [Monitoring and Consuming Events](../../developers/dapps/monitor-and-consume-events/).
+
 
 ## Restricting Access for Private Networks
 

--- a/source/docs/casper/operators/setup/node-endpoints.md
+++ b/source/docs/casper/operators/setup/node-endpoints.md
@@ -9,9 +9,9 @@ This document describes in more detail a Casper node's default endpoints:
 - [REST HTTP server port: 8888](#8888)
 - [SSE HTTP event stream server port: 9999](#9999)
 
-Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](./basic-node-configuration.md#config-file), which is the node's configuration file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
+Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](./basic-node-configuration.md#config-file) file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
 
-The default endpoints for Mainnet and Testnet are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
+The default endpoints for Mainnet and Testnet are open by default and are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
 
 
 ## Default Networking Port: 35000 {#35000}

--- a/source/docs/casper/operators/setup/node-endpoints.md
+++ b/source/docs/casper/operators/setup/node-endpoints.md
@@ -9,7 +9,7 @@ This document describes in more detail a Casper node's default endpoints:
 - [REST HTTP server port: 8888](#8888)
 - [SSE HTTP event stream server port: 9999](#9999)
 
-Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](../setup/basic-node-configuration#config-file), which is the node's configuration file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
+Node operators can modify a node's configuration options, including the port settings, by updating the [node's config.toml](./basic-node-configuration.md#config-file), which is the node's configuration file. An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
 
 The default endpoints for Mainnet and Testnet are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
 
@@ -33,7 +33,7 @@ The configuration options for the JSON-RPC HTTP server are under the `rpc_server
 address = '0.0.0.0:7777'
 ```
 
-DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc). Users would use this address to [interact with the network using CLI](../../developers/cli/). Validators would use this address to [bond](../becoming-a-validator/bonding#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding/). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
+DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc/index.md). Users would use this address to [interact with the network using CLI](../../developers/cli/index.md). Validators would use this address to [bond](../becoming-a-validator/bonding.md#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding.md). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
 
 
 ## Default REST HTTP Server Port: 8888 {#8888}
@@ -46,7 +46,8 @@ address = '0.0.0.0:8888'
 
 Opening port 8888 is recommended but not required. This port allows the node to be included in the general network health metrics, thus giving a more accurate picture of overall network health. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
 
-One may use this port to [get a trusted hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration#trusted-hash-for-synchronizing), [verify successful staging](https://docs.casperlabs.io/operators/setup/upgrade#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining#step-7-confirm-the-node-is-synchronized).
+One may use this port to [get a trusted hash](./basic-node-configuration.md#trusted-hash-for-synchronizing), [verify successful staging](./upgrade.md#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](./joining.md#step-7-confirm-the-node-is-synchronized).
+
 
 ### Example usage
 
@@ -94,12 +95,12 @@ The configuration options for the SSE HTTP event stream server are listed under 
 address = '0.0.0.0:9999'
 ```
 
-If this port is closed, the requests coming to this port will not be served, but the node remains unaffected. For details and useful commands, see [Monitoring and Consuming Events](../../developers/dapps/monitor-and-consume-events/).
+If this port is closed, the requests coming to this port will not be served, but the node remains unaffected. For details and useful commands, see [Monitoring and Consuming Events](../../developers/dapps/monitor-and-consume-events.md).
 
 
 ## Restricting Access for Private Networks
 
-Any node can join Mainnet and Testnet and communicate with the nodes in the network. Private networks may wish to restrict access for new nodes joining the network as described [here](https://docs.casperlabs.io/operators/setup-network/create-private#network-access-control).
+Any node can join Mainnet and Testnet and communicate with the nodes in the network. Private networks may wish to restrict access for new nodes joining the network as described [here](../setup-network/create-private.md#network-access-control).
 
 
 ## Summary of Related Links
@@ -108,14 +109,14 @@ Here is a summary of the links mentioned on this page:
 
 - [Network requirements](./install-node.md#network-requirements)
 - [Network communication](../../concepts/design/p2p.md)
-- [The node configuration file](../setup/basic-node-configuration.md#config-file)
-- [Interacting with the Casper JSON-RPC API](../../developers/json-rpc)
-- [Interacting with the network using CLI](../../developers/cli/)
-- [Bonding](../becoming-a-validator/bonding#example-bonding-transaction) or [unbonding](../becoming-a-validator/unbonding/) as a validator
-- [Getting a trusted node hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration#trusted-hash-for-synchronizing)
-- [Verifying successful staging](https://docs.casperlabs.io/operators/setup/upgrade#verifying-successful-staging)
-- [Confirming that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining#step-7-confirm-the-node-is-synchronized)
-- [Monitoring and consuming events](../../developers/dapps/monitor-and-consume-events/)
+- [The node configuration file](./basic-node-configuration.md#config-file)
+- [Interacting with the Casper JSON-RPC API](../../developers/json-rpc/index.md)
+- [Interacting with the network using CLI](../../developers/cli/index.md)
+- [Bonding](../becoming-a-validator/bonding.md#example-bonding-transaction) or [unbonding](../becoming-a-validator/unbonding.md) as a validator
+- [Getting a trusted node hash](./basic-node-configuration.md#trusted-hash-for-synchronizing)
+- [Verifying successful staging](./upgrade.md#verifying-successful-staging)
+- [Confirming that the node is synchronized](./joining.md#step-7-confirm-the-node-is-synchronized)
+- [Monitoring and consuming events](../../developers/dapps/monitor-and-consume-events.md)
 - [Private network access control](../setup-network/create-private.md#network-access-control)
 - [FAQs for a basic validator node ](../../faq/faq-validator.md)
 - [External FAQs on Mainnet and Testnet validator node setup](https://docs.cspr.community/docs/faq-validator.html)

--- a/source/docs/casper/operators/setup/port-settings.md
+++ b/source/docs/casper/operators/setup/port-settings.md
@@ -1,0 +1,123 @@
+# A Node's Port Settings
+
+As specified in the [Network Requirements](./install-node.md#network-requirements), a Casper node uses specific ports to communicate with client applications and other nodes on the network. This document goes into more detail describing the default port settings and linking to related topics.
+
+The [Network Communication](../../concepts/design/p2p.md) page explains how the nodes connect and communicate securely. Node connections are established using TLS, presenting a client certificate to encrypt peer-to-peer communication. Each node on the network has an identity linked with an IP and port pair where the node is reachable.
+
+## Default Port Settings
+
+Node operators can modify a node's configuration options, including the port settings, by updating the [node's configuration file (config.toml)](../setup/basic-node-configuration/#config-file). An example configuration file can be found [here](https://github.com/casper-network/casper-protocol-release/blob/main/config/config-example.toml).
+
+The default port settings for Mainnet and Testnet are described below in more detail. If the node connects to a different network, the ports may differ depending on how the network was set up.
+
+### Port for networking
+
+The configuration options for networking are under the `network` section of the `config.toml` file. The `bind_address` using port 35000 is the only port required to be open for the node to function. A Casper node taking part in the network should open connections to every other node it is aware of and has not blocked. 
+
+If the networking port is closed, the node becomes unreachable, and the node won't be discoverable in the network. If this is a validator, it will face eviction. A read-only node will be considered to be offline.
+
+```md
+# Address to bind to for listening.
+# If the port is set to 0, a random port will be used.
+bind_address = '0.0.0.0:35000'
+```
+
+### Port for the JSON-RPC HTTP server
+
+The configuration options for the JSON-RPC HTTP server are under the `rpc_server` section in the `config.toml` file. The `address` using port 7777 is the listening address for JSON-RPC HTTP server. DApps would use this address to [interact with the Casper JSON-RPC API](../../developers/json-rpc). Users would use this address to [interact with the network using CLI](../../developers/cli/). Validators would use this address to [bond](../becoming-a-validator/bonding/#example-bonding-transaction) or [unbond](../becoming-a-validator/unbonding/). If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
+
+```md
+# Listening address for JSON-RPC HTTP server. If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead. If binding fails, the JSON-RPC HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:7777'
+```
+
+### Port for the REST HTTP server
+
+The configuration options for the JSON-RPC HTTP server are under the `rest_server` section in the `config.toml` file. The `address` listing port 8888 is the listening address for the REST HTTP server. Opening port 8888 is recommended but not required. This port allows the node to be included in the general network health metrics, thus giving a more accurate picture of overall network health. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected.
+
+```md
+# Listening address for REST HTTP server. If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead. If binding fails, the REST HTTP server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:8888'
+```
+
+You may also use this port to [get a trusted hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration/#trusted-hash-for-synchronizing), [verify successful staging](https://docs.casperlabs.io/operators/setup/upgrade/#verifying-successful-staging) during an upgrade, or to [confirm that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining/#step-7-confirm-the-node-is-synchronized).
+
+For general health metrics, use this command:
+
+```bash
+curl -s http://<node_address>:8888/metrics
+```
+
+You can check the node's status using this command:
+
+```bash
+curl -s http://<node_address>:8888/status
+```
+
+To get information about the next upgrade, use:
+
+```bash
+curl -s http://<node_address>:8888/status | jq .next_upgrade
+```
+
+To get information about the last added block, use:
+
+```bash
+curl -s http://<node_address>:8888/status | jq .last_added_block_info
+```
+
+To monitor the downloading of blocks to your node:
+
+```bash
+watch -n 15 'curl -s http://<node_address>:8888/status | jq ".peers | length"; curl -s localhost:8888/status | jq .last_added_block_info'
+```
+
+To monitor local block height as well as RPC port status:
+
+```bash
+watch -n 15 'curl -s http://<node_address>:8888/status | jq ".peers | length"; curl -s localhost:8888/status | jq .last_added_block_info; casper-client get-block'
+```
+
+### Port for the SSE HTTP event stream server
+
+The configuration options for the SSE HTTP event stream server are listed under the `event_stream_server` section of the `config.toml` file. The `address` listing port 9999 is the listening address for the SSE HTTP event stream server. If this port is closed, the requests coming to this port will not be served, but the node remains unaffected. For details and useful commands, see [Monitoring and Consuming Events](../../developers/dapps/monitor-and-consume-events/).
+
+```md
+# Listening address for SSE HTTP event stream server. If the port is set to 0, a random port will be used.
+#
+# If the specified port cannot be bound to, a random port will be tried instead. If binding fails, the SSE HTTP event stream server will not run, but the node will be otherwise unaffected.
+#
+# The actual bound address will be reported via a log line if logging is enabled.
+address = '0.0.0.0:9999'
+```
+
+## Restricting Access for Private Networks
+
+Any node can join Mainnet and Testnet since they are public Casper networks. Private networks may wish to restrict access for new nodes joining the network as described [here](https://docs.casperlabs.io/operators/setup-network/create-private/#network-access-control).
+
+
+## Summary of Related Links
+
+Here is a summary of the links mentioned on this page:
+
+- [Network requirements](./install-node.md#network-requirements)
+- [Network communication](../../concepts/design/p2p.md)
+- [The node configuration file](../setup/basic-node-configuration.md#config-file)
+- [Interacting with the Casper JSON-RPC API](../../developers/json-rpc)
+- [Interacting with the network using CLI](../../developers/cli/)
+- [Bonding](../becoming-a-validator/bonding/#example-bonding-transaction) or [unbonding](../becoming-a-validator/unbonding/) as a validator
+- [Getting a trusted node hash](https://docs.casperlabs.io/operators/setup/basic-node-configuration/#trusted-hash-for-synchronizing)
+- [Verifying successful staging](https://docs.casperlabs.io/operators/setup/upgrade/#verifying-successful-staging)
+- [Confirming that the node is synchronized](https://docs.casperlabs.io/operators/setup/joining/#step-7-confirm-the-node-is-synchronized)
+- [Monitoring and consuming events](../../developers/dapps/monitor-and-consume-events/)
+- [Private network access control](../setup-network/create-private.md#network-access-control)
+- [FAQs for a basic validator node ](../../faq/faq-validator.md)
+- [External FAQs on Mainnet and Testnet validator node setup](https://docs.cspr.community/docs/faq-validator.html)


### PR DESCRIPTION
### What does this PR fix/introduce?
Adding more details about a node's ports as requested in card #463 

### Additional context
In response to the requirements written by @devendran-m, I am adding a few notes:
1. the individual ports used by a node operator should be aware of: 35000, 7777, 8888, 9999
2. purpose and significance of each port in a node operation: addressed in this PR
3. the ports that are open by default: I pointed this out in this PR
4. what will happen if a port or ports are closed: addressed in this PR
5. how to leave the ports open and why it is important to leave them open: addressed in this PR
6. how to securely block them from external users/traffic: not addressed in this PR; this requirement is for private networks, from what I understand. However, I added a small section at the end to point readers to that part of the documentation.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
- SRE team: a review from either @cryofracture, @Jiuhong-casperlabs, or @euanmcf-cl, whoever has time. Please look at the explanations' correctness and let me know if you want to add anything else.
- @ACStoneCL

FYI: @sacherjj @devendran-m @darthsiroftardis 