### PR TITLE
87 - Document validator eviction

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -195,7 +195,12 @@ module.exports = {
             label: "Becoming a Validator",
             collapsible: true,
             collapsed: true,
-            items: ["operators/becoming-a-validator/bonding", "operators/becoming-a-validator/recovering", "operators/becoming-a-validator/unbonding"],
+            items: [
+                "operators/becoming-a-validator/bonding",
+                "operators/becoming-a-validator/recovering",
+                "operators/becoming-a-validator/inactive-vs-faulty",
+                "operators/becoming-a-validator/unbonding",
+            ],
         },
         {
             type: "category",

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -195,7 +195,7 @@ module.exports = {
             label: "Becoming a Validator",
             collapsible: true,
             collapsed: true,
-            items: ["operators/becoming-a-validator/bonding", "operators/becoming-a-validator/unbonding"],
+            items: ["operators/becoming-a-validator/bonding", "operators/becoming-a-validator/recovering", "operators/becoming-a-validator/unbonding"],
         },
         {
             type: "category",

--- a/source/docs/casper/operators/becoming-a-validator/bonding.md
+++ b/source/docs/casper/operators/becoming-a-validator/bonding.md
@@ -290,7 +290,7 @@ If a bid doesn't win a slot in the auction, it is too low. The resolution is to 
 
 ## Avoiding Ejection {#avoiding-ejection}
 
-To stay bonded and avoid ejection, each validator must keep the node running and in sync with the rest of the network. To recover from ejection, you will find more details [here](./recovering.md).
+To stay bonded and avoid ejection, each validator must keep their node running and in sync with the rest of the network. To recover from ejection, you will find more details [here](./recovering.md).
 
 ## Withdrawing a Bid {#withdrawing-a-bid}
 

--- a/source/docs/casper/operators/becoming-a-validator/bonding.md
+++ b/source/docs/casper/operators/becoming-a-validator/bonding.md
@@ -288,6 +288,10 @@ Note the `era_id` and the `validator_weights` in the response above. The current
 
 If a bid doesn't win a slot in the auction, it is too low. The resolution is to increase the bid amount. It is possible to submit additional bids, to increase the odds of winning a slot. It is also possible to encourage token holders to delegate stake to you for bonding.
 
+## Avoiding Ejection {#avoiding-ejection}
+
+To stay bonded and avoid ejection, each validator must keep the node running and in sync with the rest of the network. To recover from ejection, you will find more details [here](./recovering.md).
+
 ## Withdrawing a Bid {#withdrawing-a-bid}
 
 Follow the steps in [Unbonding](./unbonding.md) to withdraw a bid.

--- a/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
+++ b/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
@@ -8,7 +8,7 @@ In the last block of each era _N_, the consensus algorithm checks whether there 
 
 Similarly, the consensus algorithm checks whether any two messages from your validator node contradict each other. If that is the case, it gets marked as **faulty** in that block. Usually, that means:
 
-* If you got marked as "inactive", your node probably crashed or was offline for the duration of one whole era, i.e., at least from when the era began until the era's last block was proposed.
+* If you got marked as **inactive**, your node probably crashed or was offline for the duration of one whole era, i.e., at least from when the era began until the era's last block was proposed.
 * If you got marked as "faulty", you were probably running two nodes with the same validator key, or you restarted a node during the era and deleted its unit file.
 
 The auction contract is run when the block gets executed, as always at the end of the era. But if you were faulty or inactive, you are now evicted and don't participate in the auction anymore. You also don't receive any rewards for era _N_. The auction determines the validator set for the era after the next (because `auction_delay` is set to `1` on mainnet), i.e., for era _N + 2_. That means you will still be a validator (with a weight proportional to your stake) in the next era, _N + 1_, but after that, you will not be a validator anymore, and your slot will be given to the next highest bidder.

--- a/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
+++ b/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
@@ -6,7 +6,7 @@ This page describes the differences between a validator node being considered in
 
 In the last block of each era _N_, the consensus algorithm checks whether there are _any_ messages from your validator node in that era that have been received by most of the other validators. Only if there is no such message does your node get marked as **inactive** in that block.
 
-Similarly, the consensus algorithm checks whether any two messages from your validator node contradict each other. If that is the case, it gets marked as "faulty" in that block. Usually, that means:
+Similarly, the consensus algorithm checks whether any two messages from your validator node contradict each other. If that is the case, it gets marked as **faulty** in that block. Usually, that means:
 
 * If you got marked as "inactive", your node probably crashed or was offline for the duration of one whole era, i.e., at least from when the era began until the era's last block was proposed.
 * If you got marked as "faulty", you were probably running two nodes with the same validator key, or you restarted a node during the era and deleted its unit file.

--- a/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
+++ b/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
@@ -4,7 +4,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This page describes the differences between a validator node being considered inactive or faulty.
 
-In the last block of each era _N_, the consensus algorithm checks whether there are _any_ messages from your validator node in that era that have been received by most of the other validators. Only if there is no such message does your node get marked as "inactive" in that block.
+In the last block of each era _N_, the consensus algorithm checks whether there are _any_ messages from your validator node in that era that have been received by most of the other validators. Only if there is no such message does your node get marked as **inactive** in that block.
 
 Similarly, the consensus algorithm checks whether any two messages from your validator node contradict each other. If that is the case, it gets marked as "faulty" in that block. Usually, that means:
 

--- a/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
+++ b/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
@@ -9,7 +9,7 @@ In the last block of each era _N_, the consensus algorithm checks whether there 
 Similarly, the consensus algorithm checks whether any two messages from your validator node contradict each other. If that is the case, it gets marked as **faulty** in that block. Usually, that means:
 
 * If you got marked as **inactive**, your node probably crashed or was offline for the duration of one whole era, i.e., at least from when the era began until the era's last block was proposed.
-* If you got marked as "faulty", you were probably running two nodes with the same validator key, or you restarted a node during the era and deleted its unit file.
+* If you got marked as **faulty**, you were probably running two nodes with the same validator key, or you restarted a node during the era and deleted its unit file.
 
 The auction contract is run when the block gets executed, as always at the end of the era. But if you were faulty or inactive, you are now evicted and don't participate in the auction anymore. You also don't receive any rewards for era _N_. The auction determines the validator set for the era after the next (because `auction_delay` is set to `1` on mainnet), i.e., for era _N + 2_. That means you will still be a validator (with a weight proportional to your stake) in the next era, _N + 1_, but after that, you will not be a validator anymore, and your slot will be given to the next highest bidder.
 

--- a/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
+++ b/source/docs/casper/operators/becoming-a-validator/inactive-vs-faulty.md
@@ -1,0 +1,20 @@
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Inactive vs. Faulty Validator Nodes
+
+This page describes the differences between a validator node being considered inactive or faulty.
+
+In the last block of each era _N_, the consensus algorithm checks whether there are _any_ messages from your validator node in that era that have been received by most of the other validators. Only if there is no such message does your node get marked as "inactive" in that block.
+
+Similarly, the consensus algorithm checks whether any two messages from your validator node contradict each other. If that is the case, it gets marked as "faulty" in that block. Usually, that means:
+
+* If you got marked as "inactive", your node probably crashed or was offline for the duration of one whole era, i.e., at least from when the era began until the era's last block was proposed.
+* If you got marked as "faulty", you were probably running two nodes with the same validator key, or you restarted a node during the era and deleted its unit file.
+
+The auction contract is run when the block gets executed, as always at the end of the era. But if you were faulty or inactive, you are now evicted and don't participate in the auction anymore. You also don't receive any rewards for era _N_. The auction determines the validator set for the era after the next (because `auction_delay` is set to `1` on mainnet), i.e., for era _N + 2_. That means you will still be a validator (with a weight proportional to your stake) in the next era, _N + 1_, but after that, you will not be a validator anymore, and your slot will be given to the next highest bidder.
+
+And even in the next era, _N + 1_:
+* If you are inactive, you won't be assigned leader slots or be allowed to propose any blocks. Your node will only vote on other proposers' blocks if it returns online and can still receive rewards. But, even if it comes back online in era _N + 1_, it will get evicted for being offline in era _N_.
+* If you are faulty, all your messages will be ignored. You won't be able to propose blocks or vote for them and won't receive block rewards.
+
+In both cases, you remain evicted until you reactivate your bid, as described [here](./recovering.md).

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -22,7 +22,7 @@ For example, if we are in Era 100 and your node is invalid, your node will be ma
 
 If you were a previous validator and still exist on the [Validators Auction](https://cspr.live/validators-auction) tab but not in [Validators](https://cspr.live/validators), you may have been evicted or outbid. 
 
-### Detection using the Casper client
+### Detection using the Casper Client
 
 The entire auction information is returned with the `casper-client get-auction-info` command. It would help if you filtered this down to your public key. 
 

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -1,24 +1,26 @@
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-# Recovering from Validator Ejection
+# Recovering from Validator Eviction
 
-This topic discusses the steps a validator needs to take if it is ejected from the validator set:
+This topic discusses the steps a validator needs to take if it is evicted from the validator set:
 
-1. Detecting the ejection
+1. Detecting the eviction
 2. Correcting any underlying node issues
 3. Re-building the contracts for bonding
 4. Activating the bid
 5. Checking the bid
 
-## Detecting the Ejection
+The [Inactive vs. Faulty Validator Nodes](./inactive-vs-faulty.md) topic explains why a node would be evicted.
 
-The validator selection occurs at the end of an Era. Due to the bonding delay, this determines the Validators for the Era after the Era is about to start. When a validating node does not participate in consensus for some time, it will be marked invalid and ejected at the end of the next Era.
+## Detecting the Eviction
 
-For example, if we are in Era 100 and your node is invalid, your node will be marked for ejection to be removed at the start of Era 102. This is due to the bonding delay of 1 Era.
+The validator selection occurs at the end of an Era. Due to the bonding delay, this determines the Validators for the Era after the Era is about to start. When a validating node does not participate in consensus for some time, it will be marked invalid and evicted at the end of the next Era.
+
+For example, if we are in Era 100 and your node is invalid, your node will be marked for eviction to be removed at the start of Era 102. This is due to the bonding delay of 1 Era.
 
 ### Detection using CSPR.live
 
-If you were a previous validator and still exist on the [Validators Auction](https://cspr.live/validators-auction) tab but not in [Validators](https://cspr.live/validators), you may have been ejected or outbid. 
+If you were a previous validator and still exist on the [Validators Auction](https://cspr.live/validators-auction) tab but not in [Validators](https://cspr.live/validators), you may have been evicted or outbid. 
 
 ### Detection using the Casper client
 
@@ -36,7 +38,7 @@ Or, if you set up the node as described in this documentation, you can run anoth
 casper-client get-auction-info | jq --arg pk "$(cat /etc/casper/validator_keys/public_key_hex)" '.result.auction_state.bids[] | select( (.public_key | ascii_downcase) == ($pk | ascii_downcase) )'
 ```
 
-You know you were ejected if the `get-auction-info` command returned your bid showing an `inactive " field.
+You know you were evicted if the `get-auction-info` command returned your bid showing an `inactive " field. See the [Inactive vs. Faulty Validator Nodes](./inactive-vs-faulty.md) page for more information.
 
 If you receive a `parse error: Invalid numeric literal at`, this usually means that your RPC port is not up yet. Get your node in sync, and the RPC will come up. This should be working before you try to recover. Try running the following command to check the status of your RPC port:
 
@@ -44,18 +46,17 @@ If you receive a `parse error: Invalid numeric literal at`, this usually means t
 casper-client get-auction-info --node-address http://<peer-ip-address>:7777
 ```
 
-
 ## Correcting any Underlying Node Issues
 
-Before fixing the ejection, you need to correct whatever problem caused your node to be ejected.
-
-Stage missed upgrades, correct any node issues, and get your node in sync. If you cannot figure out the issue, ask for help in the node-tech-support channel on [Discord](https://discord.com/invite/Q38s3Vh).
+Before fixing the eviction, you need to correct the problem that caused your node to be evicted. Stage missed upgrades, correct any node issues, and get your node in sync.
 
 To check if your node is in sync, compare the current block height at [https://cspr.live/](https://cspr.live/) with the height from your node with:
 
 ```bash
 curl -s localhost:8888/status | jq .last_added_block_info
 ```
+
+If you cannot figure out the issue, ask for help in the node-tech-support channel on [Discord](https://discord.com/invite/Q38s3Vh).
 
 ## Re-building the Contracts for Bonding
 
@@ -93,6 +94,6 @@ Check that the deploy was successful with the `casper-client get-deploy <deploy_
 
 ## Checking the Bid Activation
 
-Once your deploy processes, you can [check your bid](recovering.md#detecting-the-ejection-using-the-casper-client) again. You should now see `"inactive": false` in the output.
+Once your deploy processes, you can [check your bid](recovering.md#detecting-the-eviction-using-the-casper-client) again. You should now see `"inactive": false` in the output.
 
 If you wait until the next Era starts, you should also see your public key as a future validator on the [Validators](https://cspr.live/validators) tab.

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -24,7 +24,7 @@ If you were a previous validator and still exist on the [Validators Auction](htt
 
 ### Detection using the Casper Client
 
-The entire auction information is returned with the `casper-client get-auction-info` command. It would help if you filtered this down to your public key. 
+All auction information is returned with the `casper-client get-auction-info` command. It would help if you filtered this down to your public key. 
 
 You can replace the <public_key> with your public key manually and run this command:
 

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -43,7 +43,7 @@ You know you were evicted if the `get-auction-info` command returned your bid sh
 If you receive a `parse error: Invalid numeric literal at`, this usually means that your RPC port is not up yet. Get your node in sync, and the RPC will come up. This should be working before you try to recover. Try running the following command to check the status of your RPC port:
 
 ```bash
-casper-client get-auction-info --node-address http://<peer-ip-address>:7777
+casper-client get-auction-info
 ```
 
 ## Correcting any Underlying Node Issues

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -2,7 +2,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Recovering from Validator Ejection
 
-This topic discusses the steps a validator needs to take if it is ejected from the validator set.
+This topic discusses the steps a validator needs to take if it is ejected from the validator set:
 
 1. Detecting the ejection
 2. Correcting any underlying node issues
@@ -10,35 +10,40 @@ This topic discusses the steps a validator needs to take if it is ejected from t
 4. Activating the bid
 5. Checking the bid
 
-The validator selection occurs at the end of an Era. Due to the bonding delay, this determines the Validators for the Era after the Era is about to start.
+## Detecting the Ejection
 
-When a validating node does not participate in consensus for some time, it will be marked invalid and ejected at the end of the next Era.
+The validator selection occurs at the end of an Era. Due to the bonding delay, this determines the Validators for the Era after the Era is about to start. When a validating node does not participate in consensus for some time, it will be marked invalid and ejected at the end of the next Era.
 
 For example, if we are in Era 100 and your node is invalid, your node will be marked for ejection to be removed at the start of Era 102. This is due to the bonding delay of 1 Era.
 
-## Detecting the Ejection using a Block Explorer
+### Detection using CSPR.live
 
 If you were a previous validator and still exist on the [Validators Auction](https://cspr.live/validators-auction) tab but not in [Validators](https://cspr.live/validators), you may have been ejected or outbid. 
 
-## Detecting the Ejection using the Casper Client
+### Detection using the Casper client
 
 The entire auction information is returned with the `casper-client get-auction-info` command. It would help if you filtered this down to your public key. 
 
 You can replace the <public_key> with your public key manually and run this command:
 
-`casper-client get-auction-info | jq '.result.auction_state.bids[] | select( .public_key == "<public_key>")'`
+```bash
+casper-client get-auction-info | jq '.result.auction_state.bids[] | select( .public_key == "<public_key>")'
+```
 
 Or, if you set up the node as described in this documentation, you can run another command that will automatically put in your public key:
 
-`casper-client get-auction-info | jq --arg pk "$(cat /etc/casper/validator_keys/public_key_hex)" '.result.auction_state.bids[] | select( (.public_key | ascii_downcase) == ($pk | ascii_downcase) )'`
+```bash
+casper-client get-auction-info | jq --arg pk "$(cat /etc/casper/validator_keys/public_key_hex)" '.result.auction_state.bids[] | select( (.public_key | ascii_downcase) == ($pk | ascii_downcase) )'
+```
 
 You know you were ejected if the `get-auction-info` command returned your bid showing an `inactive " field.
 
-If you receive a `parse error: Invalid numeric literal at`, try running the following command:
+If you receive a `parse error: Invalid numeric literal at`, this usually means that your RPC port is not up yet. Get your node in sync, and the RPC will come up. This should be working before you try to recover. Try running the following command to check the status of your RPC port:
 
-`casper-client get-auction-info --node-address http://<peer-ip-address>:7777`
+```bash
+casper-client get-auction-info --node-address http://<peer-ip-address>:7777
+```
 
-The reason for this error is usually that your RPC port is not up yet. Get your node in sync, and the RPC will come up. This should be working before you try to recover.
 
 ## Correcting any Underlying Node Issues
 
@@ -48,15 +53,17 @@ Stage missed upgrades, correct any node issues, and get your node in sync. If yo
 
 To check if your node is in sync, compare the current block height at [https://cspr.live/](https://cspr.live/) with the height from your node with:
 
-`curl -s localhost:8888/status | jq .last_added_block_info`
+```bash
+curl -s localhost:8888/status | jq .last_added_block_info
+```
 
 ## Re-building the Contracts for Bonding
 
 Next, you need to re-build the smart contracts required for [bonding](./bonding.md) by following these steps:
 
 1. Navigate to the `casper-node` directory 
-1. Check out the current default release branch
-1. Re-build the contracts required for bonding
+2. Check out the current default release branch
+3. Re-build the contracts required for bonding
 
 ```bash
 cd casper-node

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -38,7 +38,7 @@ Or, if you set up the node as described in this documentation, you can run anoth
 casper-client get-auction-info | jq --arg pk "$(cat /etc/casper/validator_keys/public_key_hex)" '.result.auction_state.bids[] | select( (.public_key | ascii_downcase) == ($pk | ascii_downcase) )'
 ```
 
-You know you were evicted if the `get-auction-info` command returned your bid showing an `inactive " field. See the [Inactive vs. Faulty Validator Nodes](./inactive-vs-faulty.md) page for more information.
+You know you were evicted if the `get-auction-info` command returned your bid showing an **inactive** field. See the [Inactive vs. Faulty Validator Nodes](./inactive-vs-faulty.md) page for more information.
 
 If you receive a `parse error: Invalid numeric literal at`, this usually means that your RPC port is not up yet. Get your node in sync, and the RPC will come up. This should be working before you try to recover. Try running the following command to check the status of your RPC port:
 

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -1,4 +1,91 @@
-# Recovering from Ejection
-
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
+# Recovering from Validator Ejection
+
+This topic discusses the steps a validator needs to take if it is ejected from the validator set.
+
+1. Detecting the ejection
+2. Correcting any underlying node issues
+3. Re-building the contracts for bonding
+4. Activating the bid
+5. Checking the bid
+
+The validator selection occurs at the end of an Era. Due to the bonding delay, this determines the Validators for the Era after the Era is about to start.
+
+When a validating node does not participate in consensus for some time, it will be marked invalid and ejected at the end of the next Era.
+
+For example, if we are in Era 100 and your node is invalid, your node will be marked for ejection to be removed at the start of Era 102. This is due to the bonding delay of 1 Era.
+
+## Detecting the Ejection using a Block Explorer
+
+If you were a previous validator and still exist on the [Validators Auction](https://cspr.live/validators-auction) tab but not in [Validators](https://cspr.live/validators), you may have been ejected or outbid. 
+
+## Detecting the Ejection using the Casper Client
+
+The entire auction information is returned with the `casper-client get-auction-info` command. It would help if you filtered this down to your public key. 
+
+You can replace the <public_key> with your public key manually and run this command:
+
+`casper-client get-auction-info | jq '.result.auction_state.bids[] | select( .public_key == "<public_key>")'`
+
+Or, if you set up the node as described in this documentation, you can run another command that will automatically put in your public key:
+
+`casper-client get-auction-info | jq --arg pk "$(cat /etc/casper/validator_keys/public_key_hex)" '.result.auction_state.bids[] | select( (.public_key | ascii_downcase) == ($pk | ascii_downcase) )'`
+
+You know you were ejected if the `get-auction-info` command returned your bid showing an `inactive " field.
+
+If you receive a `parse error: Invalid numeric literal at`, try running the following command:
+
+`casper-client get-auction-info --node-address http://<peer-ip-address>:7777`
+
+The reason for this error is usually that your RPC port is not up yet. Get your node in sync, and the RPC will come up. This should be working before you try to recover.
+
+## Correcting any Underlying Node Issues
+
+Before fixing the ejection, you need to correct whatever problem caused your node to be ejected.
+
+Stage missed upgrades, correct any node issues, and get your node in sync. If you cannot figure out the issue, ask for help in the node-tech-support channel on [Discord](https://discord.com/invite/Q38s3Vh).
+
+To check if your node is in sync, compare the current block height at [https://cspr.live/](https://cspr.live/) with the height from your node with:
+
+`curl -s localhost:8888/status | jq .last_added_block_info`
+
+## Re-building the Contracts for Bonding
+
+Next, you need to re-build the smart contracts required for [bonding](./bonding.md) by following these steps:
+
+1. Navigate to the `casper-node` directory 
+1. Check out the current default release branch
+1. Re-build the contracts required for bonding
+
+```bash
+cd casper-node
+git checkout <replace with current default branch>
+make setup-rs
+make build-client-contracts 
+```
+
+## Activating the Bid
+
+Once your node is in sync and ready to validate again, you must activate your invalid bid with the `activate_bid.wasm` contract. This should be part of the compiled contracts required to join the network in [Step 3: Build the Required Contracts](../setup/joining.md#step-3-build-the-required-contracts-step-3-build-contracts).
+
+Run the following transaction to re-activate your bid and rejoin the network. You will require a balance of at least 5 CSPR for this contract. 
+
+<!-- TODO We are seeing some variability with this gas cost as of 1.4.9 and will dive into this and try to get better docs on this. -->
+
+```bash
+casper-client put-deploy \
+--secret-key /etc/casper/validator_keys/secret_key.pem \
+--chain-name casper \
+--session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm" \
+--payment-amount 5000000000 \
+--session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"
+```
+
+Check that the deploy was successful with the `casper-client get-deploy <deploy_hash>` or by searching for the deploy hash on [https://cspr.live/](https://cspr.live/).
+
+## Checking the Bid Activation
+
+Once your deploy processes, you can [check your bid](recovering.md#detecting-the-ejection-using-the-casper-client) again. You should now see `"inactive": false` in the output.
+
+If you wait until the next Era starts, you should also see your public key as a future validator on the [Validators](https://cspr.live/validators) tab.

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -1,0 +1,4 @@
+# Recovering from Ejection
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+


### PR DESCRIPTION
### What does this PR fix/introduce?
I've taken the content from [here] (https://github.com/casper-network/casper-node/wiki/Recover-from-Validator-Ejection) and [here](https://github.com/casper-network/docs/issues/87#issuecomment-1119397525), edited it, and ran through the commands. Once we bring this content into the docs, we should point the wiki page to it.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL 

