### PR TITLE
Add "Global State" concept

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -1,10 +1,10 @@
 module.exports = {
     concepts: [
         "concepts/index",
-        //"concepts/intro-to-dapps", // NEW CONTENT WILL BE HERE
+        "concepts/intro-to-dapps", // NEW CONTENT WILL BE HERE
         "concepts/accounts-and-keys",
         "concepts/understanding-hash-types",
-        //"concepts/deploy-and-deploy-lifecycle", // NEW CONTENT WILL BE HERE
+        "concepts/deploy-and-deploy-lifecycle", // NEW CONTENT WILL BE HERE
         "concepts/global-state",
         //"concepts/smart-contracts", // NEW CONTENT WILL BE HERE
         "concepts/callstack",

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -5,7 +5,7 @@ module.exports = {
         "concepts/accounts-and-keys",
         "concepts/understanding-hash-types",
         //"concepts/deploy-and-deploy-lifecycle", // NEW CONTENT WILL BE HERE
-        //"concepts/global-state", // NEW CONTENT WILL BE HERE
+        "concepts/global-state",
         //"concepts/smart-contracts", // NEW CONTENT WILL BE HERE
         "concepts/callstack",
         "concepts/session-code",

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -1,10 +1,10 @@
 module.exports = {
     concepts: [
         "concepts/index",
-        "concepts/intro-to-dapps", // NEW CONTENT WILL BE HERE
+        "concepts/intro-to-dapps",
         "concepts/accounts-and-keys",
         "concepts/understanding-hash-types",
-        "concepts/deploy-and-deploy-lifecycle", // NEW CONTENT WILL BE HERE
+        "concepts/deploy-and-deploy-lifecycle",
         "concepts/global-state",
         //"concepts/smart-contracts", // NEW CONTENT WILL BE HERE
         "concepts/callstack",

--- a/source/docs/casper/concepts/global-state.md
+++ b/source/docs/casper/concepts/global-state.md
@@ -1,7 +1,37 @@
-# Global State
+# Global State {#global-state-head}
 
-:::caution
+## Introduction {#global-state-intro}
 
-This page is under development ⚒. Any contribution is welcome!
+The "global state" is the storage layer for the blockchain. All accounts, contracts, and any associated data they have are stored in the global state. Our global state has the semantics of a key-value store (with additional permissions logic since not all users can access all values in the same way).
+
+:::note
+Refer to [Keys and Permissions](./serialization-standard.md#serialization-standard-state-keys) for further information on keys.
+:::
+
+Each block causes changes to this global state because of the execution of the deploys it contains. For validators to efficiently judge the correctness of these changes, information about the new state needs to be communicated succinctly. Moreover, we need to communicate pieces of the global state to users while allowing them to verify the correctness of the parts they receive. For these reasons, the key-value store is implemented as a [Merkle trie](#global-state-trie).
+
+## Merkle trie structure {#global-state-trie}
+
+At a high level, a Merkle trie is a key-value store data structure that can be shared piece-wise in a verifiable way (via a construction called a Merkle proof). Each node is labeled by the hash of its data. Leaf nodes are labeled with the hash of their data. Non-leaf nodes are labeled with the hash of the labels of their child nodes.
+
+Our implementation of the trie has radix of 256, meaning each branch node can have up to 256 children. A path through the tree can be an array of bytes, and serialization directly links a key with a path through the tree as its associated value.
+
+Formally, a trie node is one of the following:
+
+-   a leaf, which includes a key and a value
+-   a branch, which has up to 256 `blake2b256` hashes, pointing to up to 256 other nodes in the trie (recall each node is labeled by its hash)
+-   an extension node, which includes a byte array (called the affix) and a `blake2b256` hash pointing to another node in the trie
+
+The purpose of the extension node is to allow path compression. Consider an example where all keys use the same first four bytes for values in the trie. In this case, it would be inefficient to traverse through four branch nodes where there is only one choice; instead, the root node of the trie could be an extension node with affix equal to those first four bytes and pointer to the first non-trivial branch node.
+
+The Rust implementation of Casper's trie can be found on GitHub:
+
+-   [Definition of the trie data structure](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie/mod.rs#L340)
+-   [Reading from the trie](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie_store/operations/mod.rs#L44)
+-   [Writing to the trie](https://github.com/casper-network/casper-node/blob/dev/execution_engine/src/storage/trie_store/operations/mod.rs#L845)
+
+:::note
+
+Conceptually, each block has its trie because the state changes based on the deploys it contains. For this reason, Casper's implementation has a notion of a `TrieStore`, which allows us to look up the root node for each trie.
 
 :::

--- a/source/docs/casper/concepts/global-state.md
+++ b/source/docs/casper/concepts/global-state.md
@@ -12,6 +12,8 @@ Each block causes changes to this global state because of the execution of the d
 
 ## Merkle trie structure {#global-state-trie}
 
+![Global State](/image/design/global-state.png)
+
 At a high level, a Merkle trie is a key-value store data structure that can be shared piece-wise in a verifiable way (via a construction called a Merkle proof). Each node is labeled by the hash of its data. Leaf nodes are labeled with the hash of their data. Non-leaf nodes are labeled with the hash of the labels of their child nodes.
 
 Our implementation of the trie has radix of 256, meaning each branch node can have up to 256 children. A path through the tree can be an array of bytes, and serialization directly links a key with a path through the tree as its associated value.

--- a/source/docs/casper/concepts/global-state.md
+++ b/source/docs/casper/concepts/global-state.md
@@ -2,7 +2,7 @@
 
 ## Introduction {#global-state-intro}
 
-The "global state" is the storage layer for the blockchain. All accounts, contracts, and any associated data they have are stored in the global state. Our global state has the semantics of a key-value store (with additional permissions logic since not all users can access all values in the same way).
+"Global state" is the storage layer for the blockchain. Storage of all accounts, contracts, and their associated data occurs in global state. Our global state has the semantics of a key-value store (with additional permissions logic since not all users can access all values in the same way).
 
 :::note
 Refer to [Keys and Permissions](./serialization-standard.md#serialization-standard-state-keys) for further information on keys.

--- a/source/docs/casper/concepts/index.md
+++ b/source/docs/casper/concepts/index.md
@@ -2,6 +2,7 @@
 
 - [Accounts and Cryptographic Keys](./accounts-and-keys.md)
 - [Understanding Hash Types](./understanding-hash-types.md)
+- [Understanding Global State](./global-state.md)
 - [Understanding Call Stacks](./callstack.md)
 - [Contracts and Session Code](./session-code.md)
 - [Dictionaries](./dictionaries.md)

--- a/source/docs/casper/operators/setup-network/create-private.md
+++ b/source/docs/casper/operators/setup-network/create-private.md
@@ -536,4 +536,4 @@ After this step, the private network would be ready for use.
 
 ## Setting up a Block Explorer
 
-Private and hybrid blockchains can find information on how to set up and operate our free version of a block explorer [here](https://github.com/casper-network/casper-blockexplorer).
+Private and hybrid blockchains can find information on how to set up and operate our free version of a block explorer [here](https://github.com/casper-network/casper-blockexplorer-frontend).

--- a/source/docs/casper/resources/build-on-casper/casper-open-source-software.md
+++ b/source/docs/casper/resources/build-on-casper/casper-open-source-software.md
@@ -10,7 +10,7 @@ Name | Description | Author | Language | License | Last Update Date | Type
 [Camel Casper](https://github.com/abahmanem/camel-casper) | [Apache Camel](https://camel.apache.org/) connector for the Casper Blockchain | M.Abahmane | Java | MIT license | 2022-03-26 | Tools
 [Casper .NET SDK](https://github.com/make-software/casper-net-sdk) | Casper .NET Client SDK to interact with Casper network nodes via RPC. | MAKE Software | .NET | Apache-2.0 license | 2022-04-19 | Client SDK
 [Casper Analytics App](https://github.com/caspercommunityio/casper-analytics-app) | Casper Analytics App. Built with Ionic. Easily exportable as iOS and Andriod App | caspercommunity.io | PHP | MIT license | 2022-01-20 | Tools
-[Casper C++ SDK](https://github.com/yusufketen/casper-cpp-sdk) | C++ library to interact with Casper network nodes via RPC | Yusuf Keten | C++ | Apache License 2.0 | 2022-09-13 | Client SDK
+[Casper C++ SDK](https://github.com/caspercppsdk/casper-cpp-sdk) | C++ library to interact with Casper network nodes via RPC | Yusuf Keten | C++ | Apache License 2.0 | 2022-09-13 | Client SDK
 [Casper Calculator](https://github.com/nad128668/casper-calculator) | Casper Earnings Calculator and Node Monitor | Charles Nguyen | JavaScript | MIT license | 2021-09-26 | Tools
 [Casper Contract Upgrade](https://github.com/casper-ecosystem/contract-upgrade-example) | Example contract to demonstrate the general way of upgrading a contract and the necessary steps | Casper Labs | Rust | Apache License 2.0 | 2022-06-21 | Example Contracts
 [Casper Dart SDK](https://github.com/cdolaz/casper_dart_sdk) | Casper Dart SDK is for interacting with the Casper Blockchain using RPC. | Temiltas | Dart | Apache License 2.0 | 2022-06-26 | Client SDK


### PR DESCRIPTION
### What does this PR introduce?

New page "Global State" under _Concepts_.

### Additional context

These changes are backported from the default branch of [docs-new](https://github.com/casper-network/docs-new) repository, so you can preview them [live here](https://docs-new.casper.network/concepts/global-state/).

Original PR authored by @caspermel: https://github.com/casper-network/docs-new/pull/160.

### Checklist

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [x] All links (internal and external) have been verified.
- [x] All technical procedures have been tested.
