### PR TITLE
Add "Smart Contracts" concept

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -6,7 +6,7 @@ module.exports = {
         "concepts/understanding-hash-types",
         //"concepts/deploy-and-deploy-lifecycle", // NEW CONTENT WILL BE HERE
         //"concepts/global-state", // NEW CONTENT WILL BE HERE
-        //"concepts/smart-contracts", // NEW CONTENT WILL BE HERE
+        "concepts/smart-contracts",
         "concepts/callstack",
         "concepts/session-code",
         "concepts/dictionaries",

--- a/source/docs/casper/concepts/index.md
+++ b/source/docs/casper/concepts/index.md
@@ -4,6 +4,7 @@
 - [Understanding Hash Types](./understanding-hash-types.md)
 - [Understanding Call Stacks](./callstack.md)
 - [Contracts and Session Code](./session-code.md)
+- [Smart Contracts](./smart-contracts.md)
 - [Dictionaries](./dictionaries.md)
 - [Design](./design/index.md)
 - [Economics](./economics/index.md)

--- a/source/docs/casper/concepts/smart-contracts.md
+++ b/source/docs/casper/concepts/smart-contracts.md
@@ -1,7 +1,18 @@
 # Smart Contracts
 
-:::caution
+## General/Intro
 
-This page is under development ⚒. Any contribution is welcome!
+A smart contract is a self-executing program that automates the actions required in an agreement or contract. Once completed, the transactions are trackable and irreversible. Smart contracts permit trusted transactions and agreements to be carried out among disparate, anonymous parties without the need for a central authority, legal system, or external enforcement mechanism.
 
-:::
+## Smart Contracts in Casper
+
+Smart Contracts in Casper are implemented in the Rust programming language, and compiled to [WASM](../concepts/glossary/W.md#webassembly) which is then installed and executed on-chain. You can find a guide to writing a simple smart contract [here](../developers/writing-onchain-code/simple-contract.md). Smart Contracts are installed to the chain as part of a [Deploy](../concepts/glossary/D.md#deploy).
+
+
+#### Further Reading
+
+- [Writing Contracts](../../casper/developers/writing-onchain-code/simple-contract.md)
+- [Sending a Deploy](../developers/dapps/sending-deploys.md)
+- [Installing Smart Contracts](../developers/cli/installing-contracts.md)
+- [Calling Smart Contracts](../developers/writing-onchain-code/calling-contracts.md)
+- [Calling Smart Contracts using the Casper Client](../developers/cli/calling-contracts.md)


### PR DESCRIPTION
### What does this PR introduce?

New page "Smart Contracts" under _Concepts_.

### Additional context

These changes are backported from the default branch of [docs-new](https://github.com/casper-network/docs-new) repository, so you can preview them [live here](https://docs-new.casper.network/concepts/smart-contracts/).

Original PR authored by @caspermel: https://github.com/casper-network/docs-new/pull/161.

### Checklist

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [x] All links (internal and external) have been verified.
- [x] All technical procedures have been tested.
