### PR TITLE
866 Reading and Writing to the Blockchain

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -278,6 +278,7 @@ module.exports = {
                         "resources/tutorials/advanced/two-party-multi-sig",
                         "resources/tutorials/advanced/return-values-tutorial",
                         "resources/tutorials/advanced/list-cspr",
+                        "resources/tutorials/advanced/storage-workflow",
                     ],
                 },
             ],

--- a/source/docs/casper/concepts/design/reading-and-writing-to-the-blockchain.md
+++ b/source/docs/casper/concepts/design/reading-and-writing-to-the-blockchain.md
@@ -18,6 +18,9 @@ The Casper API includes the following functions for reading and writing to globa
 
 * [put_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) - Stores the given `Key` under the given `name` in the current context's named keys
 * [get_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) - Returns the requested `NamedKey` from the current context
+* [storage::new_uref](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_uref.html) - Creates a new URef in the current context
+* [storage::write](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.write.html) - Writes a given value under a previously created URef
+* [storage::read](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.read.html) - Reads the value from a URef in global state
 * [dictionary_put](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_put.html) - Writes the given value under the given `dictionary_item_key`
 * [dictionary_get](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_get.html) - Retrieves the value stored under a `dictionary_item_key`
 

--- a/source/docs/casper/concepts/design/reading-and-writing-to-the-blockchain.md
+++ b/source/docs/casper/concepts/design/reading-and-writing-to-the-blockchain.md
@@ -1,31 +1,24 @@
 # Reading and Writing Data to the Blockchain
 
-Casper features several means of reading and writing data to global state, depending on user needs and complexity. Reading data from global state can be done off-chain or on-chain. Writing data requires on-chain interactions, due to the nature of the system.
+Casper features several means of reading and writing data to global state, depending on user needs and complexity. Reading data from global state can be done by dApps off-chain or by smart contracts on-chain. Writing data requires on-chain interactions due to the nature of the system. Storage in global state can be accomplished using [Dictionaries](../dictionaries.md) or [`NamedKeys`](../../developers/json-rpc/types_chain.md#namedkey).
 
-Storage on global state can be accomplished with [`NamedKeys`](../../developers/json-rpc/types_chain.md#namedkey), a form of [`URef`](./casper-design.md#uref-head/) or through the [use of dictionaries](../dictionaries.md).
+:::note
 
-Due to the nature of Casper's serialization standard, `NamedKeys` should be used sparingly for smaller subsets of data. Developers should use dictionaries for larger subsets of mapped structures.
+Due to the nature of Casper's serialization standard, `NamedKeys` should be used sparingly and only for small data sets. Developers should use dictionaries for larger mapped structures.
 
-## Casper JSON-RPC
+:::
 
-The [`query_global_state`](../../developers/json-rpc/json-rpc-informational.md#query-global-state) method available through the JSON-RPC allows users to read data from global state without performing on-chain actions.
+## Using the Casper JSON-RPC
 
-## Casper API
+The [`query_global_state`](../../developers/json-rpc/json-rpc-informational.md#query-global-state) method available through the JSON-RPC allows users to read data from global state without performing on-chain actions. For more details, see the [Querying a Casper Network](../../resources/tutorials/beginner/querying-network.md) tutorial.
 
-The Casper API includes the following for reading and writing to global state:
+## Using the Casper Rust API
 
-* [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html)
+The Casper API includes the following functions for reading and writing to global state:
 
-    Returns the requested `NamedKey` from the current context.
+* [put_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) - Stores the given `Key` under the given `name` in the current context's named keys
+* [get_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) - Returns the requested `NamedKey` from the current context
+* [dictionary_put](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_put.html) - Writes the given value under the given `dictionary_item_key`
+* [dictionary_get](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_get.html) - Retrieves the value stored under a `dictionary_item_key`
 
-* [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html)
-
-    Stores the given `Key` under the given `name` in the current context's named keys.
-
-* [`dictionary_get`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_get.html)
-
-    Retrieves the value stored under a `dictionary_item_key`.
-
-* [`dictionary_put`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_put.html)
-
-    Writes the given value under the given `dictionary_item_key`.
+For more details, see the [Reading and Writing to Global State using Rust](../../resources/tutorials/advanced/storage-workflow.md) tutorial.

--- a/source/docs/casper/resources/tutorials/advanced/index.md
+++ b/source/docs/casper/resources/tutorials/advanced/index.md
@@ -4,3 +4,4 @@
 - [Two-Party Multi-Signature Deploys](./two-party-multi-sig.md)
 - [Interacting with Runtime Return Values](./return-values-tutorial.md)
 - [Listing CSPR on Your Exchange](./list-cspr.md)
+- [Reading and Writing to Global State using Rust](./storage-workflow.md)

--- a/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
+++ b/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
@@ -4,19 +4,23 @@ The following examples outline methods to read and write data to global state on
 
 Essentially, there are three means of storage within the Casper ecosystem. These consist of `runtime::put_key`, `storage::write` and `storage::dictionary_put`. These stored values can be read using `runtime::get_key`, `storage::read` and `storage::dictionary_get`, respectively. Each method stores data in a specific way, and it's important to understand the differences.
 
-* `runtime::put_key` / `runtime::get_key`
+## Description of Functions
+
+### `runtime::put_key` / `runtime::get_key`
 
 Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](./concepts/serialization-standard/#serialization-standard-state-keys) and [Serialization Standard](./serialization-standard/#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
 
-* `storage::write` / `storage::read`
+### `storage::write` / `storage::read`
 
 [`storage::write`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.write.html) writes a given value to a previously established URef (created using [`storage::new_uref`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_uref.html)). Unlike `put_key`, this value is not one of the `Key` types listed above, but rather any of the potential [`CLType`](https://docs.casperlabs.io/developers/json-rpc/types_cl/#cltype)s as outlined.
 
-* `storage:dictionary_put` / `storage::dictionary_get`
+### `storage:dictionary_put` / `storage::dictionary_get`
 
 For most data storage needs on a Casper network, dictionaries are more efficient and provide lower gas costs than `NamedKeys`. Each dictionary item exists independently, sharing a single dictionary seed URef for reference purposes.
 
 More information on dictionaries can be found on the [Reading and Writing to Dictionaries](./concepts/dictionaries/) page.
+
+## Example Code
 
 ### Example of `put_key` and `storage::write`
 

--- a/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
+++ b/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
@@ -8,7 +8,7 @@ Essentially, there are three means of storage within the Casper ecosystem. These
 
 ### `runtime::put_key` / `runtime::get_key`
 
-Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](./concepts/serialization-standard/#serialization-standard-state-keys) and [Serialization Standard](./serialization-standard/#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
+Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](../../..concepts/serialization-standard/#serialization-standard-state-keys) and [Serialization Standard](../../../concepts/serialization-standard.md#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
 
 ### `storage::write` / `storage::read`
 
@@ -18,7 +18,7 @@ Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/cont
 
 For most data storage needs on a Casper network, dictionaries are more efficient and provide lower gas costs than `NamedKeys`. Each dictionary item exists independently, sharing a single dictionary seed URef for reference purposes.
 
-More information on dictionaries can be found on the [Reading and Writing to Dictionaries](./concepts/dictionaries/) page.
+More information on dictionaries can be found on the [Reading and Writing to Dictionaries](../../../concepts/dictionaries.md) page.
 
 ## Example Code
 
@@ -75,7 +75,7 @@ This example compliments the code sample above by retrieving the `CONTRACT_HASH`
 
 ### Example of `dictionary_put` and `dictionary_get`
 
-Examples of dictionary usage for storage can be found in the *Writing Entries into a Dictionary* section of [Reading and Writing to Dictionaries](./concepts/dictionaries/#writing-entries-into-a-dictionary).
+Examples of dictionary usage for storage can be found in the *Writing Entries into a Dictionary* section of [Reading and Writing to Dictionaries](../../../concepts/dictionaries.md#writing-entries-into-a-dictionary).
 
 ## Additional Functions for Named Keys
 

--- a/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
+++ b/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
@@ -8,7 +8,7 @@ Essentially, there are three means of storage within the Casper ecosystem. These
 
 ### `runtime::put_key` / `runtime::get_key`
 
-Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](../..concepts/serialization-standard/#serialization-standard-state-keys) and [Serialization Standard](../../concepts/serialization-standard.md#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
+Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](../../../concepts/serialization-standard.md#serialization-standard-state-keys) and [Serialization Standard](../../../concepts/serialization-standard.md#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
 
 ### `storage::write` / `storage::read`
 
@@ -18,7 +18,7 @@ Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/cont
 
 For most data storage needs on a Casper network, dictionaries are more efficient and provide lower gas costs than `NamedKeys`. Each dictionary item exists independently, sharing a single dictionary seed URef for reference purposes.
 
-More information on dictionaries can be found on the [Reading and Writing to Dictionaries](../../concepts/dictionaries.md) page.
+More information on dictionaries can be found on the [Reading and Writing to Dictionaries](../../../concepts/dictionaries.md) page.
 
 ## Example Code
 
@@ -75,7 +75,7 @@ This example compliments the code sample above by retrieving the `CONTRACT_HASH`
 
 ### Example of `dictionary_put` and `dictionary_get`
 
-Examples of dictionary usage for storage can be found in the *Writing Entries into a Dictionary* section of [Reading and Writing to Dictionaries](../../concepts/dictionaries.md#writing-entries-into-a-dictionary).
+Examples of dictionary usage for storage can be found in the *Writing Entries into a Dictionary* section of [Reading and Writing to Dictionaries](../../../concepts/dictionaries.md#writing-entries-into-a-dictionary).
 
 ## Additional Functions for Named Keys
 

--- a/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
+++ b/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
@@ -8,7 +8,7 @@ Essentially, there are three means of storage within the Casper ecosystem. These
 
 ### `runtime::put_key` / `runtime::get_key`
 
-Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](../../..concepts/serialization-standard/#serialization-standard-state-keys) and [Serialization Standard](../../../concepts/serialization-standard.md#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
+Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](../..concepts/serialization-standard/#serialization-standard-state-keys) and [Serialization Standard](../../concepts/serialization-standard.md#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
 
 ### `storage::write` / `storage::read`
 
@@ -18,7 +18,7 @@ Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/cont
 
 For most data storage needs on a Casper network, dictionaries are more efficient and provide lower gas costs than `NamedKeys`. Each dictionary item exists independently, sharing a single dictionary seed URef for reference purposes.
 
-More information on dictionaries can be found on the [Reading and Writing to Dictionaries](../../../concepts/dictionaries.md) page.
+More information on dictionaries can be found on the [Reading and Writing to Dictionaries](../../concepts/dictionaries.md) page.
 
 ## Example Code
 
@@ -75,7 +75,7 @@ This example compliments the code sample above by retrieving the `CONTRACT_HASH`
 
 ### Example of `dictionary_put` and `dictionary_get`
 
-Examples of dictionary usage for storage can be found in the *Writing Entries into a Dictionary* section of [Reading and Writing to Dictionaries](../../../concepts/dictionaries.md#writing-entries-into-a-dictionary).
+Examples of dictionary usage for storage can be found in the *Writing Entries into a Dictionary* section of [Reading and Writing to Dictionaries](../../concepts/dictionaries.md#writing-entries-into-a-dictionary).
 
 ## Additional Functions for Named Keys
 

--- a/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
+++ b/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
@@ -1,0 +1,106 @@
+# Reading and Writing to Global State using Rust
+
+The following examples outline methods to read and write data to global state on a Casper network using the Rust programming language.
+
+Essentially, there are three means of storage within the Casper ecosystem. These consist of `runtime::put_key`, `storage::write` and `storage::dictionary_put`. These stored values can be read using `runtime::get_key`, `storage::read` and `storage::dictionary_get`, respectively. Each method stores data in a specific way, and it's important to understand the differences.
+
+* `runtime::put_key` / `runtime::get_key`
+
+Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.put_key.html) and [`get_key`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.get_key.html) functions refer to Casper `Key` types as outlined in both the [Understanding Hash Types](./concepts/serialization-standard/#serialization-standard-state-keys) and [Serialization Standard](./serialization-standard/#serialization-standard-state-keys). These keys are stored within a URef as a `Key` type.
+
+* `storage::write` / `storage::read`
+
+[`storage::write`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.write.html) writes a given value to a previously established URef (created using [`storage::new_uref`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_uref.html)). Unlike `put_key`, this value is not one of the `Key` types listed above, but rather any of the potential [`CLType`](https://docs.casperlabs.io/developers/json-rpc/types_cl/#cltype)s as outlined.
+
+* `storage:dictionary_put` / `storage::dictionary_get`
+
+
+
+### Example of `put_key`
+
+This sample code creates a new contract and stores the contract version in global state using the `runtime::put_key` function. The user provides a runtime argument `my_stored_value`, which is stored in a URef via the `storage::new_uref` function.
+
+If the stored value already exists, the `storage::write` function overwrites the stored value with the new runtime argument. The URef is then stored in the current context as a `NamedKey` titled `MY_STORED_VALUE_UREF`
+```rust
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let (contract_hash, _version) = storage::new_contract(
+        EntryPoints::new(),
+        None,
+        Some(CONTRACT_PACKAGE.to_string()),
+        Some(ACCESS_KEY.to_string()),
+    );
+
+    // Store contract hash under a Named key CONTRACT_HASH
+    runtime::put_key(CONTRACT_HASH, contract_hash.into());
+
+    // Store !MY_STORED_VALUE (false) as init value/type into a new URef
+    let my_value_uref = storage::new_uref(!MY_STORED_VALUE);
+
+    // Store MY_STORED_VALUE (true) under the URef value
+    storage::write(my_value_uref, MY_STORED_VALUE);
+
+    // Store the Uref under a Named key MY_STORED_VALUE_UREF
+    let my_value_key: Key = my_value_uref.into();
+    runtime::put_key(MY_STORED_VALUE_UREF, my_value_key);
+}
+
+```
+
+### Example of `get_key`
+
+In this example, a package hash is stored in global state and is retrieved using the `get_key` function.
+
+```rust
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let _contract_hash: ContractHash = runtime::get_key(CONTRACT_HASH)
+        .unwrap_or_revert()
+        .into_hash()
+        .map(ContractHash::new)
+        .unwrap_or_revert();
+
+    let my_stored_value_uref: URef = runtime::get_key(MY_STORED_VALUE_UREF)
+        .unwrap_or_revert()
+        .into_uref()
+        .map(|uref| URef::new(uref.addr(), AccessRights::default()))
+        .unwrap_or_revert()
+        .into_read();
+
+    let my_actual_stored_value: bool = storage::read(my_stored_value_uref).unwrap().unwrap();
+
+    // Compare my stored value with runtime arg
+    let my_expected_stored_value: bool = runtime::get_named_arg(ARG_MY_STORED_VALUE);
+    if my_actual_stored_value != my_expected_stored_value {
+        // We revert if my stored value is not what is expected from caller argument
+        runtime::revert(UserError::StoredValueError);
+    }
+
+    runtime::print(&my_actual_stored_value.to_string());
+}
+
+```
+
+### Example of `dictionary_put` and `dictionary_get`
+
+Examples of dictionary usage for storage can be found in the *Writing Entries into a Dictionary* section of [Reading and Writing to Dictionaries](./concepts/dictionaries/#writing-entries-into-a-dictionary).
+
+## Additional Functions for Named Keys
+
+The following functions might also be of interest for working with named keys:
+
+* [list_named_keys](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.list_named_keys.html) - Returns the named keys of the current context
+* [has_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.has_key.html) - Returns true if the key exists in the current context’s named keys
+* [remove_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.remove_key.html) - Removes the requested `NamedKey` from the current context
+
+### Example of `list_named_keys`
+
+
+
+### Example of `has_key`
+
+
+
+### Example of `remove_key`

--- a/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
+++ b/source/docs/casper/resources/tutorials/advanced/storage-workflow.md
@@ -14,13 +14,18 @@ Both the [`put_key`](https://docs.rs/casper-contract/latest/casper_contract/cont
 
 * `storage:dictionary_put` / `storage::dictionary_get`
 
+For most data storage needs on a Casper network, dictionaries are more efficient and provide lower gas costs than `NamedKeys`. Each dictionary item exists independently, sharing a single dictionary seed URef for reference purposes.
 
+More information on dictionaries can be found on the [Reading and Writing to Dictionaries](./concepts/dictionaries/) page.
 
-### Example of `put_key`
+### Example of `put_key` and `storage::write`
 
 This sample code creates a new contract and stores the contract version in global state using the `runtime::put_key` function. The user provides a runtime argument `my_stored_value`, which is stored in a URef via the `storage::new_uref` function.
 
-If the stored value already exists, the `storage::write` function overwrites the stored value with the new runtime argument. The URef is then stored in the current context as a `NamedKey` titled `MY_STORED_VALUE_UREF`
+If the stored value already exists, the `storage::write` function overwrites the stored value with the new runtime argument. The URef is then stored in the current context as a `NamedKey` titled `MY_STORED_VALUE_UREF`.
+
+Full example code can be found [here](https://github.com/casper-ecosystem/tutorials-example-wasm/blob/dev/storage-example/contract/src/main.rs).
+
 ```rust
 
 #[no_mangle]
@@ -48,9 +53,11 @@ pub extern "C" fn call() {
 
 ```
 
-### Example of `get_key`
+### Example of `get_key` and `storage::read`
 
-In this example, a package hash is stored in global state and is retrieved using the `get_key` function.
+This example compliments the code sample above by retrieving the `CONTRACT_HASH` using the `get_key` function, before comparing a provided runtime argument against the previously stored `MY_STORED_VALUE_UREF` using `storage::read`.
+
+Full example code can be found [here](https://github.com/casper-ecosystem/tutorials-example-wasm/blob/dev/storage-example/client/named_key_session/src/main.rs).
 
 ```rust
 
@@ -94,13 +101,3 @@ The following functions might also be of interest for working with named keys:
 * [list_named_keys](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.list_named_keys.html) - Returns the named keys of the current context
 * [has_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.has_key.html) - Returns true if the key exists in the current context’s named keys
 * [remove_key](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.remove_key.html) - Removes the requested `NamedKey` from the current context
-
-### Example of `list_named_keys`
-
-
-
-### Example of `has_key`
-
-
-
-### Example of `remove_key`


### PR DESCRIPTION
### What does this PR fix/introduce?
Expanded information on the methods of storage for Casper networks.

Closes #866 

### Additional context
Includes work previously done by @ipopescu to refine the existing [document](https://docs.casperlabs.io/concepts/design/reading-and-writing-to-the-blockchain/) as well as a new document "Reading and Writing to Global State using Rust" that outlines more specifics.

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casperlabs.io/workflow/contribute/).

### Reviewers
Writing: @ipopescu / Tech: @gRoussac 
FYI: @darthsiroftardis 
