### PR TITLE
Bradjohnl/dev portal migration remainder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Welcome to the documentation website for the [Casper Network](https://casper.network/). The documentation lives at this address: https://docs.casperlabs.io/.
+Welcome to the documentation website for the [Casper Network](https://casper.network/). The documentation lives at this address: https://docs.casper.network/.
 
 ## Setup
 

--- a/config/site.config.js
+++ b/config/site.config.js
@@ -3,7 +3,7 @@ const { cdns, customScripts } = require("./script.config");
 module.exports = {
     title: "Casper",
     tagline: "The best search experience for docs, integrated in minutes, for free",
-    url: "https://docs.casperlabs.io/",
+    url: "https://docs.casper.network/",
     baseUrl: "/docs/",
     trailingSlash: true,
     onBrokenLinks: "throw",

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,0 @@
-User-agent: *
-Disallow: /CNAME
-Disallow: /opensearch.xml
-Disallow: /.nojekyll
-Sitemap: https://docs.casperlabs.io/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Disallow: /CNAME
+Disallow: /opensearch.xml
+Disallow: /.nojekyll
+Sitemap: https://docs.casperlabs.io/sitemap.xml

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -118,7 +118,7 @@ RPC: Ready
 ● casper-node-launcher.service - Casper Node Launcher
    Loaded: loaded (/lib/systemd/system/casper-node-launcher.service; enabled; vendor preset: enabled)
    Active: active (running) since Wed 2022-03-16 21:08:50 UTC; 4 days ago
-     Docs: https://docs.casperlabs.io
+     Docs: https://docs.casper.network
  Main PID: 2934 (casper-node-lau)
     Tasks: 12 (limit: 4915)
    CGroup: /system.slice/casper-node-launcher.service

--- a/src/html/footer.html
+++ b/src/html/footer.html
@@ -4,7 +4,7 @@
             <li><a href="https://arxiv.org/pdf/2101.02159.pdf" target="_blank" rel="noopener">White Paper</a></li>
             <li>
                 <a
-                    href="https://docs.casperlabs.io"
+                    href="https://docs.casper.network"
                     target="_blank"
                     rel="noopener"
                 >


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR fixes remaining old URL references and updates them to the new documentation site URL. Additionally, it removes a duplicated robots.txt file. 

**Commit [243479d](https://github.com/casper-network/docs/commit/243479d67316ca750433ee0094d665e0f812cf63): fix: replace old url in the footer**

Updated the footer link from https://docs.casperlabs.io to https://docs.casper.network.

**Commit [dfb6d4b](https://github.com/casper-network/docs/commit/dfb6d4bc465169d3e821f74096b5db6585e2cb40): docs: replace link in install-node example**

Replaced the link in the install-node.md example from https://docs.casperlabs.io to https://docs.casper.network.

**Commit [10961fc](https://github.com/casper-network/docs/commit/10961fcda1e35540d2387751499ab731bc6cc95a): fix: replace old url in site.config.js**

Updated the site.config.js URL from https://docs.casperlabs.io/ to https://docs.casper.network/.

**Commit [deeef2b](https://github.com/casper-network/docs/commit/deeef2b599e4f7f315b140d5e2a7c5b7badaf952): chore: remove duplicated robots.txt**

Removed the duplicated robots.txt file.

**Commit [4568cec](https://github.com/casper-network/docs/commit/4568ceccef99dc954069176764dd2f8aab86034b): docs: update link in README**

Updated the documentation site link in the README.md file from https://docs.casperlabs.io/ to https://docs.casper.network/.

### Additional context
With the migration of the docs, some URLs still needed to be updated to reflect the new documentation site. This PR addresses those changes. 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [N/A] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [ ] All external links have been verified with `yarn run check:externals`.
  **Command still not working for me**
- [N/A] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [N/A] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).
- [N/A] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
@ipopescu @ACStoneCL 
