### PR TITLE
Updates post PR 980

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -18,9 +18,9 @@ module.exports = {
             collapsed: true,
             items: [
                 "concepts/design/index",
+                "concepts/design/casper-design",
                 "concepts/design/p2p",
                 "concepts/design/highway",
-                "concepts/design/casper-design",
                 "concepts/design/reading-and-writing-to-the-blockchain",
             ],
         },

--- a/source/docs/casper/concepts/design/casper-design.md
+++ b/source/docs/casper/concepts/design/casper-design.md
@@ -35,6 +35,7 @@ Although the network measures costs in `Gas`, payment for computation occurs in 
 Please note that Casper will not refund any amount of unused gas.
 
 This decision is taken to incentivize the [Casper Runtime Economics](../economics/runtime.md#runtime-economics) by efficiently allocating the computational resources. The [consensus-before-execution model](../economics/runtime.md#consensus-before-execution-basics-of-payment) implements the mechanism to encourage the optimized gas consumption from users and to prevent the overuse of block space by poorly handled deploys.
+
 :::
 
 ### The Casper Network Runtime {#execution-semantics-runtime}

--- a/source/docs/casper/concepts/design/index.md
+++ b/source/docs/casper/concepts/design/index.md
@@ -12,8 +12,6 @@ slug: /design
     -   [Gossiping](./p2p.md#communications-gossiping)
     -   [Requesting missing data](./p2p.md#requesting-missing-data)
     -   [Node Discovery](./p2p.md#node-discovery)
--   [Global State](./casper-design.md#global-state-head)
-    -   [Merkle trie structure](./casper-design.md#global-state-trie)
 -   [Execution Semantics](./casper-design.md#execution-semantics-head)
     -   [Measuring computational work](./casper-design.md#execution-semantics-gas)
     -   [Deploys](./casper-design.md#execution-semantics-deploys)

--- a/source/docs/casper/concepts/global-state.md
+++ b/source/docs/casper/concepts/global-state.md
@@ -2,21 +2,21 @@
 
 ## Introduction {#global-state-intro}
 
-"Global state" is the storage layer for the blockchain. Storage of all accounts, contracts, and their associated data occurs in global state. Our global state has the semantics of a key-value store (with additional permissions logic since not all users can access all values in the same way).
+The storage layer for the Casper blockchain is called *global state* and has the semantics of a key-value store with additional permissions logic. All accounts, contracts, and any associated data they have are stored in global state. Not all users can access all data, so permissions need to be set accordingly.
 
 :::note
 Refer to [Keys and Permissions](./serialization-standard.md#serialization-standard-state-keys) for further information on keys.
 :::
 
-Each block causes changes to this global state because of the execution of the deploys it contains. For validators to efficiently judge the correctness of these changes, information about the new state needs to be communicated succinctly. Moreover, we need to communicate pieces of the global state to users while allowing them to verify the correctness of the parts they receive. For these reasons, the key-value store is implemented as a [Merkle trie](#global-state-trie).
+Each finalized block causes changes to the network's global state because of the execution of the deploys it contains. For validators to efficiently judge the correctness of these changes, information about the new state needs to be communicated succinctly. Moreover, the network must communicate portions of global state to users while allowing them to verify the correctness of the parts they receive. For these reasons, the key-value store is implemented as a [Merkle trie](#global-state-trie).
 
-## Merkle trie structure {#global-state-trie}
+## Merkle Trie Structure {#global-state-trie}
 
 ![Global State](/image/design/global-state.png)
 
 At a high level, a Merkle trie is a key-value store data structure that can be shared piece-wise in a verifiable way (via a construction called a Merkle proof). Each node is labeled by the hash of its data. Leaf nodes are labeled with the hash of their data. Non-leaf nodes are labeled with the hash of the labels of their child nodes.
 
-Our implementation of the trie has radix of 256, meaning each branch node can have up to 256 children. A path through the tree can be an array of bytes, and serialization directly links a key with a path through the tree as its associated value.
+Casper's implementation of the trie has radix of 256, meaning each branch node can have up to 256 children. A path through the tree can be an array of bytes, and serialization directly links a key with a path through the tree as its associated value.
 
 Formally, a trie node is one of the following:
 
@@ -24,13 +24,13 @@ Formally, a trie node is one of the following:
 -   a branch, which has up to 256 `blake2b256` hashes, pointing to up to 256 other nodes in the trie (recall each node is labeled by its hash)
 -   an extension node, which includes a byte array (called the affix) and a `blake2b256` hash pointing to another node in the trie
 
-The purpose of the extension node is to allow path compression. Consider an example where all keys use the same first four bytes for values in the trie. In this case, it would be inefficient to traverse through four branch nodes where there is only one choice; instead, the root node of the trie could be an extension node with affix equal to those first four bytes and pointer to the first non-trivial branch node.
+The purpose of the extension node is to allow path compression. Consider an example where all keys use the same first four bytes for values in the trie. In this case, it would be inefficient to traverse through four branch nodes where there is only one choice; instead, the root node of the trie could be an extension node with an affix equal to those first four bytes and a pointer to the first non-trivial branch node.
 
 The Rust implementation of Casper's trie can be found on GitHub:
 
--   [Definition of the trie data structure](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie/mod.rs#L340)
--   [Reading from the trie](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie_store/operations/mod.rs#L44)
--   [Writing to the trie](https://github.com/casper-network/casper-node/blob/dev/execution_engine/src/storage/trie_store/operations/mod.rs#L845)
+-   [Definition of the trie data structure](https://github.com/casper-network/casper-node/blob/latest/execution_engine/src/storage/trie/mod.rs#L340)
+-   [Reading from the trie](https://github.com/casper-network/casper-node/blob/latest/execution_engine/src/storage/trie_store/operations/mod.rs#L44)
+-   [Writing to the trie](https://github.com/casper-network/casper-node/blob/latest/execution_engine/src/storage/trie_store/operations/mod.rs#L845)
 
 :::note
 

--- a/source/docs/casper/concepts/global-state.md
+++ b/source/docs/casper/concepts/global-state.md
@@ -30,9 +30,9 @@ The purpose of the extension node is to allow path compression. Consider an exam
 
 The Rust implementation of Casper's trie can be found on GitHub:
 
--   [Definition of the trie data structure](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie/mod.rs#L340)
--   [Reading from the trie](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie_store/operations/mod.rs#L44)
--   [Writing to the trie](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie_store/operations/mod.rs#L845)
+-   [Definition of the trie data structure](https://github.com/casper-network/casper-node/blob/c8db6a737c41dcdfb86ed6bed16d24284cf5c3b9/execution_engine/src/storage/trie/mod.rs#L340)
+-   [Reading from the trie](https://github.com/casper-network/casper-node/blob/c8db6a737c41dcdfb86ed6bed16d24284cf5c3b9/execution_engine/src/storage/trie_store/operations/mod.rs#L44)
+-   [Writing to the trie](https://github.com/casper-network/casper-node/blob/c8db6a737c41dcdfb86ed6bed16d24284cf5c3b9/execution_engine/src/storage/trie_store/operations/mod.rs#L845)
 
 :::note
 

--- a/source/docs/casper/concepts/global-state.md
+++ b/source/docs/casper/concepts/global-state.md
@@ -5,7 +5,9 @@
 The storage layer for the Casper blockchain is called *global state* and has the semantics of a key-value store with additional permissions logic. All accounts, contracts, and any associated data they have are stored in global state. Not all users can access all data, so permissions need to be set accordingly.
 
 :::note
+
 Refer to [Keys and Permissions](./serialization-standard.md#serialization-standard-state-keys) for further information on keys.
+
 :::
 
 Each finalized block causes changes to the network's global state because of the execution of the deploys it contains. For validators to efficiently judge the correctness of these changes, information about the new state needs to be communicated succinctly. Moreover, the network must communicate portions of global state to users while allowing them to verify the correctness of the parts they receive. For these reasons, the key-value store is implemented as a [Merkle trie](#global-state-trie).
@@ -28,9 +30,9 @@ The purpose of the extension node is to allow path compression. Consider an exam
 
 The Rust implementation of Casper's trie can be found on GitHub:
 
--   [Definition of the trie data structure](https://github.com/casper-network/casper-node/blob/latest/execution_engine/src/storage/trie/mod.rs#L340)
--   [Reading from the trie](https://github.com/casper-network/casper-node/blob/latest/execution_engine/src/storage/trie_store/operations/mod.rs#L44)
--   [Writing to the trie](https://github.com/casper-network/casper-node/blob/latest/execution_engine/src/storage/trie_store/operations/mod.rs#L845)
+-   [Definition of the trie data structure](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie/mod.rs#L340)
+-   [Reading from the trie](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie_store/operations/mod.rs#L44)
+-   [Writing to the trie](https://github.com/casper-network/casper-node/blob/v1.4.13/execution_engine/src/storage/trie_store/operations/mod.rs#L845)
 
 :::note
 


### PR DESCRIPTION
### What does this PR fix/introduce?

I had change requests for PR 980 that I couldn't submit due to a GH issue today. See 
[Notes for PR9980.pdf](https://github.com/casper-network/docs/files/11082299/Notes.for.PR9980.pdf).
Also, I noticed that we have an incorrectly formatted note on [the page.](https://docs.casper.network/concepts/global-state/)

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ACStoneCL 