### PR TITLE
Add basic unified SDK page

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -129,6 +129,7 @@ module.exports = {
                     collapsed: true,
                     items: [
                         "developers/dapps/sdk/index",
+                        "developers/dapps/sdk/client-library-usage",
                         "developers/dapps/sdk/script-sdk",
                         "developers/dapps/sdk/csharp-sdk",
                         "developers/dapps/sdk/go-sdk",

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -1,0 +1,270 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# SDK Client Library Usage
+
+## Installation
+
+<Tabs>
+
+<TabItem value="js" label="JavaScript">
+
+Use `npm` or `yarn` to install [casper-js-sdk](https://www.npmjs.com/package/casper-js-sdk) package:
+
+```bash
+npm install casper-js-sdk
+```
+```bash
+yarn install casper-js-sdk
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+Use [`pip`](https://pypi.org/project/pip/) to install [pycspr](https://pypi.org/project/pycspr/) package:
+
+```bash
+pip install pycspr
+```
+
+</TabItem>
+
+</Tabs>
+
+---
+
+## Accounts
+
+You may use the SDKs to interact with accounts on the Casper Network. Accounts can be of either ed25519 or secp256k1 cryptography.
+
+### Create new keypair
+
+<Tabs>
+
+<TabItem value="js" label="JavaScript">
+
+```javascript
+const { Keys } = require("casper-js-sdk");
+const keypair = Keys.ALGO.new();
+const { publicKey, privateKey } = keypair;
+```
+
+Replace `ALGO` with your key algorithm: `Ed25519` or `Secp256K1`.
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+from pycspr.crypto import KeyAlgorithm, get_key_pair
+keypair = get_key_pair(KeyAlgorithm.ALGO)
+```
+
+Replace `ALGO` with your key algorithm: `ED25519` or `SECP256K1`.
+
+</TabItem>
+
+</Tabs>
+
+### Exporting Keys
+
+In your `keypair` variable is a private key and a public key. There are many reasons you may want to use, read, or export your public key. You may also want access to the account hash as it is often used within smart contracts on the Casper Network. The following methods show you how to dissect your keypair.
+
+<Tabs>
+
+<TabItem value="js" label="JavaScript">
+
+```javascript
+// Create a hexadecimal representation of the public key and account hash.
+const publicKeyHex = publicKey.toHex();
+const accountHashBytes = publicKey.toAccountHash();
+const accountHashHex = Buffer.from(accountHashBytes).toString('hex');
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+import pycspr.crypto
+
+publicKeyBytes = keypair.account_key
+publicKeyHex = pycspr.crypto.cl_checksum.encode(publicKeyBytes)
+accountHashBytes = pycspr.crypto.cl_operations.get_account_hash(publicKeyBytes)
+accountHashHex = pycspr.crypto.cl_checksum.encode(accountHashBytes)
+```
+
+</TabItem>
+
+</Tabs>
+
+### Load from private key
+
+When you want to use a specific account, you should not include your private key within your source code, but instead load in your keypair from a local file.
+
+<Tabs>
+
+<TabItem value="js" label="JavaScript">
+
+```javascript
+const { Keys } = require("casper-js-sdk");
+const keypair = Keys.ALGO.loadKeyPairFromPrivateFile("./secret_key.pem");
+```
+
+Replace `ALGO` with your key algorithm: `Ed25519` or `Secp256K1`.
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+import pycspr
+keypair = pycspr.parse_private_key(
+    "./secret_key.pem",
+    pycspr.crypto.KeyAlgorithm.ALGO
+)
+```
+
+Replace `ALGO` with your key algorithm: `ED25519` or `SECP256K1`.
+
+</TabItem>
+
+</Tabs>
+
+---
+
+## Transferring CSPR
+
+Using the `keypair` created above in [Accounts](#accounts), you can sign a CSPR transferral deploy.
+
+<Tabs>
+
+<TabItem value="js" label="JavaScript">
+
+```javascript
+const { CasperClient, DeployUtil } = require("casper-js-sdk");
+
+const casperClient = new CasperClient("http://NODE_ADDRESS:7777/rpc");
+const receipientPublicKeyHex = "01e8c84f4fbb58d37991ef373c08043a45c44cd7f499453fa2bd3e141cc0113b3c"
+
+let deployParams = new DeployUtil.DeployParams(
+  keypair.publicKey,
+  "casper" // or "casper-test" for testnet
+);
+
+const session = DeployUtil.ExecutableDeployItem.newTransferWithOptionalTransferId(
+  amount,
+  recipientPublicKeyHex
+);
+
+const payment = DeployUtil.standardPayment(100000000); // Gas payment in motes
+const deploy = DeployUtil.makeDeploy(deployParams, session, payment);
+const signedDeploy = DeployUtil.signDeploy(deploy, keypair);
+
+console.log(await casperClient.putDeploy(signedDeploy));
+```
+
+*Note: You can find active online peers to communicate with from the `CasperClient` object at [cspr.live](https://cspr.live/tools/peers) for mainnet and for testnet: [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+import pycspr
+
+client = NodeClient(NodeConnection(host = "NODE_ADDRESS", port_rpc = 7777))
+recipientPublicKeyHex = "01e8c84f4fbb58d37991ef373c08043a45c44cd7f499453fa2bd3e141cc0113b3c"
+recipientPublicKeyBytes = pycspr.crypto.cl_checksum.decode(recipientPublicKeyHex)
+
+deployParams = pycspr.create_deploy_parameters(
+    account = keypair,
+    chain_name = "casper" # or "casper-test" for testnet
+)
+
+deploy = pycspr.create_transfer(
+    params = deployParams,
+    amount = int(2.5e9), # Minimum transfer, 2.5 CSPR
+    target = recipientPublicKeyBytes
+)
+
+deploy.approve(keypair)
+client.send_deploy(deploy)
+print(deploy.hash.hex())
+```
+
+*Note: You can find active online peers to communicate with from the `NodeConnection` object at [cspr.live](https://cspr.live/tools/peers) for mainnet and for testnet: [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
+
+</TabItem>
+
+</Tabs>
+
+Once submitted, the above snippet will print the deploy hash in the console.
+
+---
+
+## Installing Contracts
+
+<Tabs>
+
+<TabItem value="js" label="JavaScript">
+
+```javascript
+const { CasperClient, Contracts, RuntimeArgs, CLValueBuilder }
+
+const casperClient = new CasperClient("http://NODE_ADDRESS:7777/rpc")
+const contract = new Contracts.Contract(client)
+
+const contractWasm = new Uint8Array(fs.readFileSync("/path/to/contract.wasm").buffer)
+
+const runtimeArguments = RuntimeArgs.fromMap({
+  "argument": CLValueBuilder.string("Hello world!")
+})
+
+const deploy = contract.install(
+	contractWasm,
+	runtimeArguments,
+	"10000000000", // Gas payment (10 CSPR)
+	keypair.publicKey,
+	"casper", // or "casper-test" for testnet
+	[keypair]
+)
+
+console.log(await casperClient.putDeploy(deploy))
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+import pycspr
+from pycspr.types import ModuleBytes, CL_String
+
+client = NodeClient(NodeConnection(host = "NODE_ADDRESS", port_rpc = 7777))
+
+deployParams = pycspr.create_deploy_parameters(
+    account = keypair,
+    chain_name = "casper" # or "casper-test" for testnet
+)
+payment = pycspr.create_standard_payment(10000000000) # 10 CSPR
+session = ModuleBytes(
+    module_bytes = pycspr.read_wasm("/path/to/contract.wasm"),
+    args = {
+        "message": CL_String("Hello world!"),
+    }
+)
+
+deploy = pycspr.create_deploy(deployParams, payment, session)
+
+deploy.approve(keypair)
+client.send_deploy(deploy)
+print(deploy.hash.hex())
+```
+
+</TabItem>
+
+</Tabs>
+
+Once submitted, the above snippet will print the deploy hash in the console.

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -3,13 +3,13 @@ import TabItem from '@theme/TabItem';
 
 # SDK Client Library Usage
 
-## Installation
+## Installing SDK Client Libraries
 
 <Tabs>
 
 <TabItem value="js" label="JavaScript">
 
-Use `npm` or `yarn` to install [casper-js-sdk](https://www.npmjs.com/package/casper-js-sdk) package:
+Use `npm` or `yarn` to install the [casper-js-sdk](https://www.npmjs.com/package/casper-js-sdk) package:
 
 ```bash
 npm install casper-js-sdk
@@ -22,7 +22,7 @@ yarn install casper-js-sdk
 
 <TabItem value="python" label="Python">
 
-Use [`pip`](https://pypi.org/project/pip/) to install [pycspr](https://pypi.org/project/pycspr/) package:
+Use [`pip`](https://pypi.org/project/pip/) to install the [pycspr](https://pypi.org/project/pycspr/) package:
 
 ```bash
 pip install pycspr
@@ -34,11 +34,11 @@ pip install pycspr
 
 ---
 
-## Accounts
+## Creating Accounts
 
-You may use the SDKs to interact with accounts on the Casper Network. Accounts can be of either ed25519 or secp256k1 cryptography.
+You may use the SDKs to interact with accounts on a Casper network. Accounts can use either an Ed25519 or Secp256k1 digital signature scheme. See the [Accounts and Cryptographic Keys](../../../concepts/accounts-and-keys.md) page for more details.
 
-### Create new keypair
+### Creating new account keys
 
 <Tabs>
 
@@ -46,11 +46,11 @@ You may use the SDKs to interact with accounts on the Casper Network. Accounts c
 
 ```javascript
 const { Keys } = require("casper-js-sdk");
-const keypair = Keys.ALGO.new();
+const keypair = Keys.ED25519.new();
 const { publicKey, privateKey } = keypair;
 ```
 
-Replace `ALGO` with your key algorithm: `Ed25519` or `Secp256K1`.
+Replace `ED25519` with `SECP256K1` if you wish.
 
 </TabItem>
 
@@ -58,18 +58,18 @@ Replace `ALGO` with your key algorithm: `Ed25519` or `Secp256K1`.
 
 ```python
 from pycspr.crypto import KeyAlgorithm, get_key_pair
-keypair = get_key_pair(KeyAlgorithm.ALGO)
+keypair = get_key_pair(KeyAlgorithm.ED25519)
 ```
 
-Replace `ALGO` with your key algorithm: `ED25519` or `SECP256K1`.
+Replace `ED25519` with `SECP256K1` if you wish.
 
 </TabItem>
 
 </Tabs>
 
-### Exporting Keys
+### Exporting the public key and account hash
 
-In your `keypair` variable is a private key and a public key. There are many reasons you may want to use, read, or export your public key. You may also want access to the account hash as it is often used within smart contracts on the Casper Network. The following methods show you how to dissect your keypair.
+The `keypair` variable contains the private and public key pair for the account. You can use, read, or export the public key. You may also want access to the account hash, often used within smart contracts on a Casper network. The following methods show how to extract the public key and account hash.
 
 <Tabs>
 
@@ -99,9 +99,9 @@ accountHashHex = pycspr.crypto.cl_checksum.encode(accountHashBytes)
 
 </Tabs>
 
-### Load from private key
+### Uploading the secret key from a file
 
-When you want to use a specific account, you should not include your private key within your source code, but instead load in your keypair from a local file.
+To use a specific account, you should not include the private key in the source code; instead, upload the account's secret key from a local file. Update the path to the file in the example below.
 
 <Tabs>
 
@@ -109,10 +109,10 @@ When you want to use a specific account, you should not include your private key
 
 ```javascript
 const { Keys } = require("casper-js-sdk");
-const keypair = Keys.ALGO.loadKeyPairFromPrivateFile("./secret_key.pem");
+const keypair = Keys.ED25519.loadKeyPairFromPrivateFile("./secret_key.pem");
 ```
 
-Replace `ALGO` with your key algorithm: `Ed25519` or `Secp256K1`.
+Replace `ED25519` with `SECP256K1` if you wish.
 
 </TabItem>
 
@@ -122,11 +122,11 @@ Replace `ALGO` with your key algorithm: `Ed25519` or `Secp256K1`.
 import pycspr
 keypair = pycspr.parse_private_key(
     "./secret_key.pem",
-    pycspr.crypto.KeyAlgorithm.ALGO
+    pycspr.crypto.KeyAlgorithm.ED25519
 )
 ```
 
-Replace `ALGO` with your key algorithm: `ED25519` or `SECP256K1`.
+Replace `ED25519` with `SECP256K1` if you wish.
 
 </TabItem>
 
@@ -136,7 +136,7 @@ Replace `ALGO` with your key algorithm: `ED25519` or `SECP256K1`.
 
 ## Transferring CSPR
 
-Using the `keypair` created above in [Accounts](#accounts), you can sign a CSPR transferral deploy.
+Using the `keypair` created above in [Accounts](#accounts), you can sign a deploy that transfers CSPR.
 
 <Tabs>
 
@@ -150,7 +150,7 @@ const receipientPublicKeyHex = "01e8c84f4fbb58d37991ef373c08043a45c44cd7f499453f
 
 let deployParams = new DeployUtil.DeployParams(
   keypair.publicKey,
-  "casper" // or "casper-test" for testnet
+  "casper" // or "casper-test" for Testnet
 );
 
 const session = DeployUtil.ExecutableDeployItem.newTransferWithOptionalTransferId(
@@ -165,7 +165,7 @@ const signedDeploy = DeployUtil.signDeploy(deploy, keypair);
 console.log(await casperClient.putDeploy(signedDeploy));
 ```
 
-*Note: You can find active online peers to communicate with from the `CasperClient` object at [cspr.live](https://cspr.live/tools/peers) for mainnet and for testnet: [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
+*Note: You can find active online peers for Mainnet on [cspr.live](https://cspr.live/tools/peers) and for Testnet on [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
 
 </TabItem>
 
@@ -180,7 +180,7 @@ recipientPublicKeyBytes = pycspr.crypto.cl_checksum.decode(recipientPublicKeyHex
 
 deployParams = pycspr.create_deploy_parameters(
     account = keypair,
-    chain_name = "casper" # or "casper-test" for testnet
+    chain_name = "casper" # or "casper-test" for Testnet
 )
 
 deploy = pycspr.create_transfer(
@@ -194,7 +194,7 @@ client.send_deploy(deploy)
 print(deploy.hash.hex())
 ```
 
-*Note: You can find active online peers to communicate with from the `NodeConnection` object at [cspr.live](https://cspr.live/tools/peers) for mainnet and for testnet: [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
+*Note: You can find active online peers for Mainnet on [cspr.live](https://cspr.live/tools/peers) and for Testnet on [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
 
 </TabItem>
 
@@ -223,12 +223,12 @@ const runtimeArguments = RuntimeArgs.fromMap({
 })
 
 const deploy = contract.install(
-	contractWasm,
-	runtimeArguments,
-	"10000000000", // Gas payment (10 CSPR)
-	keypair.publicKey,
-	"casper", // or "casper-test" for testnet
-	[keypair]
+  contractWasm,
+  runtimeArguments,
+  "10000000000", // Gas payment (10 CSPR)
+  keypair.publicKey,
+  "casper", // or "casper-test" for Testnet
+  [keypair]
 )
 
 console.log(await casperClient.putDeploy(deploy))
@@ -246,7 +246,7 @@ client = NodeClient(NodeConnection(host = "NODE_ADDRESS", port_rpc = 7777))
 
 deployParams = pycspr.create_deploy_parameters(
     account = keypair,
-    chain_name = "casper" # or "casper-test" for testnet
+    chain_name = "casper" # or "casper-test" for Testnet
 )
 payment = pycspr.create_standard_payment(10000000000) # 10 CSPR
 session = ModuleBytes(

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -145,7 +145,7 @@ Using the `keypair` created above in [Accounts](#accounts), you can sign a deplo
 ```javascript
 const { CasperClient, DeployUtil } = require("casper-js-sdk");
 
-const casperClient = new CasperClient("http://NODE_ADDRESS:7777/rpc");
+const casperClient = new CasperClient("http://NODE_ADDRESS:7777");
 const receipientPublicKeyHex = "01e8c84f4fbb58d37991ef373c08043a45c44cd7f499453fa2bd3e141cc0113b3c"
 
 let deployParams = new DeployUtil.DeployParams(
@@ -213,7 +213,7 @@ Once submitted, the above snippet will print the deploy hash in the console.
 ```javascript
 const { CasperClient, Contracts, RuntimeArgs, CLValueBuilder }
 
-const casperClient = new CasperClient("http://NODE_ADDRESS:7777/rpc")
+const casperClient = new CasperClient("http://NODE_ADDRESS:7777")
 const contract = new Contracts.Contract(client)
 
 const contractWasm = new Uint8Array(fs.readFileSync("/path/to/contract.wasm").buffer)

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -78,9 +78,10 @@ The `keypair` variable contains the private and public key pair for the account.
 ```javascript
 // Create a hexadecimal representation of the public key and account hash.
 const publicKeyHex = publicKey.toHex();
-const accountHashBytes = publicKey.toAccountHash();
-const accountHashHex = Buffer.from(accountHashBytes).toString('hex');
+const accountHashHex = publicKey.toAccountHashStr();
 ```
+
+Note that `accountHashHex` will be prefixed with the text "account-hash-".
 
 </TabItem>
 

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # SDK Client Library Usage
 
-## Installing SDK Client Libraries
+## Installing the SDKs
 
 <Tabs>
 
@@ -136,7 +136,9 @@ Replace `ED25519` with `SECP256K1` if you wish.
 
 ## Transferring CSPR
 
-Using the `keypair` created above in [Accounts](#accounts), you can sign a deploy that transfers CSPR.
+Using the `keypair` created [above](#creating-accounts), you can sign a deploy that transfers CSPR.
+
+Replace the `NODE_ADDRESS` and corresponding RPC port with an active node on the network. You can find active online peers for Mainnet on [cspr.live](https://cspr.live/tools/peers) and for Testnet on [testnet.cspr.live](https://testnet.cspr.live/tools/peers). The RPC port is usually `7777`, but it depends on the network's configuration settings.
 
 <Tabs>
 
@@ -165,8 +167,6 @@ const signedDeploy = DeployUtil.signDeploy(deploy, keypair);
 console.log(await casperClient.putDeploy(signedDeploy));
 ```
 
-*Note: You can find active online peers for Mainnet on [cspr.live](https://cspr.live/tools/peers) and for Testnet on [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
-
 </TabItem>
 
 <TabItem value="python" label="Python">
@@ -185,7 +185,7 @@ deployParams = pycspr.create_deploy_parameters(
 
 deploy = pycspr.create_transfer(
     params = deployParams,
-    amount = int(2.5e9), # Minimum transfer, 2.5 CSPR
+    amount = int(2.5e9), # Minimum transfer: 2.5 CSPR
     target = recipientPublicKeyBytes
 )
 
@@ -193,8 +193,6 @@ deploy.approve(keypair)
 client.send_deploy(deploy)
 print(deploy.hash.hex())
 ```
-
-*Note: You can find active online peers for Mainnet on [cspr.live](https://cspr.live/tools/peers) and for Testnet on [testnet.cspr.live](https://testnet.cspr.live/tools/peers).*
 
 </TabItem>
 
@@ -205,6 +203,10 @@ Once submitted, the above snippet will print the deploy hash in the console.
 ---
 
 ## Installing Contracts
+
+To install a contract on the network, you need to sign and send a deploy containing the compiled Wasm.
+
+Replace the `NODE_ADDRESS` and corresponding RPC port with an active node on the network. You can find active online peers for Mainnet on [cspr.live](https://cspr.live/tools/peers) and for Testnet on [testnet.cspr.live](https://testnet.cspr.live/tools/peers). The RPC port is usually `7777`, but it depends on the network's configuration settings.
 
 <Tabs>
 


### PR DESCRIPTION
### What does this PR introduce?

New page "SDK Client Library Usage" under _Building dApps - SDK Client Libraries_, that contains unified (multi-block) SDK usage. In future it should replace all other dedicated pages, but for now we leave them, as not every information was moved yet.

### Additional context

These changes are backported from the default branch of [docs-new](https://github.com/casper-network/docs-new) repository, so you can preview them [live here](https://staging.docs.casper.network/developers/dapps/sdk/client-library-usage/).

Original PR authored by @dylanireland: https://github.com/casper-network/docs-new/pull/171.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.
