### PR TITLE
Minor update in curl command

### DIFF
--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -24,7 +24,7 @@ All the events other than `DeployAccepted` and `FinalitySignature` fall under th
 You can start watching the event stream details using a simple Curl call as in the below format:
 
 ```bash
-curl -sN http://<HOST:PORT>/events/<ENDPOINT>
+curl -s http://<HOST:PORT>/events/<ENDPOINT>
 ```
 
 - `HOST` - The IP address of a peer on the network


### PR DESCRIPTION
Typically N is only used as non-buffering when looking at event streams themselves.  So this is only used with curl on the 9999 ports.  For 8888 examples, we don't need N and should have only curl -s.

