### PR TITLE
Prevent running deploy-prod on forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
       working-directory: ./docs
 
   deploy-prod:
-    if: github.ref == 'refs/heads/dev'
+    if: ${{ github.ref == 'refs/heads/dev' && github.repository == 'casper-network/docs' }}
     needs: [backup, system-tests-predeployment]
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### What does this PR introduce?

It prevents triggering `deploy-prod` job on forked repositories. For example we have [docs-new](https://github.com/casper-network/docs-new/tree/dev-new/source/docs/casper), and every time we sync `dev` branch, it overwrites pages in our environment.

### Additional context

It is common problem that is solved by adding condition - see https://github.com/actions/runner/issues/859.

### Checklist

- [x] All technical procedures have been tested.

