### PR TITLE
Throw error when failed to download NavData asset

### DIFF
--- a/src/plugins/docusaurus-plugin-navdata/src/index.ts
+++ b/src/plugins/docusaurus-plugin-navdata/src/index.ts
@@ -80,6 +80,9 @@ const loadSocialMediaImages = async (
   url: string
 ) => {
   const response = await httpClient.get(`${url}assets/${media.iconId}`);
+  if (response.status != 200) {
+    throw new Error(await response.text());
+  }
   const text = await response.text();
   media.icon = text;
 };
@@ -90,6 +93,9 @@ const loadLogos = async (
   url: string
 ) => {
   const response = await httpClient.get(`${url}assets/${navData.logoId}`);
+  if (response.status != 200) {
+    throw new Error(await response.text());
+  }
   const text = await response.text();
   navData.logo = text;
 };
@@ -100,6 +106,9 @@ const loadFooterLogos = async (
   url: string
 ) => {
   const response = await httpClient.get(`${url}assets/${footerData.logoId}`);
+  if (response.status != 200) {
+    throw new Error(await response.text());
+  }
   const text = await response.text();
   footerData.logo = text;
 };


### PR DESCRIPTION
### What does this PR fix?

Prevent build from succeeding when _navdata_ assets cannot be downloaded. This should prevent scenarios like one we saw yesterday:

![image](https://user-images.githubusercontent.com/121791569/228525260-1e8f0fc8-03fd-4d78-8d13-6ccca1366835.png)

### Additional context

This is backport of navdata changes in https://github.com/casper-network/docs-new/pull/194.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.
