### PR TITLE
Make header font-size responsive

### DIFF
--- a/src/assets/scss/_global.scss
+++ b/src/assets/scss/_global.scss
@@ -1,6 +1,7 @@
 @use "./variables/fonts-variables";
 @use "./variables/sizes";
 @use "./mixins";
+@use "./variables/media-queries";
 
 body {
     -webkit-font-smoothing: antialiased;
@@ -220,4 +221,25 @@ a {
 //
 html {
     scroll-behavior: smooth;
+}
+
+//
+@media #{media-queries.$break-md} {
+    h1 {
+        font-size: 60px;
+    }
+}
+@media #{media-queries.$break-sm} {
+    h1 {
+        font-size: 40px;
+        line-height: 50px;
+    }
+
+    h2 {
+        font-size: 32px;
+    }
+
+    h3 {
+        font-size: 26px;
+    }
 }


### PR DESCRIPTION
### What does this PR fix?

Add commit with UI fix - responsive header size - that was missed during last changes synchronization - see https://github.com/casper-network/docs-new/pull/191#issuecomment-1488596586. This will improve size of titles displayed on smaller screen.

### Additional context

This is backport of https://github.com/casper-network/docs-new/commit/f18cdf15ef717118adb3b471c67e75f131205d5a, and you can preview it [live here](https://staging.docs.casper.network/).

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.
