### PR TITLE
Clear Docusaurus cache before build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,10 @@ jobs:
         run: |
           yarn check:externals
 
+      - name: Clear Docusaurus cache
+        run: |
+          yarn clear
+
       - name: Build app
         run: |
           yarn build --out-dir ./docs


### PR DESCRIPTION
In [docs-new repo](https://github.com/casper-network/docs-new/) we observed Docusaurus cache issues - see https://github.com/casper-network/docs-new/issues/200 for details.

This PR is backport of [commit that fixes cache issues](https://github.com/casper-network/docs-new/commit/b99c9aac54f2bdba7217e3662d0f8d206d94bab4).

