### PR TITLE
Making economics article subtitles in the sidebar self-explanatory

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -34,9 +34,9 @@ module.exports = {
                 "concepts/economics/consensus",
                 "concepts/economics/runtime",
                 "concepts/economics/gas-concepts",
-                "concepts/economics/delegation",
                 "concepts/economics/concepts",
                 "concepts/economics/staking",
+                "concepts/economics/delegation",
             ],
         },
         {

--- a/source/docs/casper/concepts/economics/runtime.md
+++ b/source/docs/casper/concepts/economics/runtime.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Runtime Economics
 slug: /runtime
 ---
 

--- a/source/docs/casper/concepts/economics/staking.md
+++ b/source/docs/casper/concepts/economics/staking.md
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Staking
 slug: /staking
 tags: ["finance", "staking", "governance"]
 ---
@@ -7,8 +7,6 @@ tags: ["finance", "staking", "governance"]
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Staking
-
-This page describes key concepts related to the staking process.
 
 A feature of Proof-of-Stake protocols is that token holders can actively participate in the protocol through a mechanism known as **staking** or **delegation**. They can stake their tokens with any validator on a Casper network. Alternatively, it is possible to stake tokens via an exchange or custody provider.
 


### PR DESCRIPTION
### What does this PR fix/introduce?
Fixes confusing titles for economics sub-articles.

Closes #1001 

### Checklist
- [X] Docs are successfully building - `yarn install && yarn run build`.

### Reviewers
@ACStoneCL 
