### PR TITLE
Dehardcode Algolia config

### DIFF
--- a/.github/templates/.env.production.j2
+++ b/.github/templates/.env.production.j2
@@ -4,6 +4,7 @@ TEXTLINT_MODE=fix
 DOCS_MODE=true
 
 # Algolia api credentials
+ALGOLIA_APP_ID={{ env['ALGOLIA_APP_ID'] }}
 ALGOLIA_INDEX_NAME={{ env['ALGOLIA_INDEX_NAME'] }}
 ALGOLIA_API_KEY={{ env['ALGOLIA_API_KEY'] }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
           template: .github/templates/.env.production.j2
           output_file: .env.production
         env:
+          ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
           ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
           ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
           CROWDIN_PERSONAL_ACCESS_TOKEN: ""

--- a/config/algolia.config.js
+++ b/config/algolia.config.js
@@ -1,7 +1,9 @@
+const appId = process.env.ALGOLIA_APP_ID;
 const indexName = process.env.ALGOLIA_INDEX_NAME;
 const apiKey = process.env.ALGOLIA_API_KEY;
 
 module.exports = {
+    appId: appId,
     apiKey: apiKey,
     indexName: indexName,
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ module.exports = {
             minHeadingLevel: 2,
             maxHeadingLevel: 6,
         },
-        algolia: algoliaConfig,
+        ...(algoliaConfig["apiKey"] && { algolia: algoliaConfig }),
         announcementBar: announcementConfig,
         colorMode: colorConfig,
         footer: footerConfig,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ module.exports = {
             minHeadingLevel: 2,
             maxHeadingLevel: 6,
         },
-        // algolia: algoliaConfig,
+        algolia: algoliaConfig,
         announcementBar: announcementConfig,
         colorMode: colorConfig,
         footer: footerConfig,
@@ -52,11 +52,6 @@ module.exports = {
         // metadatas: metadatasConfig,
         navbar: navbarConfig,
         prism: prismConfig,
-        algolia: {
-            appId: "KQNX60E7J5",
-            apiKey: "42e859bcdaa94a6c412d933cbaabe2e2",
-            indexName: "casperlabs",
-        },
     },
     presets: [
         [


### PR DESCRIPTION
### What does this PR fix?

Dehardcode Algolia configuration, by utilizing config file and repository secrets/variables.

Closes #1030.

### Additional context

This is backport of https://github.com/casper-network/docs-new/commit/7b4eccf583203e012013422c0a2acb8721d5421f and https://github.com/casper-network/docs-new/commit/8b5bffd4ce38d8faea3feaaa70e5fca64114b2ee. New repository variable was already configured:

![image](https://user-images.githubusercontent.com/121791569/229820624-2c70e210-597c-4c6d-a465-62520251e24a.png)

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.
