### PR TITLE
Fix unified SDK issues

### DIFF
--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -148,7 +148,7 @@ Replace the `NODE_ADDRESS` and corresponding RPC port with an active node on the
 ```javascript
 const { CasperClient, DeployUtil } = require("casper-js-sdk");
 
-const casperClient = new CasperClient("http://NODE_ADDRESS:7777");
+const casperClient = new CasperClient("http://NODE_ADDRESS:7777/rpc");
 const receipientPublicKeyHex = "01e8c84f4fbb58d37991ef373c08043a45c44cd7f499453fa2bd3e141cc0113b3c"
 
 let deployParams = new DeployUtil.DeployParams(
@@ -216,7 +216,7 @@ Replace the `NODE_ADDRESS` and corresponding RPC port with an active node on the
 ```javascript
 const { CasperClient, Contracts, RuntimeArgs, CLValueBuilder }
 
-const casperClient = new CasperClient("http://NODE_ADDRESS:7777")
+const casperClient = new CasperClient("http://NODE_ADDRESS:7777/rpc")
 const contract = new Contracts.Contract(client)
 
 const contractWasm = new Uint8Array(fs.readFileSync("/path/to/contract.wasm").buffer)

--- a/source/docs/casper/developers/dapps/sdk/client-library-usage.md
+++ b/source/docs/casper/developers/dapps/sdk/client-library-usage.md
@@ -46,11 +46,11 @@ You may use the SDKs to interact with accounts on a Casper network. Accounts can
 
 ```javascript
 const { Keys } = require("casper-js-sdk");
-const keypair = Keys.ED25519.new();
+const keypair = Keys.Ed25519.new();
 const { publicKey, privateKey } = keypair;
 ```
 
-Replace `ED25519` with `SECP256K1` if you wish.
+Replace `Ed25519` with `Secp256K1` if you wish.
 
 </TabItem>
 
@@ -110,10 +110,10 @@ To use a specific account, you should not include the private key in the source 
 
 ```javascript
 const { Keys } = require("casper-js-sdk");
-const keypair = Keys.ED25519.loadKeyPairFromPrivateFile("./secret_key.pem");
+const keypair = Keys.Ed25519.loadKeyPairFromPrivateFile("./secret_key.pem");
 ```
 
-Replace `ED25519` with `SECP256K1` if you wish.
+Replace `Ed25519` with `Secp256K1` if you wish.
 
 </TabItem>
 

--- a/source/docs/casper/developers/dapps/sdk/script-sdk.md
+++ b/source/docs/casper/developers/dapps/sdk/script-sdk.md
@@ -104,7 +104,7 @@ const casperClientSDK = require("casper-js-sdk");
 
 const { Keys, CasperClient, CLPublicKey, DeployUtil } = require("casper-js-sdk");
 
-const RPC_API = "http://159.65.203.12:7777";
+const RPC_API = "http://159.65.203.12:7777/rpc";
 const STATUS_API = "http://159.65.203.12:8888";
 
 const sendTransfer = async ({ from, to, amount }) => {


### PR DESCRIPTION
This PR fixes 2 bugs:

- `/rpc` suffix was recently removed - https://github.com/casper-network/docs/commit/cb101b863b4e8401b31281c0c25679e85dcf8d10 - but it is required (I tested it).
- Cryptographic algorithm in JS SDK are accessible via CamelCase, not UPPERCASE.