### PR TITLE
Add dApps prerequisites

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -122,6 +122,7 @@ module.exports = {
             collapsed: true,
             items: [
                 "developers/dapps/index",
+                "developers/dapps/prerequisites",
                 {
                     type: "category",
                     label: "SDK Client Libraries",
@@ -137,7 +138,6 @@ module.exports = {
                         //"developers/dapps/sdk/additional-libraries", // NEW CONTENT WILL BE HERE
                     ],
                 },
-                //"developers/dapps/prerequisites", // NEW CONTENT WILL BE HERE
                 "developers/dapps/technology-stack",
                 //"developers/dapps/template-frontend", // NEW CONTENT WILL BE HERE
                 "developers/dapps/signing-a-deploy",

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -1,7 +1,32 @@
 # Prerequisites
 
-:::caution
+Before trying your hand at dApp development on the Casper Network, there are a few things you should do first:
 
-This page is under development ⚒. Any contribution is welcome!
+1. Be sure you understand the language(s) you are developing in
 
-:::
+   Before beginning with one or more of the SDKs, ensure that you are familiar with the underlying language itself. There are many guides and tutorials available online to help you.
+
+   The preferred stack for building on Casper is JavaScript using the [Casper JS SDK](https://github.com/casper-ecosystem/casper-js-sdk), however there are many more SDKs available for a variety of different programming languages. Read about and examine the other available SDKs in [Introduction to SDKs](./sdk/index.md).
+
+2. Familiarize yourself with the fundamentals of the Casper Network
+
+   The Casper Network is a Proof-of-Stake smart contract blockchain written in Rust. Its architecture, from how it validates transactions to how it reaches consensus, should be well understood before developing dApps that interact with it. Read up on the Casper Network's design principles in the [design section](../../concepts/design/index.md).
+
+3. Read the documentation or source code of your chosen SDK
+
+   Many of the Casper Network's SDKs have documentation available to help you get a full grasp of the functions and methods within it. In some cases, documentation is written in the source files and rendered using a markup language. Check the repository of your preferred SDK(s) for links to documentation. There are also universal guides to teach you how to perform different functionalities using any of the available SDKs, see [Client Library Usage](./sdk/client-library-usage.md).
+
+## Development Considerations
+
+When developing a public dApp for the Casper Network, it is important to keep security in mind and write your smart contract(s) and interface(s) with caution and care, especially if your dApp interacts with tokens of value.
+
+To ensure the highest level of security, consider the following practices:
+
+1. Code review and auditing: Have your smart contracts and interfaces thoroughly reviewed and audited by experienced professionals. This will help identify any vulnerabilities, bugs, or potential exploits in your code.
+2. Implement best practices: Adhere to industry best practices in smart contract and dApp development. This includes following established design patterns, using secure coding techniques, and staying updated on the latest vulnerabilities and attack vectors.
+3. Testing and simulation: Conduct rigorous testing and simulation of your smart contracts and interfaces. This will help uncover any potential issues or weaknesses before deploying them on the mainnet.
+4. Plan for upgrades and bug fixes: Design your smart contracts to take advantage of Casper Network's support for smart contract upgradability. By doing so, you can ensure that your dApp remains secure and adaptable as the Casper ecosystem evolves, enabling seamless integration of future upgrades and bug fixes.
+5. Monitor and maintain: Regularly monitor your dApp's performance and security once it is deployed. This will help you quickly identify and address any potential threats or vulnerabilities.
+6. Educate users: Provide clear documentation and guidance to your dApp users, helping them understand how to use your application securely and effectively.
+
+By taking these precautions and focusing on security throughout the development process, you can minimize risks and build a more robust and reliable dApp for the Casper Network.

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -12,7 +12,7 @@ Before trying your hand at dApp development on a Casper network, there are a few
 
    Casper networks are Proof-of-Stake smart contract blockchains written in Rust. Their architecture, from how they validates transactions to how they reach consensus, should be well understood before developing dApps that interact with them. Read up on Casper network design principles in the [design section](../../concepts/design/index.md).
 
-3. Read the documentation or source code of your chosen SDK
+3. Read the documentation or source code of your chosen SDK.
 
    Many of the Casper Network's SDKs have documentation available to help you get a full grasp of the functions and methods within it. In some cases, documentation is written in the source files and rendered using a markup language. Check the repository of your preferred SDK(s) for links to documentation. There are also universal guides to teach you how to perform different functionalities using any of the available SDKs, see [Client Library Usage](./sdk/client-library-usage.md).
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -14,7 +14,7 @@ Before trying your hand at dApp development on a Casper network, there are a few
 
 3. Read the documentation or source code of your chosen SDK.
 
-   Many of the Casper Network's SDKs have documentation available to help you get a full grasp of the functions and methods within it. In some cases, documentation is written in the source files and rendered using a markup language. Check the repository of your preferred SDK(s) for links to documentation. There are also universal guides to teach you how to perform different functionalities using any of the available SDKs, see [Client Library Usage](./sdk/client-library-usage.md).
+   Many of the Casper SDKs have documentation available to help you get a full grasp of their functions and methods. In some cases, documentation is written in the source files and rendered using a markup language. Check the repository of your preferred SDK(s) for links to documentation. There are also universal guides to teach you how to perform different functionalities using any of the available SDKs, see [Client Library Usage](./sdk/client-library-usage.md).
 
 ## Development Considerations
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -1,6 +1,6 @@
 # Prerequisites
 
-Before trying your hand at dApp development on the Casper Network, there are a few things you should do first:
+Before trying your hand at dApp development on a Casper network, there are a few things you should do first:
 
 1. Be sure you understand the language(s) you are developing in
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -18,7 +18,7 @@ Before trying your hand at dApp development on a Casper network, there are a few
 
 ## Development Considerations
 
-When developing a public dApp for the Casper Network, it is important to keep security in mind and write your smart contract(s) and interface(s) with caution and care, especially if your dApp interacts with tokens of value.
+When developing a public dApp for a Casper network, it is important to keep security in mind and write your smart contract(s) and interface(s) with caution and care, especially if your dApp interacts with tokens of value.
 
 To ensure the highest level of security, consider the following practices:
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -8,7 +8,7 @@ Before trying your hand at dApp development on a Casper network, there are a few
 
    The preferred stack for building on Casper is JavaScript using the [Casper JS SDK](https://github.com/casper-ecosystem/casper-js-sdk), however there are many more SDKs available for a variety of different programming languages. Read about and examine the other available SDKs in [Introduction to SDKs](./sdk/index.md).
 
-2. Familiarize yourself with the fundamentals of the Casper Network
+2. Familiarize yourself with the fundamentals of Casper networks.
 
    Casper networks are Proof-of-Stake smart contract blockchains written in Rust. Their architecture, from how they validates transactions to how they reach consensus, should be well understood before developing dApps that interact with them. Read up on Casper network design principles in the [design section](../../concepts/design/index.md).
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -10,7 +10,7 @@ Before trying your hand at dApp development on a Casper network, there are a few
 
 2. Familiarize yourself with the fundamentals of the Casper Network
 
-   The Casper Network is a Proof-of-Stake smart contract blockchain written in Rust. Its architecture, from how it validates transactions to how it reaches consensus, should be well understood before developing dApps that interact with it. Read up on the Casper Network's design principles in the [design section](../../concepts/design/index.md).
+   Casper networks are Proof-of-Stake smart contract blockchains written in Rust. Their architecture, from how they validates transactions to how they reach consensus, should be well understood before developing dApps that interact with them. Read up on Casper network design principles in the [design section](../../concepts/design/index.md).
 
 3. Read the documentation or source code of your chosen SDK
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -6,7 +6,7 @@ Before trying your hand at dApp development on a Casper network, there are a few
 
    Before beginning with one or more of the SDKs, ensure that you are familiar with the underlying language itself. There are many guides and tutorials available online to help you.
 
-   The preferred stack for building on Casper is JavaScript using the [Casper JS SDK](https://github.com/casper-ecosystem/casper-js-sdk), however there are many more SDKs available for a variety of different programming languages. Read about and examine the other available SDKs in [Introduction to SDKs](./sdk/index.md).
+   The preferred stack for building on Casper is JavaScript using the [Casper JS SDK](https://github.com/casper-ecosystem/casper-js-sdk), however there are many more SDKs available for a variety of different programming languages. Read about and examine the other available SDKs in the [Introduction to SDKs](./sdk/index.md).
 
 2. Familiarize yourself with the fundamentals of Casper networks.
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -25,7 +25,7 @@ To ensure the highest level of security, consider the following practices:
 1. Code review and auditing: Have your smart contracts and interfaces thoroughly reviewed and audited by experienced professionals. This will help identify any vulnerabilities, bugs, or potential exploits in your code.
 2. Implement best practices: Adhere to industry best practices in smart contract and dApp development. This includes following established design patterns, using secure coding techniques, and staying updated on the latest vulnerabilities and attack vectors.
 3. Testing and simulation: Conduct rigorous testing and simulation of your smart contracts and interfaces. This will help uncover any potential issues or weaknesses before deploying them on the mainnet.
-4. Plan for upgrades and bug fixes: Design your smart contracts to take advantage of Casper Network's support for smart contract upgradability. By doing so, you can ensure that your dApp remains secure and adaptable as the Casper ecosystem evolves, enabling seamless integration of future upgrades and bug fixes.
+4. Plan for upgrades and bug fixes: Design your smart contracts to take advantage of Casper's support for smart contract upgradability. By doing so, you can ensure that your dApp remains secure and adaptable as the Casper ecosystem evolves, enabling seamless integration of future upgrades and bug fixes.
 5. Monitor and maintain: Regularly monitor your dApp's performance and security once it is deployed. This will help you quickly identify and address any potential threats or vulnerabilities.
 6. Educate users: Provide clear documentation and guidance to your dApp users, helping them understand how to use your application securely and effectively.
 

--- a/source/docs/casper/developers/dapps/prerequisites.md
+++ b/source/docs/casper/developers/dapps/prerequisites.md
@@ -2,7 +2,7 @@
 
 Before trying your hand at dApp development on a Casper network, there are a few things you should do first:
 
-1. Be sure you understand the language(s) you are developing in
+1. Be sure you understand the language(s) you are developing in.
 
    Before beginning with one or more of the SDKs, ensure that you are familiar with the underlying language itself. There are many guides and tutorials available online to help you.
 


### PR DESCRIPTION
### What does this PR introduce?

New dApp page "Prerequisites".

### Additional context

These changes are backported from the default branch of [docs-new](https://github.com/casper-network/docs-new) repository, so you can preview them [live here](https://staging.docs.casper.network/developers/dapps/prerequisites/).

Original PR authored by @dylanireland: https://github.com/casper-network/docs-new/pull/141.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.
