### PR TITLE
New table of contents for Resources

### DIFF
--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -1,8 +1,21 @@
 # Table of Contents
 
-- [Why Build On Casper](./build-on-casper/index.md)
-  - [Ecosystem Open-Source Software](./build-on-casper/casper-open-source-software.md)
-- [Quickstart](./quick-start.md)
-- [Tutorials](./tutorials/index.md)
-  - [Beginner Tutorials](./tutorials/beginner/index.md)
-  - [Advanced Tutorials](./tutorials/advanced/index.md)
+Introduction
+  - [Wallets and Block Explorers](./build-on-casper/index.md#wallets)
+  See a list of Wallets that support the native Casper token $CSPR
+  - [WebAssembly](./build-on-casper/index.md#developer-friendly-language)
+  Learn why WebAssembly is an advantage in contract development
+  - [Accounts](./build-on-casper/index.md#powerful-accounts)
+  Read more about the Casper account-model that allows for features like multisig
+  - [Developer tools](./build-on-casper/index.md#development-tools)
+  Explore development tools
+
+Tutorials
+  - [Beginner](./tutorials/beginner/index.md)
+  Learn to perform basic actions on the Casper Blockchain, such as read / write operations and SDK queries
+  - [Advanced](./tutorials/advanced/index.md)
+  Perform more advanced actions, such as multisig, exchange integration and vaults
+  - [Quickstart](./quick-start.md)
+  Install Rust and setup a Casper environment 
+  - [Open-Source Ecosystem](./build-on-casper/casper-open-source-software.md)
+  Explore the source code that makes up the Casper ecosystem.


### PR DESCRIPTION
### What does this PR change?

Improve index page of Resources, by adding descriptions and more links.

### Additional context

These changes are backported from the default branch of [docs-new](https://github.com/casper-network/docs-new) repository, so you can preview them [live here](https://staging.docs.casper.network/resources/).

Original PR authored by @jonas089: https://github.com/casper-network/docs-new/pull/175.

### Checklist

- [x] I ran the docs locally using `yarn install` and `yarn run start`.
- [x] All links (internal and external) have been verified.
- [x] All technical procedures have been tested.
