### PR TITLE
Polished multi-sig deploys

### DIFF
--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -226,7 +226,9 @@ Towards the end of the following output, you can observe that there is an **appr
 The next step is to send the deploy for processing on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node `http://80.92.204.108` from the Testnet; replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
 
 ```bash
-casper-client send-deploy --input transfer2.deploy --node-address http://80.92.204.108:7777
+casper-client send-deploy \
+--input transfer2.deploy \
+--node-address http://80.92.204.108:7777
 ```
 
 | Parameter    | Description                                                          |

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -226,7 +226,7 @@ Towards the end of the following output, you can observe that there is an **appr
 The next step is to send the deploy for processing on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node `http://80.92.204.108` from the Testnet; replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
 
 ```bash
-casper-client send-deploy --input transfer2.deploy --node-address http://65.21.235.219:7777
+casper-client send-deploy --input transfer2.deploy --node-address http://80.92.204.108:7777
 ```
 
 | Parameter    | Description                                                          |

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -254,7 +254,7 @@ Make a note of the *deploy_hash* from the `send-deploy` command output to verify
 
 </details>
 
-If you get an account authorization error, you must set up the source account to allow multi-signature deploys using session code. The [Two-Party Multi-Signature Deploys](../../../resources/tutorials/advanced/two-party-multi-sig.md) workflow is an example of how to accomplish this.
+If you encounter an account authorization error, you must set up the source account to allow multi-signature deploys using session code. The [Two-Party Multi-Signature Deploys](../../../resources/tutorials/advanced/two-party-multi-sig.md) workflow is an example of how to accomplish this.
 
 <details>
 <summary>Example of an account authorization error</summary>

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -223,7 +223,7 @@ Towards the end of the following output, you can observe that there is an **appr
 
 ### Sending the Deploy
 
-The next step is to send the deploy for processing on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node http://80.92.204.108 from the Testnet; replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
+The next step is to send the deploy for processing on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node `http://80.92.204.108` from the Testnet; replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
 
 ```bash
 casper-client send-deploy --input transfer2.deploy --node-address http://65.21.235.219:7777

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -35,7 +35,7 @@ casper-client make-transfer --amount 2500000000 \
 --chain-name casper-test \
 --target-account [PUBLIC_KEY_HEX] \
 --transfer-id 3 \
---payment-amount 10000 
+--payment-amount 10000 \
 --output transfer.deploy
 ```
 

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -27,7 +27,7 @@ The high-level flow to transfer tokens using a deploy file is described in the f
 
 ### Preparing the Transfer
 
-This section explains the `make-transfer` command using an example you can try on the Testnet. For this example, we are transferring 2500000000 motes from the source account (with the secret_key.pem file) to a target account. To use this example on the Mainnet, the _chain-name_ would be `casper` instead of `casper-test`. Note that we are saving the output of the `make-deploy` command in a `transfer.deploy` file.
+This section explains the `make-transfer` command using an example you can try on the Testnet. For this example, we are transferring 2500000000 motes from the source account (with the `secret_key.pem` file) to a target account. To use this example on the Mainnet, the _chain-name_ would be `casper` instead of `casper-test`. Note that we are saving the output of the `make-deploy` command in a `transfer.deploy` file.
 
 ```bash
 casper-client make-transfer --amount 2500000000 \

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -223,12 +223,12 @@ Towards the end of the following output, you can observe that there is an **appr
 
 ### Sending the Deploy
 
-The next step is to send the deploy for processing on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node `http://80.92.204.108` from the Testnet; replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
+The next step is to send the deploy for processing on the network. As described in the [Prerequisites](#prerequisites) section, you need to get an active node address from the corresponding network to complete this task. The following example uses the node `http://65.21.235.219` from the Testnet; replace this with an active node before using the command. Port `7777` is the RPC endpoint for interacting with the Casper client.
 
 ```bash
 casper-client send-deploy \
 --input transfer2.deploy \
---node-address http://80.92.204.108:7777
+--node-address http://65.21.235.219:7777
 ```
 
 | Parameter    | Description                                                          |

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -27,7 +27,7 @@ The high-level flow to transfer tokens using a deploy file is described in the f
 
 ### Preparing the Transfer
 
-This section explains the `make-transfer` command using an example you can try on the Testnet. For this example, we are transferring 2500000000 motes from the source account (with the `secret_key.pem` file) to a target account. To use this example on the Mainnet, the _chain-name_ would be `casper` instead of `casper-test`. Note that we are saving the output of the `make-deploy` command in a `transfer.deploy` file.
+This section explains the `make-transfer` command using an example you can try on the Testnet. For this example, we are transferring 2,500,000,000 motes from the source account (with the `secret_key.pem` file) to a target account. To use this example on the Mainnet, the _chain-name_ would be `casper` instead of `casper-test`. Note that we are saving the output of the `make-deploy` command in a `transfer.deploy` file.
 
 ```bash
 casper-client make-transfer --amount 2500000000 \

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -23,7 +23,7 @@ The high-level flow to transfer tokens using a deploy file is described in the f
 1. Use the `make-deploy` command to prepare a transfer and save the output in a file
 2. Use the `send-deploy` command to send the deploy to the network through a valid node
 
-<img src={useBaseUrl("/image/workflow/deploy-flow.png")} alt="Deployment flow" width="600" />
+<img src={useBaseUrl("/image/workflow/deploy-flow.png")} alt="Deployment flow" width="600" style={{backgroundColor:"#e6e6e6", padding:"0.25em"}} />
 
 ### Preparing the Transfer
 

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -14,7 +14,7 @@ You must ensure the following prerequisites are met.
     - The Casper [command-line client](../../prerequisites.md#the-casper-command-line-client)
 2. Set up the source account for multi-signature deploys, as outlined in the [Two-Party Multi-Signature Deploys](../../../resources/tutorials/advanced/two-party-multi-sig.md) workflow
 3. Get the path of the source account's _secret key_ file
-4. Get the path of a target account's _public key_ hex file
+4. Get the target account's _public key_ in hex format
 
 ## Token Transfer Workflow
 

--- a/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/multisig-deploy-transfer.md
@@ -23,7 +23,7 @@ The high-level flow to transfer tokens using a deploy file is described in the f
 1. Use the `make-deploy` command to prepare a transfer and save the output in a file
 2. Use the `send-deploy` command to send the deploy to the network through a valid node
 
-<img src={useBaseUrl("/image/workflow/deploy-flow.png")} width="600" />
+<img src={useBaseUrl("/image/workflow/deploy-flow.png")} alt="Deployment flow" width="600" />
 
 ### Preparing the Transfer
 

--- a/source/docs/casper/resources/tutorials/advanced/two-party-multi-sig.md
+++ b/source/docs/casper/resources/tutorials/advanced/two-party-multi-sig.md
@@ -50,7 +50,7 @@ make build-contract
 
 The compiled Wasm will be saved on this path:
 
-    target/wasm32-unknown-unknown/release/contract.wasm
+    contract/target/wasm32-unknown-unknown/release/contract.wasm
 
 The Casper command-line client can be used to send the compiled Wasm to the network for execution.
 

--- a/source/docs/casper/resources/tutorials/advanced/two-party-multi-sig.md
+++ b/source/docs/casper/resources/tutorials/advanced/two-party-multi-sig.md
@@ -10,7 +10,11 @@ This workflow describes how a trivial two-party multi-signature scheme for signi
 
 ## Configuring the Main Account {#configuring-the-main-account}
 
-**CAUTION**: Incorrect account configurations could render accounts defunct and unusable. We highly recommend executing any changes to an account in a test environment like Testnet before performing them in a live environment like Mainnet.
+:::caution
+
+Incorrect account configurations could render accounts defunct and unusable. We highly recommend executing any changes to an account in a test environment like Testnet before performing them in a live environment like Mainnet.
+
+:::
 
 Each Account has an `associated_keys` field, which is a list containing account hashes and their corresponding weights. Accounts can be associated by adding the account hash to the `associated_keys` field.
 

--- a/source/docs/casper/users/testnet-faucet.md
+++ b/source/docs/casper/users/testnet-faucet.md
@@ -12,8 +12,16 @@ To request test tokens, follow these steps:
 
 1. Sign-in into the Casper Testnet with the Signer. For detailed instructions, see the [Signer Guide](https://docs.cspr.community/docs/user-guides/SignerGuide.html). 
 2. Click **Tools** on the top menu bar and select **Faucet** from the drop-down menu. Or, navigate to the Faucet using this link: https://testnet.cspr.live/tools/faucet.
-3. Click **Request tokens** on the Faucet page. Tokens can be requested **only once** from the faucet.
+3. Click **Request tokens** on the Faucet page:
 
     <img src={useBaseUrl("/image/workflow/faucet-function.png")} width="500" />
+
+:::caution
+
+Tokens can be requested **only once per account**. Otherwise, the [deployment will fail](https://testnet.cspr.live/deploy/f0f6b25db767d1a6c2244324661d853ad7d4766f8489d81c36b5e2c9d982891e) with status `User error: 1`.
+
+If you have already exhausted your test funds, you can always [create a new account](../developers/prerequisites.md#creating-an-account).
+
+:::
 
 4. The Testnet will credit your account with test tokens.


### PR DESCRIPTION
### What does this PR fix?

Related issue: https://github.com/casper-network/docs-new/issues/68.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All technical procedures have been tested.
