### PR TITLE
1019 Hide the Signer until the Wallet is ready in the JS SDK

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -138,7 +138,7 @@ module.exports = {
                     ],
                 },
                 //"developers/dapps/prerequisites", // NEW CONTENT WILL BE HERE
-                //"developers/dapps/technology-stack",
+                "developers/dapps/technology-stack",
                 "developers/dapps/setup-nctl",
                 "developers/dapps/nctl-test",
                 //"developers/dapps/template-frontend", // NEW CONTENT WILL BE HERE

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -138,13 +138,13 @@ module.exports = {
                     ],
                 },
                 //"developers/dapps/prerequisites", // NEW CONTENT WILL BE HERE
-                "developers/dapps/technology-stack",
+                //"developers/dapps/technology-stack",
                 "developers/dapps/setup-nctl",
                 "developers/dapps/nctl-test",
                 //"developers/dapps/template-frontend", // NEW CONTENT WILL BE HERE
                 "developers/dapps/signing-a-deploy",
                 "developers/dapps/sending-deploys",
-                "developers/dapps/signer-integration",
+                //"developers/dapps/signer-integration",
                 //"developers/dapps/callstack-based", // NEW CONTENT WILL BE HERE
                 //"developers/dapps/explanation-session-and-contract", // NEW CONTENT WILL BE HERE
                 "developers/dapps/monitor-and-consume-events",
@@ -279,7 +279,7 @@ module.exports = {
                         "resources/tutorials/advanced/transfer-token-to-contract",
                         "resources/tutorials/advanced/two-party-multi-sig",
                         "resources/tutorials/advanced/return-values-tutorial",
-                        "resources/tutorials/advanced/list-cspr",
+                        //"resources/tutorials/advanced/list-cspr",
                         "resources/tutorials/advanced/storage-workflow",
                     ],
                 },

--- a/source/docs/casper/developers/dapps/signer-integration.md
+++ b/source/docs/casper/developers/dapps/signer-integration.md
@@ -1,5 +1,11 @@
 # Using the Casper Signer in dApp Development
 
+:::caution
+
+The Casper Signer has been deprecated and replaced with the [Casper Wallet](https://www.casperwallet.io). We are in the process of updating this page. Meanwhile, visit the guide on [Building with the Casper Wallet](https://www.casperwallet.io/develop).
+
+:::
+
 The [Casper Signer](https://github.com/casper-ecosystem/signer) is a browser plugin for interfacing with Casper accounts. You can interact with the Casper Signer using the `Signer` class in the [Casper JavaScript SDK](https://github.com/casper-ecosystem/casper-js-sdk/).
 
 ## Integrating with the Casper Signer

--- a/source/docs/casper/developers/dapps/technology-stack.md
+++ b/source/docs/casper/developers/dapps/technology-stack.md
@@ -15,9 +15,15 @@ You will need to choose a Casper-compatible SDK for the language you are using t
 
 The signing of transactions will, in many cases, need to be performed by the user on the front-end, for which you have a couple options:
 
-1. The Casper Signer
+1. The Casper Wallet
 
-   The [Casper JS SDK](https://github.com/casper-ecosystem/casper-js-sdk) has a class `Signer` that, when implemented, allows a user to sign transactions using the Casper Signer browser extension. Deploy objects are first converted to JSON, then sent to the Signer to be signed, then must be sent to the backend and forwarded to a node.
+   Use the [Casper Wallet](https://www.casperwallet.io/develop) to sign deploys for a Casper using the Casper Signer browser extension. Deploy objects are first converted to JSON, then sent to the Signer to be signed, then must be sent to the backend and forwarded to a node.
+
+   :::caution
+
+   The Casper Signer has been deprecated and replaced with the [Casper Wallet](https://www.casperwallet.io). We are in the process of updating this page. Meanwhile, visit the guide on [Building with the Casper Wallet](https://www.casperwallet.io/develop).
+
+   :::
 
 2. Third-party signers
 

--- a/source/docs/casper/developers/dapps/technology-stack.md
+++ b/source/docs/casper/developers/dapps/technology-stack.md
@@ -17,7 +17,7 @@ The signing of transactions will, in many cases, need to be performed by the use
 
 1. The Casper Wallet
 
-   Use the [Casper Wallet](https://www.casperwallet.io/develop) to sign deploys for a Casper using the Casper Signer browser extension. Deploy objects are first converted to JSON, then sent to the Signer to be signed, then must be sent to the backend and forwarded to a node.
+   Use the [Casper Wallet](https://www.casperwallet.io/develop) to sign deploys for a Casper network. Deploy objects are first converted to JSON, then sent to the Wallet to be signed, then must be sent to the backend and forwarded to a node.
 
    :::caution
 

--- a/source/docs/casper/resources/tutorials/advanced/list-cspr.md
+++ b/source/docs/casper/resources/tutorials/advanced/list-cspr.md
@@ -2,6 +2,12 @@
 
 This topic describes how to list Casper token (CSPR) on a cryptocurrency exchange. 
 
+:::caution
+
+The Casper Signer has been deprecated and replaced with the [Casper Wallet](https://www.casperwallet.io). We are in the process of updating this page. Meanwhile, visit the guide on [Building with the Casper Wallet](https://www.casperwallet.io/develop).
+
+:::
+
 CSPR is listed on [many exchanges](https://tokenmarketcaps.com/coins/casper/market) worldwide. It usually takes 1 to 3 days to list CSPR on an exchange.
 
 ## Setting up a Node


### PR DESCRIPTION
### What does this PR fix/introduce?

Temporarily hide pages that use the Signer, which has been deprecated and replaced with the Casper Wallet. The JS SDK needs to be updated, and then the docs will need updated examples as well.

The search might still serve hidden pages, but they will have a warning at the top.

<img width="895" alt="Screen Shot 2023-04-13 at 5 20 09 PM" src="https://user-images.githubusercontent.com/4185994/231828903-5636f39d-28b7-415d-9882-8a265ae08f3b.png">

<img width="922" alt="Screen Shot 2023-04-13 at 5 20 44 PM" src="https://user-images.githubusercontent.com/4185994/231828896-fa4995ac-a0a7-415e-b3bd-80237a885194.png">

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.

### Reviewers
@ACStoneCL 
