### PR TITLE
Move gtag config from theme to preset options

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,7 +47,6 @@ module.exports = {
             },
         },
         /* Optional */
-        ...(gtagConfig["trackingID"] && { gtag: gtagConfig }),
         // metadatas: metadatasConfig,
         navbar: navbarConfig,
         prism: prismConfig,
@@ -70,6 +69,7 @@ module.exports = {
                     // editCurrentVersion: true,
                     // onlyIncludeVersions: process.env.PREVIEW_DEPLOY === "true" ? ["current", ...versions.slice(0, 2)] : undefined,
                 },
+                ...(gtagConfig["trackingID"] && { gtag: gtagConfig }),
                 // IMPORTANT: disable blog feature
                 blog: false,
                 /* Blog config options */


### PR DESCRIPTION
### What does this PR fix?

Invalid `gtag` config placement - build failing after https://github.com/casper-network/docs/pull/1068:

> Error:  Unable to build website for locale en.
> Error:  Error: The "gtag" field in themeConfig should now be specified as option for plugin-google-gtag. For preset-classic, simply move themeConfig.gtag to preset options. More information at https://github.com/facebook/docusaurus/pull/5832.
> 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.
