### PR TITLE
Polished "Verifying a Transfer"

### DIFF
--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -190,7 +190,7 @@ casper-client query-global-state \
 
 </details>
 
-We can repeat the same step to query information about the _Target_ account.
+We can repeat the same step to query information about the _Target_ account:
 
 ```bash
 casper-client query-global-state \

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -16,6 +16,21 @@ The state root hash is an identifier of the current network state. It gives a sn
 casper-client get-state-root-hash --node-address [NODE_SERVER_ADDRESS]
 ```
 
+<details>
+<summary>Sample output of the get-state-root-hash command</summary>
+
+```json
+{
+  "id": -550641580167406055,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.4.13",
+    "state_root_hash": "a1f11692c5adc0e8b0a3f83e34d5831593a39ba03c8be73a0ebf7e9d9aadd76b"
+  }
+}
+```
+</details>
+
 :::note
 
 After any deploys to the network, you must get the new state root hash to see the new changes reflected. Otherwise, you will be looking at events in the past.

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -10,7 +10,7 @@ Before verifying a transfer, make sure you have:
 
 ## Query Transfer Details {#query-transfer-details}
 
-A transfer is a part of a deploy - in the Casper network, deploys can contain multiple transfers. When such a deploy is executed, the information about each individual transfer is written to the global state. Each transfer can be uniquely identified by a hash known as the `transfer-address`, a formatted string with a `transfer-` prefix.
+A transfer is a part of a deploy - in a Casper network, deploys can contain multiple transfers. Execution of the deploy includes writing information about each individual transfer to global state. A unique hash known as the `transfer-address` identifies each transfer. The `transfer-address` consists of a formatted string with a `transfer-` prefix.
 
 First, we will use the *deploy_hash* to identify the corresponding transfer:
 

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -37,7 +37,7 @@ casper-client query-global-state \
 **Request fields:**
 
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned.
--   `node-address` - An IP address of a node on the network
+-   `node-address` - An IP address of a node on the network.
 -   `state-root-hash` - Hex-encoded hash of the state root
 -   `key` - The base key for the query. This must be a properly formatted transfer address.
 

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -10,16 +10,28 @@ Before verifying a transfer, make sure you have:
 
 ## Query Transfer Details {#query-transfer-details}
 
-Deploys in a Casper network can contain multiple transfers. When such a deploy is executed, the information about each individual transfer is written to the global state. Each transfer can be uniquely identified by a hash known as the `transfer-address`, a formatted string with a `transfer-` prefix.
+A transfer is a part of a deploy - in the Casper network, deploys can contain multiple transfers. When such a deploy is executed, the information about each individual transfer is written to the global state. Each transfer can be uniquely identified by a hash known as the `transfer-address`, a formatted string with a `transfer-` prefix.
 
-We will use the `transfer-` to query more details about the transfer.
+First, we will use the *deploy_hash* to identify the corresponding transfer:
+
+```bash
+casper-client get-deploy \
+--node-address http://<node-ip-address>:7777 \
+[DEPLOY_HASH]
+```
+
+**Important response fields:**
+
+-   `"result"."execution_results"."result"."Success"."transfers"` - List of transfers contained in a successful deploy.
+
+After we have obtained the `transfer-<hex>` identifier, we can query transfer details.
 
 ```bash
 casper-client query-global-state \
 --id 8 \
 --node-address http://<node-ip-address>:7777 \
 --state-root-hash <state-root-hash> \
---key transfer-
+--key transfer-<hex>
 ```
 
 **Request fields:**
@@ -27,7 +39,7 @@ casper-client query-global-state \
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
 -   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
--   `key` - The base key for the query. This must be a properly formatted transfer address; "transfer-"
+-   `key` - The base key for the query. This must be a properly formatted transfer address.
 
 <details>
 <summary>Explore the JSON-RPC request and response generated.</summary>

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -189,7 +189,7 @@ casper-client get-balance \
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
 -   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
--   `purse-uref` - The URef under which the purse is stored. This must be a properly formatted URef "uref-\-"
+-   `purse-uref` - The URef under which the purse is stored, following the format "uref-<hex_value>".
 
 <details>
 <summary>Explore the JSON-RPC request and response generated.</summary>

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -86,7 +86,7 @@ casper-client query-global-state \
 
 </details>
 
-The query responds with more information about the transfer we conducted: its deploy hash, the account which executed the transfer, the source and target purses, and the target account. We can verify that our transfer was processed successfully using this additional information.
+The query responds with more information about the transfer we conducted: its deploy hash, the account which executed the transfer, the source and target purses, and the target account. We can verify that our transfer processed successfully using this additional information.
 
 ## The State Root Hash
 

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -170,7 +170,7 @@ casper-client query-global-state \
 
 </details>
 
-## Get Source Purse Balance {#get-source-account-balance}
+## Get Purse Balance {#get-purse-balance}
 
 All accounts on a Casper network have a purse associated with the Casper system mint, which we call the _main purse_. The balance associated with a given purse is recorded in global state, and the value can be queried using the `URef` associated with the purse.
 
@@ -224,9 +224,7 @@ casper-client get-balance \
 
 </details>
 
-## Get Target Purse Balance {#get-target-account-balance}
-
-Similarly, now that we have the address of the target purse, we can get its balance.
+Similarly, we have the address of the target purse, so we can get its balance.
 
 ```bash    
 casper-client get-balance \
@@ -235,13 +233,6 @@ casper-client get-balance \
 --state-root-hash <state-root-hash> \
 --purse-uref <target-account-purse-uref>
 ```
-
-**Request fields:**
-
--   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - An IP address of a node on the network
--   `state-root-hash` - Hex-encoded hash of the state root
--   `purse-uref` - The URef under which the purse is stored. This must be a properly formatted URef "uref-\-"
 
 <details>
 <summary>Explore the JSON-RPC request and response generated.</summary>

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -8,6 +8,74 @@ Before verifying a transfer, make sure you have:
 2. The *deploy_hash* of the transfer you want to verify
 3. The *public key* hex for the source and target accounts
 
+## Query Transfer Details {#query-transfer-details}
+
+Deploys in a Casper network can contain multiple transfers. When such a deploy is executed, the information about each individual transfer is written to the global state. Each transfer can be uniquely identified by a hash known as the `transfer-address`, a formatted string with a `transfer-` prefix.
+
+We will use the `transfer-` to query more details about the transfer.
+
+```bash
+casper-client query-global-state \
+--id 8 \
+--node-address http://<node-ip-address>:7777 \
+--state-root-hash <state-root-hash> \
+--key transfer-
+```
+
+**Request fields:**
+
+-   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
+-   `node-address` - An IP address of a node on the network
+-   `state-root-hash` - Hex-encoded hash of the state root
+-   `key` - The base key for the query. This must be a properly formatted transfer address; "transfer-"
+
+<details>
+<summary>Explore the JSON-RPC request and response generated.</summary>
+
+**JSON-RPC Request**:
+
+```json
+{
+    "id": 8,
+    "jsonrpc": "2.0",
+    "method": "state_get_item",
+    "params": {
+        "key": "transfer-8d81f4a1411d9481aed9c68cd700c39d870757b0236987bb6b7c2a7d72049c0e",
+        "path": [],
+        "state_root_hash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
+    }
+}
+```
+
+**JSON-RPC Response**:
+
+```json
+{
+    "id": 8,
+    "jsonrpc": "2.0",
+    "result": {
+        "api_version": "1.0.0",
+        "merkle_proof": "924 chars",
+        "stored_value": {
+            "Transfer": {
+                "amount": "2500000000",
+                "deploy_hash": "ec2d477a532e00b08cfa9447b7841a645a27d34ee12ec55318263617e5740713",
+                "from": "account-hash-b0049301811f23aab30260da66927f96bfae7b99a66eb2727da23bf1427a38f5",
+                "gas": "0",
+                "id": null,
+                "source": "uref-9e90f4bbd8f581816e305eb7ea2250ca84c96e43e8735e6aca133e7563c6f527-007",
+                "target": "uref-6f4026262a505d5e1b0e03b1e3b7ab74a927f8f2868120cf1463813c19acb71e-004",
+                "to": "account-hash-8ae68a6902ff3c029cea32bb67ae76b25d26329219e4c9ceb676745981fd3668"
+            }
+        }
+    }
+}
+```
+
+</details>
+
+The query responds with more information about the transfer we conducted: its deploy hash, the account which executed the transfer, the source and target purses, and the target account. We can verify that our transfer was processed successfully using this additional information.
+
 ## The State Root Hash
 
 The state root hash is an identifier of the current network state. It gives a snapshot of the blockchain state at a moment in time. You can use the state root hash to query the network state after deployments. 
@@ -266,71 +334,3 @@ casper-client get-balance \
 ```
 
 </details>
-
-## Query Transfer Details {#query-transfer-details}
-
-Deploys in a Casper network can contain multiple transfers. When such a deploy is executed, the information about each individual transfer is written to the global state. Each transfer can be uniquely identified by a hash known as the `transfer-address`, a formatted string with a `transfer-` prefix.
-
-We will use the `transfer-` to query more details about the transfer.
-
-```bash
-casper-client query-global-state \
---id 8 \
---node-address http://<node-ip-address>:7777 \
---state-root-hash <state-root-hash> \
---key transfer-
-```
-
-**Request fields:**
-
--   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - An IP address of a node on the network
--   `state-root-hash` - Hex-encoded hash of the state root
--   `key` - The base key for the query. This must be a properly formatted transfer address; "transfer-"
-
-<details>
-<summary>Explore the JSON-RPC request and response generated.</summary>
-
-**JSON-RPC Request**:
-
-```json
-{
-    "id": 8,
-    "jsonrpc": "2.0",
-    "method": "state_get_item",
-    "params": {
-        "key": "transfer-8d81f4a1411d9481aed9c68cd700c39d870757b0236987bb6b7c2a7d72049c0e",
-        "path": [],
-        "state_root_hash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
-    }
-}
-```
-
-**JSON-RPC Response**:
-
-```json
-{
-    "id": 8,
-    "jsonrpc": "2.0",
-    "result": {
-        "api_version": "1.0.0",
-        "merkle_proof": "924 chars",
-        "stored_value": {
-            "Transfer": {
-                "amount": "2500000000",
-                "deploy_hash": "ec2d477a532e00b08cfa9447b7841a645a27d34ee12ec55318263617e5740713",
-                "from": "account-hash-b0049301811f23aab30260da66927f96bfae7b99a66eb2727da23bf1427a38f5",
-                "gas": "0",
-                "id": null,
-                "source": "uref-9e90f4bbd8f581816e305eb7ea2250ca84c96e43e8735e6aca133e7563c6f527-007",
-                "target": "uref-6f4026262a505d5e1b0e03b1e3b7ab74a927f8f2868120cf1463813c19acb71e-004",
-                "to": "account-hash-8ae68a6902ff3c029cea32bb67ae76b25d26329219e4c9ceb676745981fd3668"
-            }
-        }
-    }
-}
-```
-
-</details>
-
-The query responds with more information about the transfer we conducted: its deploy hash, the account which executed the transfer, the source and target purses, and the target account. We can verify that our transfer was processed successfully using this additional information.

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -42,7 +42,7 @@ casper-client query-global-state \
 -   `key` - The base key for the query. This must be a properly formatted transfer address.
 
 <details>
-<summary>Explore the JSON-RPC request and response generated.</summary>
+<summary><b>Explore the JSON-RPC request and response generated.</b></summary>
 
 **JSON-RPC Request**:
 

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -38,7 +38,7 @@ casper-client query-global-state \
 
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned.
 -   `node-address` - An IP address of a node on the network.
--   `state-root-hash` - Hex-encoded hash of the state root
+-   `state-root-hash` - The hex-encoded hash of the state root.
 -   `key` - The base key for the query. This must be a properly formatted transfer address.
 
 <details>

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -36,7 +36,7 @@ casper-client query-global-state \
 
 **Request fields:**
 
--   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
+-   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned.
 -   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
 -   `key` - The base key for the query. This must be a properly formatted transfer address.

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -37,9 +37,9 @@ After any deploys to the network, you must get the new state root hash to see th
 
 :::
 
-## Query the Source Account {#query-the-source-account}
+## Query Account State {#query-account-state}
 
-Here, we will query for information about the _Source_ account using the `state-root-hash` of the block containing the transfer and the public key of the _Target_ account.
+Here, we will query for information about the _Source_ account, using the `state-root-hash` of the block containing the transfer:
 
 ```bash
 casper-client query-global-state \
@@ -110,9 +110,7 @@ casper-client query-global-state \
 
 </details>
 
-## Query the Target Account {#query-the-target-account}
-
-We will repeat the previous step to query information about the _Target_ account.
+We can repeat the same step to query information about the _Target_ account.
 
 ```bash
 casper-client query-global-state \
@@ -121,13 +119,6 @@ casper-client query-global-state \
 --state-root-hash <state-root-hash> \
 --key <hex-encoded-target-account-public-key>
 ```
-
-**Request fields:**
-
--   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
--   `node-address` - An IP address of a node on the network
--   `state-root-hash` - Hex-encoded hash of the state root
--   `key` - The base key for the query. This must be a properly formatted public key, account hash, contract address hash, URef, transfer hash, or deploy-info hash.
 
 <details>
 <summary>Explore the JSON-RPC request and response generated.</summary>

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -1,6 +1,6 @@
 # Verifying a Transfer
 
-## Prerequisite
+## Prerequisites
 
 Before verifying a transfer, make sure you have:
 

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -178,10 +178,10 @@ Now that we have the source purse address, we can verify its balance using the `
 
 ```bash
 casper-client get-balance \
-      --id 6 \
-      --node-address http://<node-ip-address>:7777 \
-      --state-root-hash <state-root-hash> \
-      --purse-uref <source-account-purse-uref>
+--id 6 \
+--node-address http://<node-ip-address>:7777 \
+--state-root-hash <state-root-hash> \
+--purse-uref <source-account-purse-uref>
 ```
 
 **Request fields:**

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -3,10 +3,10 @@
 ## Prerequisite
 
 Before verifying a transfer, make sure you have:
+
 1. Initiated a [Direct Transfer](./direct-token-transfer.md) or [Multi-sig Deploy Transfer](./multisig-deploy-transfer.md)
 2. The *deploy_hash* of the transfer you want to verify
 3. The *public key* hex for the source and target accounts
-
 
 ## The State Root Hash
 

--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -97,7 +97,7 @@ casper-client get-state-root-hash --node-address [NODE_SERVER_ADDRESS]
 ```
 
 <details>
-<summary>Sample output of the get-state-root-hash command</summary>
+<summary><b>Sample output of the get-state-root-hash command</b></summary>
 
 ```json
 {


### PR DESCRIPTION
### What does this PR introduce/fix?

Improved _[Verifying a Transfer](https://docs.casper.network/developers/cli/transfers/verify-transfer/)_, mainly:

- Add sample output for `get-state-root-hash`
- Merge sections about querying account state - there is no need to have 2 identical sections, one mentioning to use *source*, another mentioning *target*.
- Merge sections about querying purse - same as above.
- Move `Querying Transfer Details` to top - for me it follows logical order: after we make transfer we want to get execution details, then we can explore the side effects (query account, purse).
- Explained how to get `transfer-` identifiers from deploy.

**Because of those moves/merges, reviewing commit by commit is advised here.**

Related task: https://github.com/casper-network/docs-new/issues/69.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.