### PR TITLE
Add step for casper-client's auto completion

### DIFF
--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -52,6 +52,27 @@ sudo apt update
 sudo apt install -y casper-client casper-node-launcher jq
 ```
 
+## Enable bash auto completion for `casper-client` (optional)
+
+```bash
+sudo casper-client generate-completion
+```
+
+It defaults to `bash` but can be changed with the `--shell` argument:
+```bash
+--shell <STRING>    The type of shell to generate the completion script for [default: bash]  [possible values:
+                            zsh, bash, fish, powershell, elvish]
+
+sudo casper-client generate-completion --shell powershell
+```
+
+You need to source the new auto completion script or log out and log in again to activate it for the current shell:
+```bash
+source /usr/share/bash-completion/completions/casper-client
+```
+
+Now you can use `casper-client` and press the `tab` key to get auto completion for your commands.
+
 ## Installing All Protocols
 
 On **Mainnet**, run:

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -52,7 +52,7 @@ sudo apt update
 sudo apt install -y casper-client casper-node-launcher jq
 ```
 
-## Enable bash auto completion for `casper-client` (optional)
+## Enable Bash Auto-Completion for `casper-client` (Optional)
 
 ```bash
 sudo casper-client generate-completion


### PR DESCRIPTION
### What does this PR fix/introduce?
It enables the built-in capabilities of `casper-client` to generate and activate a bash auto completion script.

### Additional context
Maybe another place in the docs is better - feel free to adjust.

### Checklist
- [X] I set this up multiple times and it's working well and saves time when using the `casper-client` command

### Reviewers
You decide