### PR TITLE
Editing pass for PR 1058 (backport-monitor-and-consume-events)

### DIFF
--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -6,14 +6,11 @@ The Casper platform uses event streaming to signal state changes in smart contra
 
 Each Casper node streams events through the SSE (Server Sent Event) server via the port specified as the `event_stream_server.address` in the node's *config.toml*. This port is by default `9999` for nodes on [Testnet](https://testnet.cspr.live/tools/peers) and [Mainnet](https://cspr.live/tools/peers).
 
-
 Events are divided into three categories and streamed on their respective endpoints:
 
 - **Deploy events** - Associated with [Deploys](../../concepts/design/casper-design.md#execution-semantics-deploys) on a node. Currently, only a `DeployAccepted` event is emitted. The URL to consume deploy-related events on Mainnet and Testnet is `http://<HOST>:9999/events/deploys/`.
 - **Finality Signature events** - Emitted when the block has been finalized and cannot be altered. The URL to consume finality signature events on Mainnet and Testnet is `http://<HOST>:9999/events/sigs/`.
 - **Main events** - All other events fall under this type: `ApiVersion`, `BlockAdded`, `DeployProcessed`, `DeployExpired`, `Fault`, `Step`, and `Shutdown` events. The URL to consume these events on Mainnet and Testnet is `http://<HOST>:9999/events/main/`.
-
-This page describes how to listen and respond to each event type. For details on custom serializations, check the [Serialization Standard](../../concepts/serialization-standard.md). Also, the [Types](../json-rpc/types_chain.md) page defines the terms used in the event stream output.
 
 ## Listening to the Event Stream
 
@@ -183,6 +180,8 @@ A `BlockAdded` event is emitted when a new block is added to the blockchain and 
 * [approvals](../json-rpc/types_chain.md#approval) - The signer's hexadecimal-encoded public key and signature.
 
 </details>
+
+For details on custom serializations, check the [Serialization Standard](../../concepts/serialization-standard.md). Also, the [Types](../json-rpc/types_chain.md) page defines the terms used in the event stream output.
 
 ### FinalitySignature
 

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -10,7 +10,13 @@ Events are divided into three categories and streamed on their respective endpoi
 
 - **Deploy events** - Associated with [Deploys](../../concepts/design/casper-design.md#execution-semantics-deploys) on a node. Currently, only a `DeployAccepted` event is emitted. The URL to consume deploy-related events on Mainnet and Testnet is `http://<HOST>:9999/events/deploys/`.
 - **Finality Signature events** - Emitted when the block has been finalized and cannot be altered. The URL to consume finality signature events on Mainnet and Testnet is `http://<HOST>:9999/events/sigs/`.
-- **Main events** - All other events fall under this type: `ApiVersion`, `BlockAdded`, `DeployProcessed`, `DeployExpired`, `Fault`, `Step`, and `Shutdown` events. The URL to consume these events on Mainnet and Testnet is `http://<HOST>:9999/events/main/`.
+- **Main events** - All other events fall under this type, including: `BlockAdded`, `DeployProcessed`, `DeployExpired`, `Fault`, `Step`, and `Shutdown` events. The URL to consume these events on Mainnet and Testnet is `http://<HOST>:9999/events/main/`.
+
+:::note
+
+An `ApiVersion` event is always emitted when a new client connects to a node's SSE server, informing the client of the node's software version.
+
+:::
 
 ## Listening to the Event Stream
 
@@ -68,6 +74,14 @@ Replace `CHANNEL` with one of the following event streams:
 - `sigs` for `FinalitySignature` events.
 
 ## Event Types
+
+### ApiVersion
+
+The `ApiVersion` event is always the first event emitted when a new client connects to a node's SSE server. It specifies the protocol version of a node on the Casper platform. The following example contains the JSON representation of the `ApiVersion` event structure.
+
+```bash
+data:{"ApiVersion":"1.0.0"}
+```
 
 ### BlockAdded
 

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -6,11 +6,12 @@ The Casper platform uses event streaming to signal state changes in smart contra
 
 Each Casper node streams events through the SSE (Server Sent Event) server via the port specified as the `event_stream_server.address` in the node's *config.toml*. This port is by default `9999` for nodes on [Testnet](https://testnet.cspr.live/tools/peers) and [Mainnet](https://cspr.live/tools/peers).
 
-Events are divided into three categories and streamed on their respective paths:
-<!-- TODO check definitions and add the paths for each stream -->
-- **Deploy events** - Associated with [Deploys](../../concepts/design/casper-design.md#execution-semantics-deploys) on a node. Currently, only a `DeployAccepted` event is emitted.
-- **Finality Signature events** - The block has been finalized and cannot be altered.
-- **Main events** - `ApiVersion`, `BlockAdded`, `DeployProcessed`, `DeployExpired`, `Fault`, `Step`, and `Shutdown` events.
+
+Events are divided into three categories and streamed on their respective endpoints:
+
+- **Deploy events** - Associated with [Deploys](../../concepts/design/casper-design.md#execution-semantics-deploys) on a node. Currently, only a `DeployAccepted` event is emitted. The URL to consume deploy-related events on Mainnet and Testnet is `http://<HOST>:9999/events/deploys/`.
+- **Finality Signature events** - Emitted when the block has been finalized and cannot be altered. The URL to consume finality signature events on Mainnet and Testnet is `http://<HOST>:9999/events/sigs/`.
+- **Main events** - All other events fall under this type: `ApiVersion`, `BlockAdded`, `DeployProcessed`, `DeployExpired`, `Fault`, `Step`, and `Shutdown` events. The URL to consume these events on Mainnet and Testnet is `http://<HOST>:9999/events/main/`.
 
 This page describes how to listen and respond to each event type. For details on custom serializations, check the [Serialization Standard](../../concepts/serialization-standard.md). Also, the [Types](../json-rpc/types_chain.md) page defines the terms used in the event stream output.
 

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -2,11 +2,9 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 # Monitoring and Consuming Events
 
-The Casper platform uses event streaming to signal state changes in smart contracts and nodes. Emitted events can be captured by applications that are actively listening for them. Using Casper's client-side SDKs, dApps can consume these events and perform actions based on event data.
+The Casper platform uses event streaming to signal state changes in smart contracts and nodes. Using Casper's client-side SDKs, dApps actively listening for emitted events can consume these events and perform actions based on event data.
 
-A node on a Casper network streams events through the SSE (Server Sent Event) server. The default configuration of the Casper node provides event streaming via the port specified as the `event_stream_server.address` in the node's *config.toml*. This port is by default `9999` for nodes on [Testnet](https://testnet.cspr.live/tools/peers) and [Mainnet](https://cspr.live/tools/peers).
-
-Casper nodes emit three event streams on their corresponding endpoints.
+Each Casper node streams events through the SSE (Server Sent Event) server via the port specified as the `event_stream_server.address` in the node's *config.toml*. This port is by default `9999` for nodes on [Testnet](https://testnet.cspr.live/tools/peers) and [Mainnet](https://cspr.live/tools/peers).
 
 <!--TODO add the original content back:
 
@@ -26,11 +24,11 @@ All the events other than DeployAccepted and FinalitySignature fall under this t
 
 -->
 
-Refer to the [serialization standard](../../concepts/serialization-standard.md) to get details on required custom serializations and the [types](../json-rpc/types_chain.md) page to find definitions of the terms used in the event stream output.
+This page describes each event type, and how to listen and respond to events. For details on custom serializations, check the [Serialization Standard](../../concepts/serialization-standard.md). Also, the [Types](../json-rpc/types_chain.md) page defines the terms used in the event stream output.
 
 ## Listening to the Event Stream
 
-Set up an event listener in your dApp using the following code:
+To consume the event stream, set up an event listener in your dApp using the following code:
 
 <Tabs>
 
@@ -87,7 +85,8 @@ Replace `CHANNEL` with one of the following event categories:
 
 ### BlockAdded
 
-Emitted when a new block is added to the blockchain and stored locally in the node.
+`BlockAdded` events are emitted when a new block is added to the blockchain and stored locally in the node.
+<!--TODO double check this definition with the design section -->
 
 <details>
 <summary>Expand to view output</summary>
@@ -129,7 +128,7 @@ Emitted when a new block is added to the blockchain and stored locally in the no
 
 ### DeployAccepted
 
-Emitted when a node on the network receives a deploy.
+`DeployAccepted` events are emitted when a node on the network receives a deploy.
 
 <details>
 <summary>Expand to view output</summary>
@@ -199,7 +198,7 @@ Emitted when a node on the network receives a deploy.
 
 ### FinalitySignature
 
-This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/design/casper-design.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures. <!-- TODO not sure about the first part of this explanation, need to double check it: "final approvals from validators are signe" -->
+This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/deploy-and-deploy-lifecycle.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures. <!-- TODO not sure about the first part of this explanation, need to double check it: "final approvals from validators are signed" -->
 
 <details>
 <summary>Expand to view output</summary>
@@ -224,7 +223,7 @@ This event indicates that the final approvals from validators are signed and fur
 
 ### DeployProcessed
 
-Emitted when a deploy is processed on the blockchain and has not expired. Applications can listen to deploys from a certain account, during a certain time, containing certain data, etc, parse the data and discard what is not needed.
+Emitted when a deploy is processed on the blockchain and has not expired. Applications can listen to deploys for a specific account, during a certain time, containing some data, parse the data and discard what is not needed. <!-- TODO double check this definition -->
 
 <details>
 <summary>Expand to view output</summary>
@@ -394,7 +393,7 @@ The `Shutdown` event is emitted when the node is about to shut down, usually for
 
 ## Reacting to Events
 
-To perform functions upon receiving event data, an application may parse each event needed for its use case and respond accordingly. The dApp may act on some events and not others, or it may act upon them all. Each event type contains additional data that might help in deciding whether or not to take an action. For example, `DeployAccepted` events contain the public key of the account that submitted the deploy, the contract address, and more. This information can be useful in determining how to proceed, or whether not react at all.
+To perform functions upon receiving event data, an application may parse each event needed for its use case and respond accordingly. The dApp may act on some events and not others, or it may act upon them all depending on its use case. Each event type contains additional data that might help in deciding whether or not to take an action. For example, `DeployAccepted` events contain the public key of the account that submitted the deploy, the contract address, and more. This information can be useful in determining how to proceed, or whether not react at all. <!-- TODO simplify this paragraph -->
 
 <Tabs>
 
@@ -424,7 +423,7 @@ def eventHandler(event):
 
 ## Unsubscribing from Events
 
-In many cases, an application may need to unsubscribe after a certain amount of time, or may want to unsubscribe from some events but not others. Casper's SDKs provide this ability with the `unsubscribe` function:
+In many cases, an application may need to unsubscribe after a certain amount of time, or may want to unsubscribe from some events but not others. The Casper SDKs provide this ability with the `unsubscribe` function:
 
 <Tabs>
 
@@ -442,7 +441,7 @@ es.unsubscribe(EventName.EVENT_NAME)
 
 ## Stopping the Event Stream
 
-A dApp may cease listening to events altogether using the `stop` function:
+A dApp may cease listening to all events using the `stop` function:
 
 <Tabs>
 

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -10,10 +10,9 @@ Events are divided into three categories and streamed on their respective paths:
 <!-- TODO check definitions and add the paths for each stream -->
 - **Deploy events** - Associated with [Deploys](../../concepts/design/casper-design.md#execution-semantics-deploys) on a node. Currently, only a `DeployAccepted` event is emitted.
 - **Finality Signature events** - The block has been finalized and cannot be altered.
-section to learn more about finality signatures.
 - **Main events** - `ApiVersion`, `BlockAdded`, `DeployProcessed`, `DeployExpired`, `Fault`, `Step`, and `Shutdown` events.
 
-This page describes each event type, and how to listen and respond to events. For details on custom serializations, check the [Serialization Standard](../../concepts/serialization-standard.md). Also, the [Types](../json-rpc/types_chain.md) page defines the terms used in the event stream output.
+This page describes how to listen and respond to each event type. For details on custom serializations, check the [Serialization Standard](../../concepts/serialization-standard.md). Also, the [Types](../json-rpc/types_chain.md) page defines the terms used in the event stream output.
 
 ## Listening to the Event Stream
 
@@ -109,7 +108,7 @@ Replace `CHANNEL` with one of the following event categories:
 }
 ```
 
-- [block_hash](../../concepts/serialization-standard.md#block-hash) - The cryptographic hash that is used to identify a block.
+- [block_hash](../../concepts/serialization-standard.md#block-hash) - The cryptographic hash that identifies a block.
 - [block](../../concepts/serialization-standard.md#serialization-standard-block) - The JSON representation of the block.
 - [proposer](../../concepts/serialization-standard.md#body) - The validator selected to propose the block.
 
@@ -181,13 +180,13 @@ Replace `CHANNEL` with one of the following event categories:
 * [body_hash](../../concepts/hash-types.md) - The blake2b hash of the deploy body.
 * [payment](../../concepts/glossary/P.md#payment-code) - Gas payment information.
 * [session](../../concepts/session-code.md#what-is-session-code) - The session logic defining the deploy's functionality.
-* [approvals](../json-rpc/types_chain.md#approval) - The signer's hexadecimal-encoded public key along with its signature.
+* [approvals](../json-rpc/types_chain.md#approval) - The signer's hexadecimal-encoded public key and signature.
 
 </details>
 
 ### FinalitySignature
 
-This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/deploy-and-deploy-lifecycle.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures. 
+This event indicates that the final approvals from validators are signed, and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/deploy-and-deploy-lifecycle.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures. 
 
 <details>
 <summary>Expand to view output</summary>
@@ -203,16 +202,17 @@ This event indicates that the final approvals from validators are signed and fur
 }
 ```
 
-- [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash that is used to identify a block.
+<!-- TODO check definitions -->
+- [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash identifying a block.
 - [era_id](../../concepts/serialization-standard.md#eraid) - The period of time used to specify when specific events in a blockchain network occur.
-- [signature](../../concepts/serialization-standard.md#signature) - A serialized byte representation of the validator's signature.
+- [signature](../../concepts/serialization-standard.md#signature) - Serialized bytes representing the validator's signature.
 - [public_key](../../concepts/serialization-standard.md#publickey) - The hexadecimal-encoded public key of the validator.
 
 </details>
 
 ### DeployProcessed
 
-Emitted when a deploy is processed on the blockchain and has not expired. Applications can listen to deploys for a specific account, during a certain time, containing some data, parse the data and discard what is not needed. <!-- TODO double check this definition -->
+These events are emitted when a deploy is processed on the blockchain and has not expired. Applications can listen to deploys for a specific account during a particular time, containing some data, parse the data and discard what is not needed. <!-- TODO double check this definition -->
 
 <details>
 <summary>Expand to view output</summary>
@@ -249,9 +249,9 @@ Emitted when a deploy is processed on the blockchain and has not expired. Applic
 
 * [deploy_hash](../../concepts/serialization-standard.md#deploy-hash) - The cryptographic hash of a Deploy.
 * [account](../../concepts/serialization-standard.md#serialization-standard-account) - The hexadecimal-encoded public key of the account submitting the deploy.
-* [timestamp](../../concepts/serialization-standard.md#timestamp) - A timestamp type, representing a concrete moment in time.
+* [timestamp](../../concepts/serialization-standard.md#timestamp) - A timestamp type representing a concrete moment in time.
 * [dependencies](../../concepts/serialization-standard.md#deploy-header) - A list of Deploy hashes. 
-* [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash that is used to identify a Block.
+* [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash identifying a Block.
 * [execution_result](../../concepts/serialization-standard.md#executionresult) - The execution status of the deploy, which is either `Success` or `Failure`.
 
 </details>
@@ -293,7 +293,7 @@ The `Fault` event is emitted if there is a validator error.
 ```
 
 * [era_id](../../concepts/serialization-standard.md#eraid) - The period of time used to specify when specific events in a blockchain network occur.
-* [public_key](../../concepts/serialization-standard.md#publickey) - The hexadecimal-encoded public key of the validator that faulted.
+* [public_key](../../concepts/serialization-standard.md#publickey) - The hexadecimal-encoded public key of the validator that caused the fault.
 * [timestamp](../../concepts/serialization-standard.md#timestamp) - A timestamp representing the moment the validator faulted.
 
 </details>
@@ -367,7 +367,7 @@ The `Step` event is emitted at the end of every era and contains the execution e
 
 ### Shutdown
 
-The `Shutdown` event is emitted when the node is about to shut down, usually for an upgrade. This causes a termination of the event stream.
+The `Shutdown` event is emitted when the node is about to shut down, usually for an upgrade, causing a termination of the event stream.
 
 <details>
 <summary>Expand the below section to view the Shutdown event details:</summary>
@@ -375,14 +375,14 @@ The `Shutdown` event is emitted when the node is about to shut down, usually for
 ```bash
 "Shutdown"
 ```
-* Shutdown - The "Shutdown" text notifies the event listener that a shutdown will be occurring.
+* Shutdown - The "Shutdown" text notifies the event listener that a shutdown will occur.
 
 </details>
 
 
 ## Reacting to Events
 
-To perform functions upon receiving event data, an application may parse each event needed for its use case and respond accordingly. The dApp may act on some events and not others, or it may act upon them all depending on its use case. Each event type contains additional data that might help in deciding whether or not to take an action. For example, `DeployAccepted` events contain the public key of the account that submitted the deploy, the contract address, and more. This information can be useful in determining how to proceed, or whether not react at all. <!-- TODO simplify this paragraph -->
+An application may parse each event needed for its use case and respond accordingly. The dApp may act on some events and not others, or it may act upon them all, depending on its use case. Each event type contains additional data that might help in deciding whether or not to take an action. For example, `DeployAccepted` events contain the account's public key that submitted the deploy, the contract address, and more. This information can help determine how to proceed or whether or not to react.
 
 <Tabs>
 
@@ -412,7 +412,7 @@ def eventHandler(event):
 
 ## Unsubscribing from Events
 
-In many cases, an application may need to unsubscribe after a certain amount of time, or may want to unsubscribe from some events but not others. The Casper SDKs provide this ability with the `unsubscribe` function:
+In many cases, an application may need to unsubscribe after a certain time or may want to unsubscribe from some events but not others. The Casper SDKs provide this ability with the `unsubscribe` function:
 
 <Tabs>
 
@@ -446,7 +446,7 @@ es.stop()
 
 ## Replaying the Event Stream
 
-This command will replay the event stream from an old event onwards. Replace the `NODE_ADDRESS`, `CHANNEL`, and `ID` fields with the values of your scenario.
+This command will replay the event stream from an old event onward. Replace the `NODE_ADDRESS`, `CHANNEL`, and `ID` fields with the values of your scenario.
 
 <Tabs>
 
@@ -466,11 +466,11 @@ curl -sN http://65.21.235.219:9999/events/main?start_from=29267508
 
 </Tabs>
 
-Each URL can have a query string added to the form `?start_from=ID`, where ID is an integer representing an old event ID. With this query, you can replay the event stream from that old event onwards. If you specify an event ID that has already been purged from the cache, the server will replay all the cached events.
+Each URL can have a query string added to the form `?start_from=ID`, where ID is an integer representing an old event ID. With this query, you can replay the event stream from that old event onward. If you specify an event ID already purged from the cache, the server will replay all the cached events.
 
 :::note
 
 The server keeps only a limited number of events cached to allow replaying the stream to clients using the `?start_from=` query string. The cache size can be set differently on each node using the `event_stream_buffer_length` value in the *config.toml*. By default, it is only 5000. 
-The intended use case is to allow a client consuming the event stream that loses its connection to reconnect and hopefully catch up with events that were emitted while it was disconnected.
+The intended use case is to allow a client consuming the event stream that loses its connection to reconnect and catch up with events that were emitted while it was disconnected.
 
 :::

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -6,23 +6,12 @@ The Casper platform uses event streaming to signal state changes in smart contra
 
 Each Casper node streams events through the SSE (Server Sent Event) server via the port specified as the `event_stream_server.address` in the node's *config.toml*. This port is by default `9999` for nodes on [Testnet](https://testnet.cspr.live/tools/peers) and [Mainnet](https://cspr.live/tools/peers).
 
-<!--TODO add the original content back:
-
-There are three types of event streams in our platform categorized based on the emitting endpoint of the nodes. Those are:
-
-Deploy events
-
-These are associated with Deploys on a node. Currently, only DeployAccepted event is emitted . Refer to the Deploys section to discover more about Deploys and their life cycles.
-
-Finality Signature event
-
-This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the consensus reached section and block finality section to learn more about finality signatures.
-
-Main events
-
-All the events other than DeployAccepted and FinalitySignature fall under this type. Those are ApiVersion, BlockAdded, DeployProcessed, DeployExpired, Fault, Step, and Shutdown events.
-
--->
+Events are divided into three categories and streamed on their respective paths:
+<!-- TODO check definitions and add the paths for each stream -->
+- **Deploy events** - Associated with [Deploys](../../concepts/design/casper-design.md#execution-semantics-deploys) on a node. Currently, only a `DeployAccepted` event is emitted.
+- **Finality Signature events** - The block has been finalized and cannot be altered.
+section to learn more about finality signatures.
+- **Main events** - `ApiVersion`, `BlockAdded`, `DeployProcessed`, `DeployExpired`, `Fault`, `Step`, and `Shutdown` events.
 
 This page describes each event type, and how to listen and respond to events. For details on custom serializations, check the [Serialization Standard](../../concepts/serialization-standard.md). Also, the [Types](../json-rpc/types_chain.md) page defines the terms used in the event stream output.
 
@@ -198,7 +187,7 @@ Replace `CHANNEL` with one of the following event categories:
 
 ### FinalitySignature
 
-This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/deploy-and-deploy-lifecycle.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures. <!-- TODO not sure about the first part of this explanation, need to double check it: "final approvals from validators are signed" -->
+This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/deploy-and-deploy-lifecycle.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures. 
 
 <details>
 <summary>Expand to view output</summary>

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -1,6 +1,6 @@
 import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
-# Monitor and Consume Events
+# Monitoring and Consuming Events
 
 The Casper platform uses event streaming to signal state changes in smart contracts and nodes. Emitted events can be captured by applications that are actively listening for them. Using Casper's client-side SDKs, dApps can consume these events and perform actions based on event data.
 
@@ -129,7 +129,7 @@ Emitted when a new block is added to the blockchain and stored locally in the no
 
 ### DeployAccepted
 
-Emitted when a deploy executes successfully and is accepted on the network. <!--TODO this is not correct. -->
+Emitted when a node on the network receives a deploy.
 
 <details>
 <summary>Expand to view output</summary>

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -2,13 +2,35 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 
 # Monitor and Consume Events
 
-The Casper Network emits events through its native event stream, which can be captured by applications that are actively listning for them. Using Casper's client side SDKs, you can consume these events within your dApp and perform actions based on event data.
+The Casper platform uses event streaming to signal state changes in smart contracts and nodes. Emitted events can be captured by applications that are actively listening for them. Using Casper's client-side SDKs, dApps can consume these events and perform actions based on event data.
 
-The default configuration of the Casper node provides event streaming via the port specified as the `event_stream_server.address` in the node's *config.toml*, which is by default `9999` for nodes on [Testnet](https://testnet.cspr.live/tools/peers) and [Mainnet](https://cspr.live/tools/peers). 
+A node on a Casper network streams events through the SSE (Server Sent Event) server. The default configuration of the Casper node provides event streaming via the port specified as the `event_stream_server.address` in the node's *config.toml*. This port is by default `9999` for nodes on [Testnet](https://testnet.cspr.live/tools/peers) and [Mainnet](https://cspr.live/tools/peers).
 
-## Listen to the Event Stream
+Casper nodes emit three event streams on their corresponding endpoints.
 
-Setup an event listener in your app using the following:
+<!--TODO add the original content back:
+
+There are three types of event streams in our platform categorized based on the emitting endpoint of the nodes. Those are:
+
+Deploy events
+
+These are associated with Deploys on a node. Currently, only DeployAccepted event is emitted . Refer to the Deploys section to discover more about Deploys and their life cycles.
+
+Finality Signature event
+
+This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the consensus reached section and block finality section to learn more about finality signatures.
+
+Main events
+
+All the events other than DeployAccepted and FinalitySignature fall under this type. Those are ApiVersion, BlockAdded, DeployProcessed, DeployExpired, Fault, Step, and Shutdown events.
+
+-->
+
+Refer to the [serialization standard](../../concepts/serialization-standard.md) to get details on required custom serializations and the [types](../json-rpc/types_chain.md) page to find definitions of the terms used in the event stream output.
+
+## Listening to the Event Stream
+
+Set up an event listener in your dApp using the following code:
 
 <Tabs>
 
@@ -52,20 +74,14 @@ curl -s http://NODE_ADDRESS:9999/events/CHANNEL
 
 </Tabs>
 
-:::tip
+You can find node addresses of active online peers to replace `NODE_ADDRESS`, by navigating to [cspr.live](https://cspr.live/tools/peers) for Mainnet and [testnet.cspr.live](https://testnet.cspr.live/tools/peers) for Testnet.
 
-You can find active online peers' `NODE_ADDRESS`es at [cspr.live](https://cspr.live/tools/peers) for mainnet and [testnet.cspr.live](https://testnet.cspr.live/tools/peers) for testnet.
+Replace `EVENT_NAME` with one of the event types listed [below](#event-types).
 
-:::
-
-Where `CHANNEL` is replaced with;
- `main` for the following event types;
- `ApiVersion`, `BlockAdded`, `DeployExpired`, `DeployProcessed`, `Fault` or `Step`. 
-`deploys` for event types;
- `DeployAccepted`, or 
-`sigs` for event type `FinalitySignature`.
-
-And where `EVENT_NAME` is one of the following different types of events emitted by the Casper Network:
+Replace `CHANNEL` with one of the following event categories:
+- `main` for `ApiVersion`, `BlockAdded`, `DeployExpired`, `DeployProcessed`, `Fault`, or `Step` events.
+- `deploys` for `DeployAccepted` events.
+- `sigs` for `FinalitySignature` events.
 
 ## Event Types
 
@@ -105,23 +121,15 @@ Emitted when a new block is added to the blockchain and stored locally in the no
 }
 ```
 
-- [block_hash](../../concepts/serialization-standard.md#block-hash)
-
-  The cryptographic hash that is used to identify a block.
-
-- [block](../../concepts/serialization-standard.md#serialization-standard-block)
-
-  The JSON representation of the block.
-
-- [proposer](../../concepts/serialization-standard.md#body)
-
-  The validator selected to propose the block.
+- [block_hash](../../concepts/serialization-standard.md#block-hash) - The cryptographic hash that is used to identify a block.
+- [block](../../concepts/serialization-standard.md#serialization-standard-block) - The JSON representation of the block.
+- [proposer](../../concepts/serialization-standard.md#body) - The validator selected to propose the block.
 
 </details>
 
 ### DeployAccepted
 
-Emitted when a deploy executes successfully and is accepted on the network.
+Emitted when a deploy executes successfully and is accepted on the network. <!--TODO this is not correct. -->
 
 <details>
 <summary>Expand to view output</summary>
@@ -180,35 +188,18 @@ Emitted when a deploy executes successfully and is accepted on the network.
 }
 ```
 
-* [hash](../../concepts/hash-types.md)
-
-  The blake2b hash of the deploy.
-
-* [account](../../concepts/serialization-standard.md#serialization-standard-account)
-
-  The hexadecimal-encoded public key of the account submitting the deploy.
-
-* [body_hash](../../concepts/hash-types.md)
-
-  The blake2b hash of the deploy body.
-
-* [payment](../../concepts/glossary/P.md#payment-code)
-
-  Gas payment information.
-
-* [session](../../concepts/session-code.md#what-is-session-code)
-
-  The session logic defining the deploy's functionality.
-
-* [approvals](../json-rpc/types_chain.md#approval)
-
-  The signer's hexadecimal-encoded public key along with its signature.
+* [hash](../../concepts/hash-types.md) - The blake2b hash of the deploy.
+* [account](../../concepts/serialization-standard.md#serialization-standard-account) - The hexadecimal-encoded public key of the account submitting the deploy.
+* [body_hash](../../concepts/hash-types.md) - The blake2b hash of the deploy body.
+* [payment](../../concepts/glossary/P.md#payment-code) - Gas payment information.
+* [session](../../concepts/session-code.md#what-is-session-code) - The session logic defining the deploy's functionality.
+* [approvals](../json-rpc/types_chain.md#approval) - The signer's hexadecimal-encoded public key along with its signature.
 
 </details>
 
 ### FinalitySignature
 
-This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/design/casper-design.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures.
+This event indicates that the final approvals from validators are signed and further alterations to the block will not be allowed. Refer to the [consensus reached](../../concepts/design/casper-design.md#consensus-reached) and [block finality](../../concepts/glossary/B.md#block-finality) sections to learn more about finality signatures. <!-- TODO not sure about the first part of this explanation, need to double check it: "final approvals from validators are signe" -->
 
 <details>
 <summary>Expand to view output</summary>
@@ -224,27 +215,16 @@ This event indicates that the final approvals from validators are signed and fur
 }
 ```
 
-- [block_hash](../../concepts/serialization-standard.md#block-hash)
-
-  A cryptographic hash that is used to identify a block.
-
-- [era_id](../../concepts/serialization-standard.md#eraid)
-
-  The period of time used to specify when specific events in a blockchain network occur.
-
-- [signature](../../concepts/serialization-standard.md#signature)
-
-  A serialized byte representation of the validator's signature.
-
-- [public_key](../../concepts/serialization-standard.md#publickey)
-
-  The hexadecimal-encoded public key of the validator.
+- [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash that is used to identify a block.
+- [era_id](../../concepts/serialization-standard.md#eraid) - The period of time used to specify when specific events in a blockchain network occur.
+- [signature](../../concepts/serialization-standard.md#signature) - A serialized byte representation of the validator's signature.
+- [public_key](../../concepts/serialization-standard.md#publickey) - The hexadecimal-encoded public key of the validator.
 
 </details>
 
 ### DeployProcessed
 
-Emitted when a deploy is processed on the blockchain. This applies to every deploy; to listen to deploys from a certain account, during a certain time, containing certain data, etc, parse the data and discard what is not needed.
+Emitted when a deploy is processed on the blockchain and has not expired. Applications can listen to deploys from a certain account, during a certain time, containing certain data, etc, parse the data and discard what is not needed.
 
 <details>
 <summary>Expand to view output</summary>
@@ -279,35 +259,18 @@ Emitted when a deploy is processed on the blockchain. This applies to every depl
 }
 ```
 
-* [deploy_hash](../../concepts/serialization-standard.md#deploy-hash)
-
-  The cryptographic hash of a Deploy.
-
-* [account](../../concepts/serialization-standard.md#serialization-standard-account)
-
-  The hexadecimal-encoded public key of the account submitting the deploy.
-
-* [timestamp](../../concepts/serialization-standard.md#timestamp)
-
-  A timestamp type, representing a concrete moment in time.
-
-* [dependencies](../../concepts/serialization-standard.md#deploy-header)
-
-  A list of Deploy hashes. 
-
-* [block_hash](../../concepts/serialization-standard.md#block-hash)
-
-  A cryptographic hash that is used to identify a Block.
-
-* [execution_result](../../concepts/serialization-standard.md#executionresult)
-
-  The execution status of the deploy (Success or Failure).
+* [deploy_hash](../../concepts/serialization-standard.md#deploy-hash) - The cryptographic hash of a Deploy.
+* [account](../../concepts/serialization-standard.md#serialization-standard-account) - The hexadecimal-encoded public key of the account submitting the deploy.
+* [timestamp](../../concepts/serialization-standard.md#timestamp) - A timestamp type, representing a concrete moment in time.
+* [dependencies](../../concepts/serialization-standard.md#deploy-header) - A list of Deploy hashes. 
+* [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash that is used to identify a Block.
+* [execution_result](../../concepts/serialization-standard.md#executionresult) - The execution status of the deploy, which is either `Success` or `Failure`.
 
 </details>
 
 ### DeployExpired
 
-`DeployExpired` event is emitted when a Deploy becomes no longer valid to be executed or added to a block due to their times to live (TTLs) expiring.
+A `DeployExpired` event is emitted when the Deploy is no longer valid for processing or being added to a block due to its time to live (TTL) having expired.
 
 <details>
   <summary>Expand to view output</summary>
@@ -320,9 +283,7 @@ Emitted when a deploy is processed on the blockchain. This applies to every depl
 }
 ```
 
-* [deploy_hash](../../concepts/serialization-standard.md#deploy-hash)
-
-  The cryptographic hash of a Deploy.
+* [deploy_hash](../../concepts/serialization-standard.md#deploy-hash) - The cryptographic hash of a Deploy.
 
 </details>
 
@@ -409,21 +370,10 @@ The `Step` event is emitted at the end of every era and contains the execution e
 }
 ```
 
-* [era_id](../../concepts/serialization-standard.md#eraid)
-
-  The period of time is used to specify when specific events in a blockchain network will occur.
-
-* [execution_effect](../../concepts/serialization-standard.md#executioneffect)
-
-  The journal of execution transforms from a single Deploy.
-
-* [operations](../../concepts/serialization-standard.md#operation)
-
-  Operations performed while executing a deploy.
-
-* [transform](../../concepts/serialization-standard.md#transform)
-
-  The actual transformation performed while executing a deploy.
+* [era_id](../../concepts/serialization-standard.md#eraid) - The period of time is used to specify when specific events in a blockchain network will occur.
+* [execution_effect](../../concepts/serialization-standard.md#executioneffect) - The journal of execution transforms from a single Deploy.
+* [operations](../../concepts/serialization-standard.md#operation) - Operations performed while executing a deploy.
+* [transform](../../concepts/serialization-standard.md#transform) - The actual transformation performed while executing a deploy.
 
 </details>
 
@@ -437,19 +387,14 @@ The `Shutdown` event is emitted when the node is about to shut down, usually for
 ```bash
 "Shutdown"
 ```
-* Shutdown
-
-  The "Shutdown" text notifies the event listener that a shutdown will be occurring.
+* Shutdown - The "Shutdown" text notifies the event listener that a shutdown will be occurring.
 
 </details>
 
----
 
-Refer to the [serialization standard](../../concepts/serialization-standard.md) page to get details on required custom serializations and the [types](../json-rpc/types_chain.md) page to find definitions of the terms used in the event stream output.
+## Reacting to Events
 
-## Act on Events
-
-To perform functions upon receiving event data, you will need to parse each event that is recognized and respond in your own way. You may choose to act on some events and not others, or you may act upon them all. For each event type, there will be more data you can check to decide if the event received is one you want to react to. For example, `DeployAccepted` events will contain the public key of the account that submitted the deploy, the contract address, and more. You can use this information to determine whether you would like to react and how, or not.
+To perform functions upon receiving event data, an application may parse each event needed for its use case and respond accordingly. The dApp may act on some events and not others, or it may act upon them all. Each event type contains additional data that might help in deciding whether or not to take an action. For example, `DeployAccepted` events contain the public key of the account that submitted the deploy, the contract address, and more. This information can be useful in determining how to proceed, or whether not react at all.
 
 <Tabs>
 
@@ -477,9 +422,9 @@ def eventHandler(event):
 
 </Tabs>
 
-## Unsubscribe from Events
+## Unsubscribing from Events
 
-In many cases, you may want to only be subscribed to events for a certain amount of time, or may want to unsubscribe from some events but not others. Casper's SDKs provide this ability:
+In many cases, an application may need to unsubscribe after a certain amount of time, or may want to unsubscribe from some events but not others. Casper's SDKs provide this ability with the `unsubscribe` function:
 
 <Tabs>
 
@@ -493,11 +438,11 @@ es.unsubscribe(EventName.EVENT_NAME)
 
 </Tabs>
 
-Where `EVENT_NAME` is one of the different [event types](#event-types) emitted by the Casper Network.
+- `EVENT_NAME` - One of the different [event types](#event-types) emitted by a Casper node.
 
-## Stop Streaming Events
+## Stopping the Event Stream
 
-If at any time in the lifecycle of your dApp you would like to cease listening to events altogether, you may do so using:
+A dApp may cease listening to events altogether using the `stop` function:
 
 <Tabs>
 
@@ -511,7 +456,7 @@ es.stop()
 
 </Tabs>
 
-## Replay Event Stream
+## Replaying the Event Stream
 
 This command will replay the event stream from an old event onwards. Replace the `NODE_ADDRESS`, `CHANNEL`, and `ID` fields with the values of your scenario.
 

--- a/source/docs/casper/developers/dapps/monitor-and-consume-events.md
+++ b/source/docs/casper/developers/dapps/monitor-and-consume-events.md
@@ -17,7 +17,7 @@ This page describes how to listen and respond to each event type. For details on
 
 ## Listening to the Event Stream
 
-To consume the event stream, set up an event listener in your dApp using the following code:
+Applications can listen for such events for a specific account during a particular era, containing certain data. Then, they can parse the data and discard what is not needed. To consume the event stream, set up an event listener in your dApp using the following code:
 
 <Tabs>
 
@@ -65,7 +65,7 @@ You can find node addresses of active online peers to replace `NODE_ADDRESS`, by
 
 Replace `EVENT_NAME` with one of the event types listed [below](#event-types).
 
-Replace `CHANNEL` with one of the following event categories:
+Replace `CHANNEL` with one of the following event streams:
 - `main` for `ApiVersion`, `BlockAdded`, `DeployExpired`, `DeployProcessed`, `Fault`, or `Step` events.
 - `deploys` for `DeployAccepted` events.
 - `sigs` for `FinalitySignature` events.
@@ -74,8 +74,7 @@ Replace `CHANNEL` with one of the following event categories:
 
 ### BlockAdded
 
-`BlockAdded` events are emitted when a new block is added to the blockchain and stored locally in the node.
-<!--TODO double check this definition with the design section -->
+A `BlockAdded` event is emitted when a new block is added to the blockchain and stored locally in the node.
 
 <details>
 <summary>Expand to view output</summary>
@@ -176,11 +175,11 @@ Replace `CHANNEL` with one of the following event categories:
 }
 ```
 
-* [hash](../../concepts/hash-types.md) - The blake2b hash of the deploy.
-* [account](../../concepts/serialization-standard.md#serialization-standard-account) - The hexadecimal-encoded public key of the account submitting the deploy.
-* [body_hash](../../concepts/hash-types.md) - The blake2b hash of the deploy body.
+* [hash](../../concepts/hash-types.md) - The blake2b hash of the Deploy.
+* [account](../../concepts/serialization-standard.md#serialization-standard-account) - The hexadecimal-encoded public key of the account submitting the Deploy.
+* [body_hash](../../concepts/hash-types.md) - The blake2b hash of the Deploy body.
 * [payment](../../concepts/glossary/P.md#payment-code) - Gas payment information.
-* [session](../../concepts/session-code.md#what-is-session-code) - The session logic defining the deploy's functionality.
+* [session](../../concepts/session-code.md#what-is-session-code) - The session logic defining the Deploy's functionality.
 * [approvals](../json-rpc/types_chain.md#approval) - The signer's hexadecimal-encoded public key and signature.
 
 </details>
@@ -203,9 +202,8 @@ This event indicates that the final approvals from validators are signed, and fu
 }
 ```
 
-<!-- TODO check definitions -->
-- [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash identifying a block.
-- [era_id](../../concepts/serialization-standard.md#eraid) - The period of time used to specify when specific events in a blockchain network occur.
+- [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash identifying a Block.
+- [era_id](../../concepts/serialization-standard.md#eraid) - A period of time during which the validator set does not change.
 - [signature](../../concepts/serialization-standard.md#signature) - Serialized bytes representing the validator's signature.
 - [public_key](../../concepts/serialization-standard.md#publickey) - The hexadecimal-encoded public key of the validator.
 
@@ -213,7 +211,7 @@ This event indicates that the final approvals from validators are signed, and fu
 
 ### DeployProcessed
 
-These events are emitted when a deploy is processed on the blockchain and has not expired. Applications can listen to deploys for a specific account during a particular time, containing some data, parse the data and discard what is not needed. <!-- TODO double check this definition -->
+A `DeployProcessed` event is emitted when a given Deploy has been executed.
 
 <details>
 <summary>Expand to view output</summary>
@@ -249,11 +247,11 @@ These events are emitted when a deploy is processed on the blockchain and has no
 ```
 
 * [deploy_hash](../../concepts/serialization-standard.md#deploy-hash) - The cryptographic hash of a Deploy.
-* [account](../../concepts/serialization-standard.md#serialization-standard-account) - The hexadecimal-encoded public key of the account submitting the deploy.
+* [account](../../concepts/serialization-standard.md#serialization-standard-account) - The hexadecimal-encoded public key of the account submitting the Deploy.
 * [timestamp](../../concepts/serialization-standard.md#timestamp) - A timestamp type representing a concrete moment in time.
 * [dependencies](../../concepts/serialization-standard.md#deploy-header) - A list of Deploy hashes. 
 * [block_hash](../../concepts/serialization-standard.md#block-hash) - A cryptographic hash identifying a Block.
-* [execution_result](../../concepts/serialization-standard.md#executionresult) - The execution status of the deploy, which is either `Success` or `Failure`.
+* [execution_result](../../concepts/serialization-standard.md#executionresult) - The execution status of the Deploy, which is either `Success` or `Failure`.
 
 </details>
 
@@ -293,7 +291,7 @@ The `Fault` event is emitted if there is a validator error.
 }
 ```
 
-* [era_id](../../concepts/serialization-standard.md#eraid) - The period of time used to specify when specific events in a blockchain network occur.
+* [era_id](../../concepts/serialization-standard.md#eraid) - A period of time during which the validator set does not change.
 * [public_key](../../concepts/serialization-standard.md#publickey) - The hexadecimal-encoded public key of the validator that caused the fault.
 * [timestamp](../../concepts/serialization-standard.md#timestamp) - A timestamp representing the moment the validator faulted.
 
@@ -359,10 +357,10 @@ The `Step` event is emitted at the end of every era and contains the execution e
 }
 ```
 
-* [era_id](../../concepts/serialization-standard.md#eraid) - The period of time is used to specify when specific events in a blockchain network will occur.
+* [era_id](../../concepts/serialization-standard.md#eraid) - A period of time during which the validator set does not change.
 * [execution_effect](../../concepts/serialization-standard.md#executioneffect) - The journal of execution transforms from a single Deploy.
-* [operations](../../concepts/serialization-standard.md#operation) - Operations performed while executing a deploy.
-* [transform](../../concepts/serialization-standard.md#transform) - The actual transformation performed while executing a deploy.
+* [operations](../../concepts/serialization-standard.md#operation) - Operations performed while executing a Deploy.
+* [transform](../../concepts/serialization-standard.md#transform) - The actual transformation performed while executing a Deploy.
 
 </details>
 


### PR DESCRIPTION
### What does this PR fix/introduce?

This is a detailed editing pass for PR #1058. It was easier for me to raise a PR rather than leave comments on #1058. I've also edited some of the original content (before PR 1058), which needed to be refreshed. 

**Summary of changes**
- I kept the original title to be consistent with the rest of the docs.
- I added back some of the original content:
   - information about the 3 event streams (deploys, sigs, main) and their URLs
   - the ApiVersion info
- I rewrote some of the explanations. For example, each node emits events, not the platform as a whole.
- Formatted the bullet points to match what is already in the document and in other parts of the docs.
- Did an editing pass to match the docs style guidelines. 

The technical procedures still need to be reviewed by a developer, this is why the box is not checked below.

Related task: https://github.com/casper-network/docs-new/issues/45.

### Checklist

- [ ] Docs are successfully building - `yarn install && yarn run build`.
- [ ] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [ ] All external links have been verified with `yarn run check:externals`.
- [ ] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [ ] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).
- [ ] If structural changes are introduced (not just content changes), cross-browser testing has been completed.

### Reviewers
@ACStoneCL, @dylanireland or @andrzej-casper 
