### PR TITLE
893 Updating `EraInfo` Type with Parameter

### DIFF
--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -318,6 +318,10 @@ Era ID newtype.
 
 Auction metadata. Intended to be recorded at each era.
 
+Required Parameters:
+
+* [`seigniorage_allocation`](#seigniorageallocation-seigniorageallocation) Information about a seigniorage allocation.
+
 ## EraSummary {#erasummary}
 
 The summary of an era.
@@ -762,7 +766,7 @@ Represents a collection of arguments passed to a smart contract.
 
 ## SeigniorageAllocation {#seigniorageallocation}
 
-Information about a seignorage allocation.
+Information about a seigniorage allocation.
 
 * `Validator` Info about a seigniorage allocation for a validator.
 


### PR DESCRIPTION
### What does this PR fix/introduce?
Including the `seigniorage_allocation` parameter within `EraInfo` on the Types page.

Closes #893 

### Additional context
[EraInfo should contain the actual field set #893](https://github.com/casper-network/docs/issues/893)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ipopescu 
