### PR TITLE
Fix formatting in upgrade tutorial

### DIFF
--- a/source/docs/casper/resources/tutorials/beginner/upgrade-contract.md
+++ b/source/docs/casper/resources/tutorials/beginner/upgrade-contract.md
@@ -2,9 +2,7 @@
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-This tutorial examines how to upgrade an existing contract, a process similar to upgrading any other software. You can change an unlocked [contract package](https://docs.rs/casper-types/latest/casper_types/struct.ContractPackage.html) by adding a new contract and updating the default contract version that the contract package should use. You will need to know the contract package hash and use the [add_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.add_contract_version.html) API. 
-
-**Note:** you can also create a [locked contract package](#locked-contract-package) that cannot be versioned and is therefore not upgradable.
+This tutorial examines how to upgrade an existing contract, a process similar to upgrading any other software. You can change an unlocked [contract package](https://docs.rs/casper-types/latest/casper_types/struct.ContractPackage.html) by adding a new contract and updating the default contract version that the contract package should use. You will need to know the contract package hash and use the [add_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.add_contract_version.html) API. You can also create a [locked contract package](#locked-contract-package) that cannot be versioned and is therefore not upgradable.
 
 ## Video Tutorial {#video-tutorial}
 
@@ -13,30 +11,31 @@ Here is a video walkthrough of this tutorial.
 <iframe width="560" height="315" src="https://www.youtube.com/embed?v=Q4ZXNV8EVTk&list=PL8oWxbJ-csEogSV-M0IPiofWP5I_dLji6&index=4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Prerequisites {#prerequisites}
-- The [ContractPackageHash](https://docs.rs/casper-types/latest/casper_types/contracts/struct.ContractPackageHash.html) referencing the [ContractPackage](https://docs.rs/casper-types/latest/casper_types/struct.ContractPackage.html) where an unlocked contract is stored in global state
-- You should be familiar with [writing smart contracts](/writing-contracts), [on-chain contracts](../../../developers/dapps/sending-deploys.md), and [calling contracts](../../../developers/cli/calling-contracts.md) on a Casper network
-- You have installed [A Counter on the Testnet](/counter-testnet/) that you will upgrade as part of this tutorial
+
+- The [ContractPackageHash](https://docs.rs/casper-types/latest/casper_types/contracts/struct.ContractPackageHash.html) referencing the [ContractPackage](https://docs.rs/casper-types/latest/casper_types/struct.ContractPackage.html) where an unlocked contract is stored in global state.
+- You should be familiar with [writing smart contracts](/writing-contracts), [on-chain contracts](../../../developers/dapps/sending-deploys.md), and [calling contracts](../../../developers/cli/calling-contracts.md) on a Casper network.
+- You have installed [A Counter on the Testnet](/counter-testnet/) that you will upgrade as part of this tutorial.
 
 :::note
 
 Installing the first version of the contract (contract-v1.wasm) as shown in the [counter tutorial](/counter-testnet) is a prerequisite before installing the second version of the contract (contract-v2.wasm).
 
-If you explore [the code](https://github.com/casper-ecosystem/counter/), you will observe the different versions of the contract.
-
-- `contract-v1` is the counter contract you can see in the [A Counter on the Testnet](/counter-testnet/) tutorial
-- `contract-v2` is the contract with the new `counter_decrement` entry point
-
 :::
+
+If you explore [the code](https://github.com/casper-ecosystem/counter/), you will observe the different versions of the contract:
+
+- `contract-v1` is the counter contract you can see in the [A Counter on the Testnet](/counter-testnet/) tutorial.
+- `contract-v2` is the contract with the new `counter_decrement` entry point.
 
 ## Contract Versioning Flow {#contract-versioning-flow}
 
 The following is an example workflow for creating a versioned contract package. Your workflow may differ if you have already created the contract package and have a handle on its hash. 
 
-1. Create a contract in the most common way, using [new_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_contract.html)
-2. Add a new version of the contract using [add_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.add_contract_version.html)
-3. Build the new contract and generate the corresponding `.wasm` file
-4. Install the contract on the network via a deploy
-5. Verify that your new contract version works as desired
+1. Create a contract in the most common way, using [new_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_contract.html).
+2. Add a new version of the contract using [add_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.add_contract_version.html).
+3. Build the new contract and generate the corresponding `.wasm` file.
+4. Install the contract on the network via a deploy.
+5. Verify that your new contract version works as desired.
 
 In this tutorial, you will use [the second version](https://github.com/casper-ecosystem/counter/blob/master/contract-v2/src/main.rs) of the counter contract to perform the upgrade.
 
@@ -63,21 +62,16 @@ When creating the contract, you can specify the package name and access URef for
     runtime::put_key(CONTRACT_VERSION_KEY, version_uref.into());
 ```
 
-The [first version of the counter](https://github.com/casper-ecosystem/counter/blob/57e3912735f93e1d0f667b936675964ecfdc6594/contract-v1/src/main.rs#L94) shows you a contract package that can be versioned. This step is covered in the [A Counter on the Testnet](/counter-testnet/) tutorial.
+The [first version of the counter](https://github.com/casper-ecosystem/counter/blob/57e3912735f93e1d0f667b936675964ecfdc6594/contract-v1/src/main.rs#L94) shows you a contract package that can be versioned. This step is covered in the tutorial for [A Counter on the Testnet](/counter-testnet/).
 
-:::note
+Additional details:
 
-- We are versioning the contract package, not the contract. The contract is always at a set version, and it is the package that specifies the contract version to be used
-- The Wasm file name of the new contract could differ from the old contract; after sending the deploy to the network, the contract package hash connects the different contract versions
-
-:::
+1. We are versioning the contract package, not the contract. The contract is always at a set version, and the package specifies the contract version to be used.
+2. The Wasm file name of the new contract could differ from the old contract; after sending the deploy to the network, the contract package hash connects the different contract versions.
 
 ### Step 2. Add a new contract to the package
 
-There are many changes you could make to a Casper contract, including:
-- Adding new entry points
-- Modifying the behavior of an existing entry point in the contract
-- Completely re-writing the contract
+There are many changes you could make to a Casper contract, like adding new entry points, modifying the behavior of an existing entry point, or completely re-writing the contract.
 
 To add a new contract version in the package, invoke the [add_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.add_contract_version.html) function and pass in the [ContractPackageHash](https://docs.rs/casper-types/latest/casper_types/contracts/struct.ContractPackageHash.html), [EntryPoints](https://docs.rs/casper-types/latest/casper_types/contracts/struct.EntryPoints.html), and [NamedKeys](https://docs.rs/casper-types/latest/casper_types/contracts/type.NamedKeys.html). In the counter example, you will find the `add_contract_version` call [here](https://github.com/casper-ecosystem/counter/blob/57e3912735f93e1d0f667b936675964ecfdc6594/contract-v2/src/main.rs#L164).
 
@@ -90,19 +84,17 @@ To add a new contract version in the package, invoke the [add_contract_version](
 
 Explanation of arguments:
 
-  - `contract_package_hash` - This hash directs you to the contract package. See [Hash and Key Explanations](../../../concepts/hash-types.md#hash-and-key-explanations)
-  - `entry_points` - Entry points of the contract, which can be modified or newly added
-  - `named_keys` - Named key pairs of the contract
+- `contract_package_hash` - This hash directs you to the contract package. See [Hash and Key Explanations](../../../concepts/hash-types.md#hash-and-key-explanations).
+- `entry_points` - Entry points of the contract, which can be modified or newly added.
+- `named_keys` - Named key pairs of the contract.
 
-:::note
+The new contract version carries on named keys from the previous version. If you specify a new set of named keys, they will be combined with the old named keys in the new contract version. If the old and new contract versions use the same named keys, then the new values would be present in the new version of the contract.
 
-- The new contract version carries on named keys from the previous version. If you specify a new set of named keys, they will be combined with the old named keys in the new contract version. If the old and new contract versions use the same named keys, then the new values would be present in the new version of the contract
-- You will need to manage contract versioning, considering clients that may use older versions. Here are a few options: 
-   - Pin your client contract to the contract hash of a specific version
-   - Use [call_versioned_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.call_versioned_contract.html) with a version number to pin your client contract to that version
-   - Call a contract using [call_versioned_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.call_versioned_contract.html) and version "None", which uses the newest version of the contract
+You will need to manage contract versioning, considering clients that may use older versions. Here are a few options: 
 
-:::
+1. Pin your client contract to the contract hash of a specific version.
+2. Use [call_versioned_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.call_versioned_contract.html) with a version number to pin your client contract to that version.
+3. Call a contract using [call_versioned_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.call_versioned_contract.html) and version "None", which uses the newest version of the contract.
 
 ### Step 3. Build the contract Wasm
 
@@ -117,7 +109,6 @@ make build-contract
 ### Step 4. Install the contract
 
 [Install the contract](../../../developers/dapps/sending-deploys.md#sending-the-deploy) on the network via a deploy and verify the deploy status. You can also [monitor the event stream](../../../developers/dapps/sending-deploys.md#monitoring-the-event-stream-for-deploys) to see when your deploy is accepted.
-
 
 To observe the upgrade workflow, you can install the second contract version on the chain. This version contains the `counter_decrement` entry point.
 
@@ -141,8 +132,6 @@ casper-client put-deploy \
 You can write unit tests to verify the behavior of the new contract version with [call_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.call_contract.html) or [call_versioned_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.call_versioned_contract.html). When you add a new contract to the package (which increments the highest enabled version), you will obtain a new contract hash, the primary identifier of the contract. You can use the contract hash with call_contract. Alternatively, you can use call_versioned_contract and specify the contract_package_hash and the newly added version.
 
 For the simple example counter above, here are the [corresponding tests](https://github.com/casper-ecosystem/counter/blob/master/tests/src/integration_tests.rs). Notice how the tests store and verify the [contract's version](https://github.com/casper-ecosystem/counter/blob/57e3912735f93e1d0f667b936675964ecfdc6594/contract-v1/src/main.rs#L107) and entry points.
-
-:::note
 
 You could store the latest version of the contract package under a NamedKey, as shown [here](https://github.com/casper-ecosystem/counter/blob/57e3912735f93e1d0f667b936675964ecfdc6594/contract-v1/src/main.rs#L107). Then, you can query the NamedKey to check the latest version of the contract package.
 
@@ -173,8 +162,6 @@ You could store the latest version of the contract package under a NamedKey, as 
 ```
 
 </details>
-
-:::
 
 You can also test the new entry point by using the Rust command-line client.
 
@@ -367,6 +354,6 @@ Apply the contract entry points and named keys when you call the function. You c
 
 :::note
 
-Creating a locked contract package is an irreversible decision. For a contract that can be upgraded, use new_contract as explained above.
+Creating a locked contract package is an irreversible decision. To upgrade a contract, use [new_contract](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.new_contract.html) as Step 1 explains.
 
 :::

--- a/source/docs/casper/resources/tutorials/beginner/upgrade-contract.md
+++ b/source/docs/casper/resources/tutorials/beginner/upgrade-contract.md
@@ -336,9 +336,11 @@ casper-client put-deploy \
 ```
 
 :::note
+
 There are two ways to call versioned contracts:
 1. [Calling Contracts by Package Hash](/developers/writing-onchain-code/calling-contracts/#StoredVersionedContractByHash)
 2. [Calling Contracts by Package Name](/developers/writing-onchain-code/calling-contracts/#StoredVersionedContractByName)
+
 :::
 
 After calling the entry point, the count value should be decremented. You can verify it by querying the network again using the new state root hash.


### PR DESCRIPTION
### What does this PR fix/introduce?

While trying to fix a formatting issue, I noticed that this document has too many long notes. Also, I think we should use numbered lists whenever possible, until the bullet points are fixed.

Closes #1130 


### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ACStoneCL 
