### PR TITLE
987 Updating 1.5 JSON-RPC with Example Code

### DIFF
--- a/source/docs/casper/concepts/callstack.md
+++ b/source/docs/casper/concepts/callstack.md
@@ -1,3 +1,7 @@
+---
+title: Call Stacks
+---
+
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Understanding Call Stacks
@@ -8,7 +12,7 @@ When the session code within a Deploy interacts with one or more contracts, this
 
 ## The Caller
 
-In every instance of a call stack, the originating [caller](https://docs.rs/casper-types/latest/casper_types/system/mint/trait.RuntimeProvider.html#tymethod.get_caller) is the session code within the account's context that began the interaction. Contract code cannot spontaneously act without session code to activate it. As such, the session code represents the *zeroth* entity in each call stack.
+In every instance of a call stack, the originating caller is the session code within the account's context that began the interaction. Contract code cannot spontaneously act without session code to activate it. As such, the session code represents the *zeroth* entity in each call stack.
 
 ## The Immediate Caller
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -244,6 +244,22 @@ This method returns a state root hash at a given [Block](../../concepts/design/c
 
 This method returns raw bytes for chainspec files.
 
+<details>
+
+<summary><b>Example info_get_chainspec request</b></summary>
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "method": "info_get_chainspec",
+  "id": 5510244237763930243
+}
+
+```
+
+</details>
+
 ### `info_get_chainspec_result`
 
 |Parameter|Type|Description|
@@ -253,25 +269,24 @@ This method returns raw bytes for chainspec files.
 
 <details>
 
-<summary><b>Example info_get_chainspec</b></summary>
+<summary><b>Example info_get_chainspec result</b></summary>
+
+Please note that adding a `--vv` flag will return the full chainspec bytes.
 
 ```bash
 
 {
-              "name": "info_get_chainspec_example",
-              "params": [],
-              "result": {
-                "name": "info_get_chainspec_example_result",
-                "value": {
-                  "api_version": "1.4.8",
-                  "chainspec_bytes": {
-                    "chainspec_bytes": "2a2a",
-                    "maybe_genesis_accounts_bytes": null,
-                    "maybe_global_state_bytes": null
-                  }
-                }
-              }
-            }
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.5.0",
+    "chainspec_bytes": {
+      "chainspec_bytes": "[22040 hex chars]",
+      "maybe_genesis_accounts_bytes": null,
+      "maybe_global_state_bytes": null
+    }
+  },
+  "id": 5510244237763930243
+}
 
 ```
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-transactional.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-transactional.md
@@ -119,6 +119,90 @@ The `speculative_exec` endpoint provides a method to execute a `Deploy` without 
 |[block_identifier](./types_chain.md#blockidentifier)|Object|The block hash or height on top of which to execute the deploy. If not supplied,the most recent block will be used.|
 |[deploy](./types_chain.md#deploy)|Object|A Deploy consists of an item containing a smart contract along with the requester's signature(s).|
 
+<details>
+
+<summary><b>Example speculative_exec request</b></summary>
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "method": "speculative_exec",
+  "params": {
+    "block_identifier": null,
+    "deploy": {
+      "hash": "b6aa46333fb858deee7f259a5bca581251c6200a5d902aeb1244c3a7169b5971",
+      "header": {
+        "account": "01a2905e4680aa49e0b44100d9dfc861b9605bb35f9956b1e99eb43863363d80aa",
+        "timestamp": "2023-05-23T13:32:45.554Z",
+        "ttl": "30m",
+        "gas_price": 1,
+        "body_hash": "74db109805bb20de43ef89a5b084544a858908b236601519d5827cd9b7fbb925",
+        "dependencies": [],
+        "chain_name": "integration-test"
+      },
+      "payment": {
+        "ModuleBytes": {
+          "module_bytes": "",
+          "args": [
+            [
+              "amount",
+              {
+                "cl_type": "U512",
+                "bytes": "0400e1f505",
+                "parsed": "100000000"
+              }
+            ]
+          ]
+        }
+      },
+      "session": {
+        "Transfer": {
+          "args": [
+            [
+              "amount",
+              {
+                "cl_type": "U512",
+                "bytes": "0400f90295",
+                "parsed": "2500000000"
+              }
+            ],
+            [
+              "target",
+              {
+                "cl_type": "PublicKey",
+                "bytes": "01265ea737411b349ad3d0fc724c2c588acd2765c057e5c690cd5e3dade401782b",
+                "parsed": "01265ea737411b349ad3d0fc724c2c588acd2765c057e5c690cd5e3dade401782b"
+              }
+            ],
+            [
+              "id",
+              {
+                "cl_type": {
+                  "Option": "U64"
+                },
+                "bytes": "010000000000000000",
+                "parsed": 0
+              }
+            ]
+          ]
+        }
+      },
+      "approvals": [
+        {
+          "signer": "01a2905e4680aa49e0b44100d9dfc861b9605bb35f9956b1e99eb43863363d80aa",
+          "signature": "01c94d517d5bbc8d5c74e0e68b8cb308561ff979a1c91907b56d427cc90156c437726c0b736d17f7303f2db66e405c7e5c8175b8b863703938eff1659766dff808"
+        }
+      ]
+    }
+  },
+  "id": 6889533540839698701
+}
+
+```
+
+</details>
+
 ### `speculative_exec_result`
 
 The result contains the hash of the targeted block and the results of the execution.
@@ -128,3 +212,301 @@ The result contains the hash of the targeted block and the results of the execut
 |api_version|String|The RPC API version.|
 |[block_hash](./types_chain.md#blockhash)|Object|The Block hash on top of which the deploy was executed.|
 |[execution_results](./types_chain.md#executionresult)|Object|The map of Block hash to execution result.|
+
+<details>
+
+<summary><b>Example speculative_exec result</b></summary>
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "id": -8801853076373554652,
+  "result": {
+    "api_version": "1.5.0",
+    "block_hash": "ff862326b08702a5089d64e32100537b7ff984cac4c0ba6d1c561f7c47125f76",
+    "execution_result": {
+      "Success": {
+        "effect": {
+          "operations": [],
+          "transforms": [
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "account-hash-f466e7f5f9240fb577d1d4c650c4063752553406dff7aa24b4822ba2b72e5b65",
+              "transform": "Identity"
+            },
+            {
+              "key": "account-hash-f466e7f5f9240fb577d1d4c650c4063752553406dff7aa24b4822ba2b72e5b65",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-0a300922655180354a9ee92b808c7b45b08e5b01d9da0bac9a9b3415bcebbf8d",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-59c6451dd58463708fa0b122e97114f07fa5f609229c9d67ac9426935416fbeb",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-ea3c9bdcbe57f067a29609d397981b2d0fb39853a0a9f06e444b06404eadcb1a",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678",
+              "transform": {
+                "WriteCLValue": {
+                  "cl_type": "U512",
+                  "bytes": "05f0e630ed87",
+                  "parsed": "583799990000"
+                }
+              }
+            },
+            {
+              "key": "balance-ea3c9bdcbe57f067a29609d397981b2d0fb39853a0a9f06e444b06404eadcb1a",
+              "transform": {
+                "AddUInt512": "100000000"
+              }
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "account-hash-f466e7f5f9240fb577d1d4c650c4063752553406dff7aa24b4822ba2b72e5b65",
+              "transform": "Identity"
+            },
+            {
+              "key": "account-hash-f466e7f5f9240fb577d1d4c650c4063752553406dff7aa24b4822ba2b72e5b65",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-0a300922655180354a9ee92b808c7b45b08e5b01d9da0bac9a9b3415bcebbf8d",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-59c6451dd58463708fa0b122e97114f07fa5f609229c9d67ac9426935416fbeb",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-ea3c9bdcbe57f067a29609d397981b2d0fb39853a0a9f06e444b06404eadcb1a",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678",
+              "transform": {
+                "WriteCLValue": {
+                  "cl_type": "U512",
+                  "bytes": "05f0e630ed87",
+                  "parsed": "583799990000"
+                }
+              }
+            },
+            {
+              "key": "balance-ea3c9bdcbe57f067a29609d397981b2d0fb39853a0a9f06e444b06404eadcb1a",
+              "transform": {
+                "AddUInt512": "100000000"
+              }
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-59c6451dd58463708fa0b122e97114f07fa5f609229c9d67ac9426935416fbeb",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-92ec6dfbdf151e20b55c89e0a327959cf6e5b091c5f2b39201c1858e2943f3bd",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678",
+              "transform": {
+                "WriteCLValue": {
+                  "cl_type": "U512",
+                  "bytes": "05f0ed2d5887",
+                  "parsed": "581299990000"
+                }
+              }
+            },
+            {
+              "key": "balance-92ec6dfbdf151e20b55c89e0a327959cf6e5b091c5f2b39201c1858e2943f3bd",
+              "transform": {
+                "AddUInt512": "2500000000"
+              }
+            },
+            {
+              "key": "transfer-97426c848475dae98446f2c2fd00ec7901cd8ddfe250171ff4ed25d78412a612",
+              "transform": {
+                "WriteTransfer": {
+                  "deploy_hash": "d898910011b1f2f8797a442740e69cd5de41b9f796e658e962a24663e6199e5a",
+                  "from": "account-hash-0a9b33af5108c5a6e1067b0ddec6853ce1745d591375d767ac5db680d21845e7",
+                  "to": "account-hash-f466e7f5f9240fb577d1d4c650c4063752553406dff7aa24b4822ba2b72e5b65",
+                  "source": "uref-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678-007",
+                  "target": "uref-92ec6dfbdf151e20b55c89e0a327959cf6e5b091c5f2b39201c1858e2943f3bd-004",
+                  "amount": "2500000000",
+                  "gas": "0",
+                  "id": 0
+                }
+              }
+            },
+            {
+              "key": "deploy-d898910011b1f2f8797a442740e69cd5de41b9f796e658e962a24663e6199e5a",
+              "transform": {
+                "WriteDeployInfo": {
+                  "deploy_hash": "d898910011b1f2f8797a442740e69cd5de41b9f796e658e962a24663e6199e5a",
+                  "transfers": [
+                    "transfer-97426c848475dae98446f2c2fd00ec7901cd8ddfe250171ff4ed25d78412a612"
+                  ],
+                  "from": "account-hash-0a9b33af5108c5a6e1067b0ddec6853ce1745d591375d767ac5db680d21845e7",
+                  "source": "uref-7c25ef9382fcae902b922866434f7111a1b34534323e93ff5bf22f1a401c2678-007",
+                  "gas": "100000000"
+                }
+              }
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-0a300922655180354a9ee92b808c7b45b08e5b01d9da0bac9a9b3415bcebbf8d",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-ea3c9bdcbe57f067a29609d397981b2d0fb39853a0a9f06e444b06404eadcb1a",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-d2dfc9409965993f9e186db762b585274dcafe439fa1321cfca08017262c8e46",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-59c6451dd58463708fa0b122e97114f07fa5f609229c9d67ac9426935416fbeb",
+              "transform": "Identity"
+            },
+            {
+              "key": "hash-f8df015ba26860a7ec8cab4ee99f079325b0bbb9ef0e7810b63d85df39da95fe",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-ea3c9bdcbe57f067a29609d397981b2d0fb39853a0a9f06e444b06404eadcb1a",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-ecc530e74cf2185936a334aa1e0f07539aa3b33c4b547e71fc4109151755652f",
+              "transform": "Identity"
+            },
+            {
+              "key": "balance-ea3c9bdcbe57f067a29609d397981b2d0fb39853a0a9f06e444b06404eadcb1a",
+              "transform": {
+                "WriteCLValue": {
+                  "cl_type": "U512",
+                  "bytes": "00",
+                  "parsed": "0"
+                }
+              }
+            },
+            {
+              "key": "balance-ecc530e74cf2185936a334aa1e0f07539aa3b33c4b547e71fc4109151755652f",
+              "transform": {
+                "AddUInt512": "100000000"
+              }
+            }
+          ]
+        },
+        "transfers": [
+          "transfer-97426c848475dae98446f2c2fd00ec7901cd8ddfe250171ff4ed25d78412a612"
+        ],
+        "cost": "100000000"
+      }
+    }
+  }
+}
+
+```
+
+
+</details>


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR adds example code for the `specualtive_exec` and `info_get_chainspec` JSON-RPC endpoints.

Closes #987 

### Additional context
[Update 1.5 Endpoint JSON-RPC Example Code #987](https://github.com/casper-network/docs/issues/987)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ipopescu 
