### PR TITLE
1039 - Add firewall rules for operators

### DIFF
--- a/source/docs/casper/operators/setup/node-endpoints.md
+++ b/source/docs/casper/operators/setup/node-endpoints.md
@@ -183,6 +183,28 @@ address = '0.0.0.0:9999'
 If this port is closed, the requests coming to this port will not be served, but the node remains unaffected. For details and useful commands, see [Monitoring and Consuming Events](../../developers/dapps/monitor-and-consume-events.md).
 
 
+## Setting up Firewall Rules
+
+To limit inbound traffic to the node’s endpoints, you can set firewall rules similar to the `ufw` commands below:
+
+```bash
+sudo apt install ufw -y
+sudo ufw disable
+sudo ufw reset
+sudo ufw default allow outgoing
+sudo ufw default deny incoming
+sudo ufw limit ssh
+sudo ufw limit 7777/tcp
+sudo ufw limit 8888/tcp
+sudo ufw limit 35000/tcp
+sudo ufw enable
+```
+
+These commands will limit requests to the available ports of your node. Port 35000 should be left open, although you can limit traffic, as it is crucial for node-to-node communication.
+
+If you have any concerns, questions, or issues, please [submit a request](https://support.casperlabs.io/hc/en-gb/requests/new) to the Casper support team.
+
+
 ## Restricting Access for Private Networks
 
 Any node can join Mainnet and Testnet and communicate with the nodes in the network. Private networks may wish to restrict access for new nodes joining the network as described [here](../setup-network/create-private.md#network-access-control).


### PR DESCRIPTION
### What does this PR fix/introduce?

This PR adds the firewall rules from the support portal.

Closes #1039 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL 