### PR TITLE
1036 Update open file limit for operators

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -189,6 +189,7 @@ module.exports = {
                 "operators/setup/basic-node-configuration",
                 "operators/setup/node-endpoints",
                 "operators/setup/install-node",
+                "operators/setup/open-files",
                 "operators/setup/upgrade",
                 "operators/setup/joining",
             ],

--- a/source/docs/casper/operators/index.md
+++ b/source/docs/casper/operators/index.md
@@ -25,6 +25,7 @@ Then, you can follow the node [installation instructions](./setup/install-node.m
   - [Recommended Hardware Specifications](./setup/hardware.md): system requirements for the Casper Mainnet and Testnet
   - [Basic Node Configuration](./setup/basic-node-configuration.md): processes and files involved in setting up a Casper node
   - [Installing a Node](./setup/install-node.md): step-by-step instructions to install a Casper node
+  - [Setting the Open Files Limit](./setup/open-files.md): required setting for the Casper node to run correctly
   - [Upgrading the Node](./setup/upgrade.md): before joining the network, the node needs to be upgraded
   - [Joining a Running Network](./setup/joining.md): steps to join an existing Casper network
   - [Setting up a Non-Root User](./setup/non-root-user.md): logging into the node remotely using a key

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -17,9 +17,9 @@ Of these `35000` is the only port required to be open for your node to function,
 
 The recommended OS version is Ubuntu 20.04.
 
-## Specifying the Number of Open Files
+## Required Number of Open Files
 
-Please read through [this page on nofiles configuration](https://github.com/casper-network/casper-node/wiki/Increasing-default-nofile-HARD-limit-for-a-node) to put settings in `/etc/security/limits.conf` for your node to ensure proper operation.
+Before beginning, [update the maximum open files limit](./open-files.md) for your system. Specifically, update your node's `/etc/security/limits.conf` file to ensure proper operation.
 
 ## Required Clean Up
 

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -19,7 +19,7 @@ The recommended OS version is Ubuntu 20.04.
 
 ## Required Number of Open Files
 
-Before beginning, [update the maximum open files limit](./open-files.md) for your system. Specifically, update your node's `/etc/security/limits.conf` file to ensure proper operation.
+Before beginning, [update the maximum open files limit](./open-files.md) for your system. Specifically, update the node's `/etc/security/limits.conf` file as described [here](./open-files.md#updating-limits-conf), to ensure proper node operation.
 
 ## Required Clean Up
 

--- a/source/docs/casper/operators/setup/open-files.md
+++ b/source/docs/casper/operators/setup/open-files.md
@@ -1,0 +1,101 @@
+# Setting the Open Files Limit
+
+When the `casper-node` launches, it tries to set the maximum open files limit (`nofile`) for the process to `64000`. With some systems, this limit will be larger than the default hard limit of `4096`. 
+
+The node software uses file handles for both files and network connections. Since network connections are unpredictable, running out of file handles can stop critical file writes from occurring. Therefore, the default `nofile` limit needs to be increased.
+
+With the `casper-node-launcher` running, you can see what the system allocated by finding the process ID (PID) for the `casper-node` with the following command.
+
+```bash
+pgrep "casper-node$"
+```
+
+<details>
+<summary>Sample output</summary>
+
+```bash
+$ pgrep "casper-node$"
+275928
+```
+
+:::note
+
+This PID will change, so you need to run the above command to get the current version with your system. Also, it will not be `275928` each time.
+
+:::
+
+</details>
+
+If you do not get a value in return, you do not have the `casper-node-launcher` running correctly.
+
+To find the current `nofile` (number of open files) hard limit, run `prlimit` with the PID from the previous command:
+
+```bash
+sudo prlimit -n -p <PID>
+```
+
+<details>
+<summary>Sample output</summary>
+
+```bash
+$ sudo prlimit -n -p 275928
+RESOURCE DESCRIPTION              SOFT HARD UNITS
+NOFILE   max number of open files 1024 4096 files
+```
+</details>
+
+You can also embed both commands as shown here:
+
+```bash
+sudo prlimit -n -p $(pgrep "casper-node$")
+```
+
+<details>
+<summary>Sample output</summary>
+
+```bash
+$ sudo prlimit -n -p $(pgrep "casper-node$")
+RESOURCE DESCRIPTION              SOFT HARD UNITS
+NOFILE   max number of open files 1024 4096 files
+```
+
+</details>
+
+If you receive `prlimit: option requires an argument -- 'p'`, then `pgrep "casper-node$"` is not returning anything because the `casper-node-launcher` is no longer running.
+
+## Setting the Limit Manually {#updating-manually}
+
+Run the command below to set the `nofile` limit for an active process without restarting the `casper-node-launcher` and `casper-node` processes. Note that this setting is active only while the `casper-node` process runs. To make this setting permanent, [update the `limits.conf`](#updating-limits-conf) file instead.
+
+```bash
+sudo prlimit --nofile=64000 --pid=$(pgrep "casper-node$")`
+```
+
+Next, check that the `prlimit` has changed:
+
+```bash
+sudo prlimit -n -p $(pgrep "casper-node$")
+```
+
+<details>
+<summary>Sample output</summary>
+
+```bash
+$ sudo prlimit -n -p $(pgrep "casper-node$")
+RESOURCE DESCRIPTION               SOFT  HARD UNITS
+NOFILE   max number of open files 64000 64000 files
+```
+
+</details>
+
+## Updating the `limits.conf` File {#updating-limits-conf}
+
+It is possible to persist the `nofile` limit across server reboots, `casper-node-launcher` restarts, and protocol upgrades, by adding the `nofile` setting for the `casper` user in `/etc/security/limits.conf`.
+
+Add the following row to the bottom of the `/etc/security/limits.conf` file:
+
+```bash
+casper          hard    nofile          64000
+```
+
+Afterward, log out of any shells to enable this change. Restarting the node should maintain the correct `nofile` setting.


### PR DESCRIPTION
### What does this PR fix/introduce?

Closes #1036 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL 
