### PR TITLE
1038 Archiving and restoring a node DB

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -218,7 +218,7 @@ module.exports = {
             label: "Advanced Topics",
             collapsible: true,
             collapsed: true,
-            items: ["operators/advanced-topics/archiving-and-restoring"],
+            items: ["operators/advanced-topics/archiving-and-restoring", "operators/advanced-topics/moving-node"],
         },
     ],
     resources: [

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -213,6 +213,13 @@ module.exports = {
             collapsed: true,
             items: ["operators/setup-network/chain-spec", "operators/setup-network/create-private", "operators/setup-network/staging-files-for-new-network"],
         },
+        {
+            type: "category",
+            label: "Advanced Topics",
+            collapsible: true,
+            collapsed: true,
+            items: ["operators/advanced-topics/archiving-and-restoring"],
+        },
     ],
     resources: [
         "resources/index",

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -69,7 +69,7 @@ The `-T[thread count]` is the number of threads that `zstd` should use for compr
 
 ### Long-distance matching
 
-The `--long=31` argument is where we see the most space gained by the algorithm because it controls the size of the matching window in powers of 2 (2**31 is 2 GB). The downside is that it requires 2.0 GB memory during compression and decompression as it looks ahead and rebuilds ahead. The default is 27 or 128 MB.
+The `--long=31` argument is where we see the most space gained by the algorithm because it controls the size of the matching window in powers of 2 (2**31 is 2 GB). The downside is that it requires 2.0 GB memory during compression and decompression as it looks and rebuilds ahead. The default is 27 or 128 MB.
 
 At compression 19, we see a 30 GB file using the default 128 MB look ahead, and a 13 GB file using 2 GB look ahead. Since all validators should have 16-32 GB of memory, we keep this at `--long=31`.
 

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -1,52 +1,56 @@
 # Archiving and Restoring a Database
 
-This article describes processes for the compression and decompression of a Casper node database (DB) and streaming from a backup location.
+This article describes processes for the compression and decompression of a Casper node database and streaming from a backup location.
 
-After testing a few methods of compressing and decompressing the current LMDB-based DB system used by the `casper-node`, the best method in both compression speed and space is using [Zstd](http://facebook.github.io/zstd/).  
+[Zstandard](http://facebook.github.io/zstd/) is the best method for compression speed and space for the current LMDB-based database system that the `casper-node` uses. 
 
 :::note
 
-The values presented in this document assume that the `trie-compact` tool was run on a Mainnet database for compression. [Reach out](https://support.casperlabs.io/hc/en-gb) to the support team if you have questions about this tool.
+The values presented in this document assume that the `trie-compact` tool was run on a Mainnet database for compression. Contact the [support team](https://support.casperlabs.io/hc/en-gb) if you have questions.
 
 :::
 
-## Zstd Limitations
+## Zstandard Limitations
 
-The current DB uses sparse files, which can contain partially nothing and not be processed efficiently. It is possible to use `tar` as a prefilter for stripping sparse data, eliminating the need to do a full read for the full size and processing.
+The current DB implementation uses sparse files, which can be partially empty, thus not being processed efficiently. You can use `tar` as a pre-filter for stripping sparse data, as shown [here](#compression), thus eliminating the need to read the full DB size and improving processing.
 
-## Zstd Installation
+## Zstandard Installation
 
-This is available with `sudo apt install zstd`. Note that 1.4.4 is distributed with 20.04, and 1.3.3 is with 18.04. There is much more information when compressing with later versions.
+To install Zstandard, run the following command:
+
+```bash
+sudo apt install zstd
+```
+
+Note that Zstandard version 1.4.4 is distributed with Ubuntu 20.04, while version 1.3.3 is distributed with Ubuntu 18.04. Later versions have more documentation. 
 
 ## Initial Warnings
 
-It should go without saying that the `casper-node-launcher` process of the node (and therefore the `casper-node` process using the DB) should be stopped with any compression or before decompression into a location. Otherwise, strange things can and will occur.
+You need to stop the `casper-node-launcher` process of the node (and, therefore, the `casper-node` process using the DB) before any compression or decompression into a location. Otherwise, strange things can and will occur.
 
 ## Compression
 
-The most basic `tar` commands needed are:
+Run the following basic `tar` command from the DB directory. For Mainnet, the directory would be `/var/lib/casper/casper-node/casper`, and for Testnet it would be `/var/lib/casper/casper-node/casper-test`.
 
-```base
+```bash
 tar -cv --sparse .
 ```
 
-This would be from within the DB directory. For Mainnet, the directory would be `/var/lib/casper/casper-node/casper`, and for Testnet it would be `/var/lib/casper/casper-node/casper-test`.
+On some systems, you may get better performance if you specify the block number as an argument:
 
-To get a little better performance on some systems, you may specify the block number arguments to `tar`, which results in:
-
-```base
+```bash
 tar -b 4096 -cv --sparse .
 ```
 
-Stream this into `zstd` by piping:
+You can then stream the result into `zstd`. The sections below discuss the [level](#compression-level), [thread count](#thread-count), and [long](#long-distance-matching) arguments.
 
-```base
+```bash
 tar -b 4096 -cv --sparse . | zstd -[level] -cv -T[thread count] --long=31 > [path_to]/file.tar.zst
 ```
 
 ### Compression level 
 
-The `-[level]` argument is the compression level from 1 to 19 (and 20-22 with expansion).   In testing, we found 15 to be the sweet spot in compression time vs. size. Lower compression makes sense if you are creating an archive to transfer once and use. If you are creating an archive to be downloaded by many, then the extra time for higher compression may be helpful.
+The `-[level]` argument is the compression level from 1 to 19 (and 20-22 with expansion). In testing, we found 15 to be the sweet spot in compression time vs. size. We recommend lower compression if you plan to transfer the archive only once. If you are creating an archive to be downloaded by many, then the extra time for higher compression may be helpful.
 
 Here are some examples of a Mainnet DB compression at block 741160:
 
@@ -57,31 +61,41 @@ Here are some examples of a Mainnet DB compression at block 741160:
 | 17      | 87:42           | 13.0 GB |
 | 19      | 197:08          | 12.9 GB |
 
-For local backups, using 1-5 is a great compression speed to size trade-off.  
+For local backups, using 1-5 is a great compression speed-to-size trade-off.  
 
 ### Thread count
 
-The `-T[thread count]` is the number of threads that `zstd` should use for compression. This parallels well. If running a script or command on varying machines, use `T0` to auto-detect. This will run the same number of threads as the detected cores. For machines with multiple threads per core, a speed-up can be further obtained by configuring an actual # near the number of threads. It is advisable to stay within the number of CPU threads. I will use `-T0` in most of my recommendations.
+The `-T[thread count]` is the number of threads that `zstd` should use for compression. If running a script or command on varying machines, use `T0` to allow `zstd` to detect the number of cores and run with the same number of threads as the detected cores. A speed-up can be obtained for machines with multiple threads per core by configuring a thread count near the number of threads. It is advisable to stay within the number of CPU threads. The recommendations in this article will use `-T0`.
 
 ### Long-distance matching
 
-The `--long=31` argument is what we see the most space gained by the algorithm. This controls the size of the matching window in powers of 2.  2**31 is 2 GB. The downside is that it requires 2.0 GB memory during compression and decompression as it looks ahead and rebuilds ahead. The default is 27 or 128 MB.  
+The `--long=31` argument is where we see the most space gained by the algorithm because it controls the size of the matching window in powers of 2 (2**31 is 2 GB). The downside is that it requires 2.0 GB memory during compression and decompression as it looks ahead and rebuilds ahead. The default is 27 or 128 MB.
 
-At compression 19, we see a 30 GB file using the default 128 MB look ahead, and a 13 GB file using 2 GB look ahead. Since all validators should have 16-32 GB of memory, we keep this at `-long=31`.   
+At compression 19, we see a 30 GB file using the default 128 MB look ahead, and a 13 GB file using 2 GB look ahead. Since all validators should have 16-32 GB of memory, we keep this at `--long=31`.
 
-The important thing here is that decompression requires a compatible argument. If you try with a different long-distance matching value, it will error, and the value to be used will be given.
+An important note is that decompression requires a compatible argument. Trying with a different long-distance matching value will throw an error, but the value to be used will be given.
 
-### TLDR
+### Summary of commands
 
-General:
-`tar -b 4096 -cv --sparse . | zstd -15 -cv -T0 --long=31 > [path_to]/file.tar.zst`
+The general command for compression is:
 
-For local backups:
-`tar -b 4096 -cv --sparse . | zstd -5 -cv -T0 --long=31 > [path_to]/file.tar.zst`
+```bash
+tar -b 4096 -cv --sparse . | zstd -15 -cv -T0 --long=31 > [path_to]/file.tar.zst
+```
+
+For local backups, use a lower compression level:
+
+```bash
+tar -b 4096 -cv --sparse . | zstd -5 -cv -T0 --long=31 > [path_to]/file.tar.zst
+```
 
 ## Decompression
 
-`zstd -d` is the command for decompression; however, the same `--long` value must be passed. So for all `casper-node` related decompression, you will likely always use `zstd -cd --long=31 <.tar.zst file>`.  
+`zstd -d` is the command for decompression; however, the same `--long` value used for compression must be specified. For all `casper-node` DB-related decompression, you will likely use this command:
+
+```bash
+zstd -cd --long=31 <.tar.zst file>
+```
 
 If `--long=31` is omitted, you might see an error such as this, which also gives you the solution:
 
@@ -91,21 +105,27 @@ If `--long=31` is omitted, you might see an error such as this, which also gives
 ./casper.tar.zst : Use --long=31 or --memory=2048MB
 ```
 
-This will be piped into a `tar xv` command. With decompressing files to be used by the casper-node, we would want these created using `sudo -u casper`.
+Pipe the `zstd` result into a `tar -xv` command. Also, create the decompressed files using `sudo -u casper`, because the files will be used by the `casper-node`. Run the following command inside an empty DB location:
 
-So `zstd -cd -long=31 <.tar.zst file> | sudo -u casper tar -xv` inside the empty DB location.
+```bash
+zstd -cd --long=31 <.tar.zst file> | sudo -u casper tar -xv
+```
 
-To fix ownership, use `sudo /etc/casper/node_util.py fix_permissions`.
+To fix ownership, use this command:
+
+```bash
+sudo /etc/casper/node_util.py fix_permissions
+```
 
 ## Streamed Decompression
 
-If a `.tar.zst` archive is hosted on a website and you will not need the file after decompressing, you can stream it into the process. This uses the ability for `curl` to output to stdout with `--output`.
+If a `.tar.zst` archive is hosted on a website and you will not need the file after decompressing, you can stream it into the process using `curl`, which can output to stdout with `--output` and stream binary to your terminal.
 
-```base
+```bash
 curl -s --output - <URL for tar.zstd file>
 ```
 
-This will stream a bunch of binary to your terminal. If we pipe that into the previous process, we get the following command that decompresses the files from `curl` directly into the local directory:
+If you pipe the output into the previous process, you can decompress the files from `curl` directly into a local directory:
 
 ```bash
 curl -s --output - <tar.zst URL> | zstd -d --long=31 | sudo -u casper tar xv
@@ -113,6 +133,10 @@ curl -s --output - <tar.zst URL> | zstd -d --long=31 | sudo -u casper tar xv
 
 ## Starting a New Node with a Decompressed DB
 
-If you are not syncing normally, you will want to tell the node to run at the protocol version of the tip of your DB. This is most easily done with the `node_util.py` script included in `casper-node-launcher` install.
+If you are not syncing normally, you will want to tell the node to run at the protocol version of the tip of your DB. You can do this most efficiently with the `node_util.py` script included in the `casper-node-launcher` installation.
 
-If you are using an archive from 1.4.5, you will run `sudo /etc/casper/node_util.py force_run_version 1_4_5`.
+For example, if you are using a DB archive from node version 1.4.5, you would run this command:
+
+```bash
+sudo /etc/casper/node_util.py force_run_version 1_4_5
+```

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -1,0 +1,119 @@
+# Archive and Restore of casper node DB with zstd
+
+Note: Values presented in this document assume that the `trie-compact` tool was run on MainNet DB to shrink.  This will be rolled out on or after the release of 1.4.6.
+
+# Summary
+
+After testing a few methods of compressing and decompressing the current LMDB-based DB system used by casper-node, the best method in both compression speed and space is using [Zstd](http://facebook.github.io/zstd/).  
+
+This will describe processes for compression and decompression as well as streaming from a backup location.
+
+# Zstd limitations
+
+Current DB uses sparse files which can contain partially nothing. This is not processed efficiently, so I have been using tar as a prefilter for stripping this sparse data.  This eliminates needed to do a full read for the entire size and processing.
+
+# Zstd install
+
+This is available with `sudo apt install zstd`.  Note that 1.4.4 is distributed with 20.04 and 1.3.3 is with 18.04.  There is much more information when compressing with later versions.
+
+# Initial Warnings
+
+It should go without saying that the `casper-node-launcher` process of the node (and therefore the `casper-node` process using the DB) should be stopped with any compression or before decompression into a location.  Otherwise, strange things can and will occur that are not good.
+
+# Compression
+
+The most basic `tar` commands needed are:
+
+```
+tar -cv --sparse .
+```
+
+This would be from within the DB directory, for example: `/var/lib/casper/casper-node/casper` (or `casper-test` at the end).  
+
+I've found a little better performance on some systems by offering block number arguments to `tar`, which results in:
+
+```
+tar -b 4096 -cv --sparse .
+```
+
+We will stream this into `zstd` by piping.
+
+```
+tar -b 4096 -cv --sparse . | zstd -[level] -cv -T[thread count] --long=31 > [path_to]/file.tar.zst
+```
+
+## Compression level 
+
+The `-[level]` argument is level of compression from 1 to 19 (and 20-22 with expansion.)   In testing, we are finding 15 to be the sweet spot in time of compression vs size.  If you are creating an archive to be downloaded by many, then the extra time for higher compression may be useful.  If you are creating an archive for you to transfer once and use, then lower compression makes sense.
+
+Some examples for MainNet DB compression at block 741160:
+
+| Level   | Time (min:sec)  | Size    |
+|---------|-----------------|---------|
+| 12      | 29:20           | 15.8 GB |
+| 15      | 46:15           | 13.0 GB |
+| 17      | 87:42           | 13.0 GB |
+| 19      | 197:08          | 12.9 GB |
+
+For local backups, using 1-5 might be a great speed of compression to size trade-off.  
+
+## Thread count
+
+The `-T[thread count]` is the number of threads that `zstd` should use for compression.  This parallels pretty well.  If you are running a script or command on varying machines, use `T0` to auto-detect.  This will run the same number of threads as detected cores.  For machines with multiple threads per core, a speed-up can be further obtained by configuring an actual # near the number of threads.  It is not advisable to exceed the number of CPU threads.  I will use `-T0` in most of my recommendations.
+
+## Long distance matching
+
+The `-long=31` argument is what we see the most space gained by the algorithm.  This controls the size of the matching window in powers of 2.  2**31 is 2 GB.  The downside of this is it requires 2.0 GB memory during compression and decompression as it looks ahead and rebuilds ahead.  The default is 27 or 128 MB.  
+
+At compression 19, we see a 30 GB file using the default 128 MB look ahead and a 13 GB file using 2 GB look ahead.  Since all validators should have 16-32 GB of memory, we just keep this at `-long=31`.   
+
+The important thing here is that decompression requires a compatible argument.  If you try with a different long distance matching value, it will error and the value to be used will be given.
+
+## TLDR
+
+General:
+`tar -b 4096 -cv --sparse . | zstd -15 -cv -T0 --long=31 > [path_to]/file.tar.zst`
+
+For local backups:
+`tar -b 4096 -cv --sparse . | zstd -5 -cv -T0 --long=31 > [path_to]/file.tar.zst`
+
+# Decompression
+
+`zstd -d` is the command for decompression, however the same `-long` value must be passed. So for all `casper-node` related decompression you will likely always use `zstd -cd -long=31 <.tar.zst file>`.  
+
+If `-long=31` is omitted you might see an error such as this:
+```
+./casper.tar.zst : Decoding error (36) : Frame requires too much memory for decoding 
+./casper.tar.zst : Window size larger than maximum : 2147483648 > 134217728
+./casper.tar.zst : Use --long=31 or --memory=2048MB
+```
+which gives you the fix.
+
+
+This will be piped into a `tar xv` command.  With decompressing files to be used by the casper-node, we would want these created using `sudo -u casper`.
+
+So `zstd -cd -long=31 <.tar.zst file> | sudo -u casper tar -xv` inside the empty db location.
+
+If you screw up permissions, you can use `sudo /etc/casper/node_util.py fix_permissions` to fix ownership.
+
+# Streamed Decompression
+
+If a `.tar.zst` archive is hosted on a website and you will not need the file after decompressing, you can stream it into the process.  This uses the ability for `curl` to output to stdout with `--output`.
+
+```
+curl -s --output - <URL for tar.zstd file>
+```
+
+This will stream a bunch of binary to your terminal.  If we pipe that into the previous process we get:
+
+```
+curl -s --output - <tar.zst URL> | zstd -d --long=31 | sudo -u casper tar xv
+```
+
+Which will decompress the files from `curl` directly into the local directory.
+
+# Starting fresh node with decompressed DB
+
+If you are not syncing normally, you will want to tell the node to run at the protocol version of the tip of your DB.  This is most easily done with the `node_util.py` script included in `casper-node-launcher` install.
+
+If you are using an archive from 1.4.5, you would run `sudo /etc/casper/node_util.py force_run_version 1_4_5`.

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -128,12 +128,12 @@ curl -s --output - <URL for tar.zstd file>
 If you pipe the output into the previous process, you can decompress the files from `curl` directly into a local directory:
 
 ```bash
-curl -s --output - <tar.zst URL> | zstd -d --long=31 | sudo -u casper tar xv
+curl -s --output - <tar.zst URL> | zstd -d --long=31 | sudo -u casper tar -xv
 ```
 
 ## Starting a New Node with a Decompressed DB
 
-If you are not syncing normally, you will want to tell the node to run at the protocol version of the tip of your DB. You can do this most efficiently with the `node_util.py` script included in the `casper-node-launcher` installation.
+If you are starting a node with a decompressed DB, you must tell the node to run at the protocol version of the tip of your DB. You can do this most efficiently with the `node_util.py` script included in the `casper-node-launcher` installation.
 
 For example, if you are using a DB archive from node version 1.4.5, you would run this command:
 

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -1,6 +1,6 @@
 # Archiving and Restoring a Database
 
-This article describes processes for the compression and decompression of a Casper node database and streaming from a backup location.
+This documentation describes processes for the compression and decompression of a Casper node database and streaming from a backup location.
 
 [Zstandard](http://facebook.github.io/zstd/) is the best method for compression speed and space for the current LMDB-based database system that the `casper-node` uses. 
 

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -105,7 +105,7 @@ If `--long=31` is omitted, you might see an error such as this, which also gives
 ./casper.tar.zst : Use --long=31 or --memory=2048MB
 ```
 
-Pipe the `zstd` result into a `tar -xv` command. Also, create the decompressed files using `sudo -u casper`, because the files will be used by the `casper-node`. Run the following command inside an empty DB location:
+You can then use the `zstd` result to populate a `tar -xv` command. Also, create the decompressed files using `sudo -u casper`, because the files will be used by the `casper-node`. Run the following command inside an empty DB location:
 
 ```bash
 zstd -cd --long=31 <.tar.zst file> | sudo -u casper tar -xv

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -1,52 +1,54 @@
-# Archive and Restore of casper node DB with zstd
+# Archiving and Restoring a Database
 
-Note: Values presented in this document assume that the `trie-compact` tool was run on MainNet DB to shrink.  This will be rolled out on or after the release of 1.4.6.
+This article describes processes for the compression and decompression of a Casper node database (DB) and streaming from a backup location.
 
-# Summary
+After testing a few methods of compressing and decompressing the current LMDB-based DB system used by the `casper-node`, the best method in both compression speed and space is using [Zstd](http://facebook.github.io/zstd/).  
 
-After testing a few methods of compressing and decompressing the current LMDB-based DB system used by casper-node, the best method in both compression speed and space is using [Zstd](http://facebook.github.io/zstd/).  
+:::note
 
-This will describe processes for compression and decompression as well as streaming from a backup location.
+The values presented in this document assume that the `trie-compact` tool was run on a Mainnet database for compression. [Reach out](https://support.casperlabs.io/hc/en-gb) to the support team if you have questions about this tool.
 
-# Zstd limitations
+:::
 
-Current DB uses sparse files which can contain partially nothing. This is not processed efficiently, so I have been using tar as a prefilter for stripping this sparse data.  This eliminates needed to do a full read for the entire size and processing.
+## Zstd Limitations
 
-# Zstd install
+The current DB uses sparse files, which can contain partially nothing and not be processed efficiently. It is possible to use `tar` as a prefilter for stripping sparse data, eliminating the need to do a full read for the full size and processing.
 
-This is available with `sudo apt install zstd`.  Note that 1.4.4 is distributed with 20.04 and 1.3.3 is with 18.04.  There is much more information when compressing with later versions.
+## Zstd Installation
 
-# Initial Warnings
+This is available with `sudo apt install zstd`. Note that 1.4.4 is distributed with 20.04, and 1.3.3 is with 18.04. There is much more information when compressing with later versions.
 
-It should go without saying that the `casper-node-launcher` process of the node (and therefore the `casper-node` process using the DB) should be stopped with any compression or before decompression into a location.  Otherwise, strange things can and will occur that are not good.
+## Initial Warnings
 
-# Compression
+It should go without saying that the `casper-node-launcher` process of the node (and therefore the `casper-node` process using the DB) should be stopped with any compression or before decompression into a location. Otherwise, strange things can and will occur.
+
+## Compression
 
 The most basic `tar` commands needed are:
 
-```
+```base
 tar -cv --sparse .
 ```
 
-This would be from within the DB directory, for example: `/var/lib/casper/casper-node/casper` (or `casper-test` at the end).  
+This would be from within the DB directory. For Mainnet, the directory would be `/var/lib/casper/casper-node/casper`, and for Testnet it would be `/var/lib/casper/casper-node/casper-test`.
 
-I've found a little better performance on some systems by offering block number arguments to `tar`, which results in:
+To get a little better performance on some systems, you may specify the block number arguments to `tar`, which results in:
 
-```
+```base
 tar -b 4096 -cv --sparse .
 ```
 
-We will stream this into `zstd` by piping.
+Stream this into `zstd` by piping:
 
-```
+```base
 tar -b 4096 -cv --sparse . | zstd -[level] -cv -T[thread count] --long=31 > [path_to]/file.tar.zst
 ```
 
-## Compression level 
+### Compression level 
 
-The `-[level]` argument is level of compression from 1 to 19 (and 20-22 with expansion.)   In testing, we are finding 15 to be the sweet spot in time of compression vs size.  If you are creating an archive to be downloaded by many, then the extra time for higher compression may be useful.  If you are creating an archive for you to transfer once and use, then lower compression makes sense.
+The `-[level]` argument is the compression level from 1 to 19 (and 20-22 with expansion).   In testing, we found 15 to be the sweet spot in compression time vs. size. Lower compression makes sense if you are creating an archive to transfer once and use. If you are creating an archive to be downloaded by many, then the extra time for higher compression may be helpful.
 
-Some examples for MainNet DB compression at block 741160:
+Here are some examples of a Mainnet DB compression at block 741160:
 
 | Level   | Time (min:sec)  | Size    |
 |---------|-----------------|---------|
@@ -55,21 +57,21 @@ Some examples for MainNet DB compression at block 741160:
 | 17      | 87:42           | 13.0 GB |
 | 19      | 197:08          | 12.9 GB |
 
-For local backups, using 1-5 might be a great speed of compression to size trade-off.  
+For local backups, using 1-5 is a great compression speed to size trade-off.  
 
-## Thread count
+### Thread count
 
-The `-T[thread count]` is the number of threads that `zstd` should use for compression.  This parallels pretty well.  If you are running a script or command on varying machines, use `T0` to auto-detect.  This will run the same number of threads as detected cores.  For machines with multiple threads per core, a speed-up can be further obtained by configuring an actual # near the number of threads.  It is not advisable to exceed the number of CPU threads.  I will use `-T0` in most of my recommendations.
+The `-T[thread count]` is the number of threads that `zstd` should use for compression. This parallels well. If running a script or command on varying machines, use `T0` to auto-detect. This will run the same number of threads as the detected cores. For machines with multiple threads per core, a speed-up can be further obtained by configuring an actual # near the number of threads. It is advisable to stay within the number of CPU threads. I will use `-T0` in most of my recommendations.
 
-## Long distance matching
+### Long-distance matching
 
-The `-long=31` argument is what we see the most space gained by the algorithm.  This controls the size of the matching window in powers of 2.  2**31 is 2 GB.  The downside of this is it requires 2.0 GB memory during compression and decompression as it looks ahead and rebuilds ahead.  The default is 27 or 128 MB.  
+The `--long=31` argument is what we see the most space gained by the algorithm. This controls the size of the matching window in powers of 2.  2**31 is 2 GB. The downside is that it requires 2.0 GB memory during compression and decompression as it looks ahead and rebuilds ahead. The default is 27 or 128 MB.  
 
-At compression 19, we see a 30 GB file using the default 128 MB look ahead and a 13 GB file using 2 GB look ahead.  Since all validators should have 16-32 GB of memory, we just keep this at `-long=31`.   
+At compression 19, we see a 30 GB file using the default 128 MB look ahead, and a 13 GB file using 2 GB look ahead. Since all validators should have 16-32 GB of memory, we keep this at `-long=31`.   
 
-The important thing here is that decompression requires a compatible argument.  If you try with a different long distance matching value, it will error and the value to be used will be given.
+The important thing here is that decompression requires a compatible argument. If you try with a different long-distance matching value, it will error, and the value to be used will be given.
 
-## TLDR
+### TLDR
 
 General:
 `tar -b 4096 -cv --sparse . | zstd -15 -cv -T0 --long=31 > [path_to]/file.tar.zst`
@@ -77,43 +79,40 @@ General:
 For local backups:
 `tar -b 4096 -cv --sparse . | zstd -5 -cv -T0 --long=31 > [path_to]/file.tar.zst`
 
-# Decompression
+## Decompression
 
-`zstd -d` is the command for decompression, however the same `-long` value must be passed. So for all `casper-node` related decompression you will likely always use `zstd -cd -long=31 <.tar.zst file>`.  
+`zstd -d` is the command for decompression; however, the same `--long` value must be passed. So for all `casper-node` related decompression, you will likely always use `zstd -cd --long=31 <.tar.zst file>`.  
 
-If `-long=31` is omitted you might see an error such as this:
-```
+If `--long=31` is omitted, you might see an error such as this, which also gives you the solution:
+
+```bash
 ./casper.tar.zst : Decoding error (36) : Frame requires too much memory for decoding 
 ./casper.tar.zst : Window size larger than maximum : 2147483648 > 134217728
 ./casper.tar.zst : Use --long=31 or --memory=2048MB
 ```
-which gives you the fix.
 
+This will be piped into a `tar xv` command. With decompressing files to be used by the casper-node, we would want these created using `sudo -u casper`.
 
-This will be piped into a `tar xv` command.  With decompressing files to be used by the casper-node, we would want these created using `sudo -u casper`.
+So `zstd -cd -long=31 <.tar.zst file> | sudo -u casper tar -xv` inside the empty DB location.
 
-So `zstd -cd -long=31 <.tar.zst file> | sudo -u casper tar -xv` inside the empty db location.
+To fix ownership, use `sudo /etc/casper/node_util.py fix_permissions`.
 
-If you screw up permissions, you can use `sudo /etc/casper/node_util.py fix_permissions` to fix ownership.
+## Streamed Decompression
 
-# Streamed Decompression
+If a `.tar.zst` archive is hosted on a website and you will not need the file after decompressing, you can stream it into the process. This uses the ability for `curl` to output to stdout with `--output`.
 
-If a `.tar.zst` archive is hosted on a website and you will not need the file after decompressing, you can stream it into the process.  This uses the ability for `curl` to output to stdout with `--output`.
-
-```
+```base
 curl -s --output - <URL for tar.zstd file>
 ```
 
-This will stream a bunch of binary to your terminal.  If we pipe that into the previous process we get:
+This will stream a bunch of binary to your terminal. If we pipe that into the previous process, we get the following command that decompresses the files from `curl` directly into the local directory:
 
-```
+```bash
 curl -s --output - <tar.zst URL> | zstd -d --long=31 | sudo -u casper tar xv
 ```
 
-Which will decompress the files from `curl` directly into the local directory.
+## Starting a New Node with a Decompressed DB
 
-# Starting fresh node with decompressed DB
+If you are not syncing normally, you will want to tell the node to run at the protocol version of the tip of your DB. This is most easily done with the `node_util.py` script included in `casper-node-launcher` install.
 
-If you are not syncing normally, you will want to tell the node to run at the protocol version of the tip of your DB.  This is most easily done with the `node_util.py` script included in `casper-node-launcher` install.
-
-If you are using an archive from 1.4.5, you would run `sudo /etc/casper/node_util.py force_run_version 1_4_5`.
+If you are using an archive from 1.4.5, you will run `sudo /etc/casper/node_util.py force_run_version 1_4_5`.

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -73,7 +73,7 @@ The `--long=31` argument is where we see the most space gained by the algorithm 
 
 At compression 19, we see a 30 GB file using the default 128 MB look ahead, and a 13 GB file using 2 GB look ahead. Since all validators should have 16-32 GB of memory, we keep this at `--long=31`.
 
-An important note is that decompression requires a compatible argument. Trying with a different long-distance matching value will throw an error, but the value to be used will be given.
+An important note is that decompression requires a compatible argument. Trying with a different long-distance matching value will result in an error. However, it will also return the necessary value to provide.
 
 ### Summary of commands
 

--- a/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
+++ b/source/docs/casper/operators/advanced-topics/archiving-and-restoring.md
@@ -125,7 +125,7 @@ If a `.tar.zst` archive is hosted on a website and you will not need the file af
 curl -s --output - <URL for tar.zstd file>
 ```
 
-If you pipe the output into the previous process, you can decompress the files from `curl` directly into a local directory:
+If you use the output along with the previous process, you can decompress the files from `curl` directly into a local directory:
 
 ```bash
 curl -s --output - <tar.zst URL> | zstd -d --long=31 | sudo -u casper tar -xv

--- a/source/docs/casper/operators/advanced-topics/moving-node.md
+++ b/source/docs/casper/operators/advanced-topics/moving-node.md
@@ -1,0 +1,94 @@
+#  Moving a Validating Node
+
+This guide is for active validators who want to move their node to another machine. There are two primary methods to achieve this, outlined below.
+
+## Method One: Copying the Data to a New Location
+
+This method is simple but requires downtime. The node needs to download all the blocks generated while it is stopped.
+
+1. Stop the node.
+2. Copy the node's data to a new mount:
+
+    ```bash
+    rsync -av --inplace --sparse  /var/lib/casper/ /new_mount
+    ```
+
+3. Change the mount point.
+4. Restart the node.
+
+## Method Two: Swapping Keys with a Hot Backup
+
+This method is a safer option, limiting downtime and enabling a smooth transition from the old to the new node. It keeps the node in sync with the tip of the chain.
+
+1. Once a node is running (`current_node`), create a second node (`backup_node`) on another machine. These two nodes will run in parallel.
+2. When the `backup_node` is up to date, stop both nodes.
+3. Swap their associated keys.
+4. Restart the `backup_node`.
+
+### Preparation for swapping
+
+Let both nodes synchronize to the tip of the blockchain. Keep the current validating node running with the original validator keyset.
+
+Bond the `backup_node` and wait until rewards are issued.
+
+To swap keys:
+
+1. Create the following folder structure on both nodes under the `/etc/casper/validator_keys/` directory.
+2. Create subdirectories for the `current_node` and `backup_node`.
+3. Copy each node's keyset under the corresponding directories.
+
+```bash
+/etc/casper/validator_keys/
+├── public_key.pem
+├── public_key_hex
+├── secret_key.pem
+├── current_node
+│   ├── public_key.pem
+│   ├── public_key_hex
+│   └── secret_key.pem
+└── backup_node
+|   ├── public_key.pem
+|   ├── public_key_hex
+|   └── secret_key.pem
+```
+
+This setup allows key swapping by running the `sudo -u casper cp * ../` command, as shown below.
+
+### Swapping the nodes
+
+On the `current_node`, run these commands:
+
+```bash
+sudo systemctl stop casper-node-launcher
+cd /etc/casper/validator_keys/backup_node
+sudo -u casper cp * ../
+```
+
+On the `backup_node` (the future validator), run these commands:
+
+```bash
+sudo systemctl stop casper-node-launcher
+cd /etc/casper/validator_keys/current_node
+sudo -u casper cp * ../
+sudo systemctl start casper-node-launcher
+```
+
+Restart the original validator node (`current_node`), which is now the new backup:
+
+```bash
+sudo systemctl start casper-node-launcher 
+```
+
+### Understanding rewards impact
+
+After swapping, the new validator node shows no round length until an era transition occurs and will lose all rewards from the point of the switch until the end of that era. The validator is not ejected but will receive rewards starting with the next era. 
+
+:::tip
+
+You could time the swap right before the era ends to minimize reward losses.
+
+:::
+
+### Checking file permissions
+
+After the swap, check and fix file permissions by running the `/etc/casper/node_util.py` utility.

--- a/source/docs/casper/operators/index.md
+++ b/source/docs/casper/operators/index.md
@@ -35,3 +35,6 @@ Then, you can follow the node [installation instructions](./setup/install-node.m
   - [The Chain Specification](./setup-network/chain-spec.md): files needed to create a genesis block
   - [Setting up a Private Casper Network](./setup-network/create-private.md): a step-by-step guide to establishing and configuring a private Casper network
   - [Staging Files for a New Network](./setup-network/staging-files-for-new-network.md): a guide to hosting protocol files for a new Casper network
+- Advanced Topics
+  - [Archiving and Restoring a Database](./advanced-topics/archiving-and-restoring.md): using `zstd` for the compression and decompression of a Casper node database and streaming from a backup location
+   

--- a/source/docs/casper/operators/index.md
+++ b/source/docs/casper/operators/index.md
@@ -37,4 +37,5 @@ Then, you can follow the node [installation instructions](./setup/install-node.m
   - [Staging Files for a New Network](./setup-network/staging-files-for-new-network.md): a guide to hosting protocol files for a new Casper network
 - Advanced Topics
   - [Archiving and Restoring a Database](./advanced-topics/archiving-and-restoring.md): using `zstd` for the compression and decompression of a Casper node database and streaming from a backup location
-   
+  - [Moving a Validating Node](./advanced-topics/moving-node.md): ways to move a validator node to another machine
+


### PR DESCRIPTION
### What does this PR fix/introduce?

Add content from the wiki for archiving and restoring a node database.

Closes #1038 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL 