### PR TITLE
1037 Moving a node to a new machine

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -218,7 +218,7 @@ module.exports = {
             label: "Advanced Topics",
             collapsible: true,
             collapsed: true,
-            items: ["operators/advanced-topics/archiving-and-restoring"],
+            items: ["operators/advanced-topics/archiving-and-restoring", "operators/advanced-topics/moving-node"],
         },
     ],
     resources: [

--- a/source/docs/casper/operators/advanced-topics/moving-node.md
+++ b/source/docs/casper/operators/advanced-topics/moving-node.md
@@ -18,7 +18,7 @@ This method is simple but requires downtime. The node needs to download all the 
 
 ## Method Two: Swapping Keys with a Hot Backup
 
-This method is a safer option, limiting downtime and enabling a smooth transition from the old to the new node, as the node stays in sync with the tip of the chain.
+This method is a safer option, limiting downtime and enabling a smooth transition from the old to the new node. It keeps the node in sync with the tip of the chain.
 
 1. Once a node is running (`current_node`), create a second node (`backup_node`) on another machine. These two nodes will run in parallel.
 2. When the `backup_node` is up to date, stop both nodes.

--- a/source/docs/casper/operators/advanced-topics/moving-node.md
+++ b/source/docs/casper/operators/advanced-topics/moving-node.md
@@ -81,7 +81,7 @@ sudo systemctl start casper-node-launcher
 
 ### Understanding rewards impact
 
-After swapping, the new validator node shows no round length until an ear transition occurs and will lose all rewards from the point of the switch until the end of that era. The validator is not ejected but will receive rewards starting with the next era. 
+After swapping, the new validator node shows no round length until an era transition occurs and will lose all rewards from the point of the switch until the end of that era. The validator is not ejected but will receive rewards starting with the next era. 
 
 :::tip
 

--- a/source/docs/casper/operators/advanced-topics/moving-node.md
+++ b/source/docs/casper/operators/advanced-topics/moving-node.md
@@ -1,0 +1,56 @@
+This is a description of my backup node cutover tests for an active validator using 1.4.1 casper-node.
+
+# Setup
+
+Created two nodes and key sets.   We will call these `val` and `backup`.
+
+I copied both keys to /etc/casper/validator_keys/ under val or backup directories.  
+
+ * /etc/casper/validator_keys
+   * public_key_hex
+   * public_key.pem
+   * secret_key.pem
+   * val
+     * public_key_hex
+     * public_key.pem
+     * secret_key.pem
+   * backup
+     * public_key_hex
+     * public_key.pem
+     * secret_key.pem
+
+This allows going into `val` or `backup` and doing a `sudo -u casper cp * ../` to "enable" that node to be that key.
+
+Synced both to tip.  Bonded in the val key and waited until rewards were issued.
+
+# Swapping which node is the active validator
+
+On the current validator (future backup):
+```
+sudo systemctl stop casper-node-launcher on current val
+cd /etc/casper/validator_keys/backup
+sudo -u casper cp * ../
+```
+
+On the current backup (future validator):
+```
+sudo systemctl stop casper-node-launcher on current backup
+cd /etc/casper/validator_keys/val
+sudo -u casper cp * ../
+sudo systemctl start casper-node-launcher  (now as val)
+```
+
+Back on the old validator (new backup):
+```
+sudo systemctl start casper-node-launcher 
+```
+
+# Rewards Cost
+
+I noticed that the validator node shows no round length until an Era transition occurs.  It is not ejected, but it does not continue to receive rewards until the next era.   So if there is a choice for when to do this, you want to time it to just before the era ends.
+
+It seems you lose all rewards from the point of the switch till the end of that Era.  Rewards are then normal in the next Era.
+
+# Permissions
+
+Make sure permissions are good.  `/etc/casper/node_util.py` has methods to check and fix file permissions after moves.

--- a/source/docs/casper/operators/index.md
+++ b/source/docs/casper/operators/index.md
@@ -37,4 +37,5 @@ Then, you can follow the node [installation instructions](./setup/install-node.m
   - [Staging Files for a New Network](./setup-network/staging-files-for-new-network.md): a guide to hosting protocol files for a new Casper network
 - Advanced Topics
   - [Archiving and Restoring a Database](./advanced-topics/archiving-and-restoring.md): using `zstd` for the compression and decompression of a Casper node database and streaming from a backup location
-   
+  - [Moving a Validating Node](./advanced-topics/moving-node.md): ways to move a validator node to another machine
+


### PR DESCRIPTION
### What does this PR fix/introduce?

Merges content from the wiki and support portal. Once the content is live, the support portal article could point to this refurbished article in the docs. FYI @cryofracture.

This PR builds on the structure from PR 1038, so I would like to merge it there first.

Closes #1037 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL 
FYI @cryofracture 