### PR TITLE
Change links and examples for the new Go SDK

### DIFF
--- a/source/docs/casper/developers/dapps/sdk/go-sdk.md
+++ b/source/docs/casper/developers/dapps/sdk/go-sdk.md
@@ -1,99 +1,109 @@
-# Golang SDK
-
+# Go SDK
 
 ## Usage Examples
 
-This section includes some examples of how to use Golang SDK:
+This section includes some examples of how to use Go SDK:
 
-* Sending a transfer
-* Installing a contract via a Deploy
+-   [Get a _Deploy_ from the Network](#get-a-deploy-from-the-network)
+-   [Handle the deploy processed event](#handle-the-deploy-processed-event)
+-   [Sending a transfer](#sending-a-transfer)
 
-## Generating Account Keys
+### Get a Deploy from the Network
 
+```go
+package main
 
-```bash
-    import (
-        "fmt"
-        "github.com/casper-ecosystem/casper-golang-sdk/keypair"
-        "github.com/casper-ecosystem/casper-golang-sdk/keypair/ed25519"
-        "github.com/casper-ecosystem/casper-golang-sdk/sdk"
-        "math/big"
-        "time"
-    )
-```
-```bash
-    func main() {
-        nodeRpc := "http://159.65.118.250:7777"
-        nodeEvent := "http://159.65.118.250:9999"
-        privKeyPath := "/path/to/secret_key.pem"
-        
-        rpcClient, _ := sdk.NewRpcClient(nodeRpc)
-        eventClient := sdk.NewEventService(nodeEvent)
+import (
+    "context"
+    "fmt"
+    "net/http"
 
-        pair, _ := ed25519.ParseKeyFiles(privKeyPath)
-        target, _ := keypair.FromPublicKeyHex("0172a54c123b336fb1d386bbdff450623d1b5da904f5e2523b3e347b6d7573ae80")
+    "github.com/make-software/casper-go-sdk/casper"
+)
 
-        deployParams := sdk.DeployParams{
-            Account:   pair.PublicKey(),
-            Timestamp: time.Now(),
-            TTL:       30 * time.Minute,
-            GasPrice:  1,
-            ChainName: "casper-test",
-        }
-        payment := sdk.StandardPayment(big.NewInt(100000000))
-        session := sdk.NewTransfer(big.NewInt(25000000000), target, uint64(5589324))
-
-        deploy, _ := sdk.MakeDeploy(deployParams, payment, session)
-        _ = deploy.Sign(pair)
-        putDeploy, _ := rpcClient.PutDeploy(deploy)
-
-        processedDeploy, _ := eventClient.AwaitDeploy(putDeploy.DeployHash)
-
-        fmt.Printf("%+v\n", processedDeploy)
+func main() {
+    handler := casper.NewRPCHandler("https://<Node Address and Port>/rpc", http.DefaultClient)
+    client := casper.NewRPCClient(handler)
+    deployHash := "62972eddc6fdc03b7ec53e52f7da7e24f01add9a74d68e3e21d924051c43f126"
+    deploy, err := client.GetDeploy(context.Background(), deployHash)
+    if err != nil {
+        return
     }
+    fmt.Println(deploy.Deploy.Hash)
+}
 ```
 
-## Deploying a contract
+### Handle the deploy processed event
 
-```bash
-    import (
-        "fmt"
-        "github.com/casper-ecosystem/casper-golang-sdk/keypair"
-        "github.com/casper-ecosystem/casper-golang-sdk/keypair/ed25519"
-        "github.com/casper-ecosystem/casper-golang-sdk/sdk"
-        "math/big"
-        "time"
-    )
+```go
+package main
+
+import (
+    "context"
+    "log"
+
+    "github.com/make-software/casper-go-sdk/sse"
+)
+
+func main() {
+    client := sse.NewClient("https://<Node Address and Port>/events/main")
+    defer client.Stop()
+    client.RegisterHandler(
+        sse.DeployProcessedEventType,
+        func(ctx context.Context, rawEvent sse.RawEvent) error {
+            deploy, err := rawEvent.ParseAsDeployProcessedEvent()
+            if err != nil {
+                return err
+            }
+            log.Printf("Deploy hash: %s", deploy.DeployProcessed.DeployHash)
+            return nil
+        })
+    lastEventID := 1234
+    client.Start(context.TODO(), lastEventID)
+}
 ```
-```bash
-    func main() {
-        nodeRpc := "http://159.65.118.250:7777"
-        nodeEvent := "http://159.65.118.250:9999"
-        privKeyPath := "/path/to/secret_key.pem"
-        modulePath := "/path/to/contract.wasm"
 
-        rpcClient, _ := sdk.NewRpcClient(nodeRpc)
-        eventClient := sdk.NewEventService(nodeEvent)
+### Sending a transfer
 
-        pair, _ := ed25519.ParseKeyFiles(privKeyPath)
-        module, _ := ioutil.ReadFile(modulePath)
+```go
+package main
 
-        deployParams := sdk.DeployParams{
-            Account:   pair.PublicKey(),
-            Timestamp: time.Now(),
-            TTL:       30 * time.Minute,
-            GasPrice:  1,
-            ChainName: "casper-test",
-        }
-        payment := sdk.StandardPayment(big.NewInt(100000000))
-        session := sdk.NewModuleBytes(module, nil)
+import (
+    "context"
+    "encoding/hex"
+    "log"
+    "math/big"
+    "net/http"
 
-        deploy, _ := sdk.MakeDeploy(deployParams, payment, session)
-        _ = deploy.Sign(pair)
-        putDeploy, _ := rpcClient.PutDeploy(deploy)
+    "github.com/make-software/casper-go-sdk/casper"
+    "github.com/make-software/casper-go-sdk/types/clvalue"
+)
 
-        processedDeploy, _ := eventClient.AwaitDeploy(putDeploy.DeployHash)
-
-        fmt.Printf("%+v\n", processedDeploy)
+func main() {
+    accountPublicKey, err := casper.NewPublicKey("012488699f9a31e36ecf002675cd7186b48e6a735d10ec1b308587ca719937752c")
+    if err != nil { return }
+    amount := big.NewInt(100000000)
+    session := casper.ExecutableDeployItem{
+        ModuleBytes: &casper.ModuleBytes{
+            ModuleBytes: hex.EncodeToString([]byte("<Contract WASM>")),
+            Args: (&casper.Args{}).
+                AddArgument("target", clvalue.NewCLByteArray(accountPublicKey.AccountHash().Bytes())).
+                AddArgument("amount", *clvalue.NewCLUInt512(amount)),
+        },
     }
- ```   
+
+    payment := casper.StandardPayment(amount)
+
+    deployHeader := casper.DefaultHeader()
+    deployHeader.Account = accountPublicKey
+    deployHeader.ChainName = "casper-test"
+
+    newDeploy, err := casper.MakeDeploy(deployHeader, payment, session)
+
+    handler := casper.NewRPCHandler("https://<Node Address>:7777/rpc", http.DefaultClient)
+    client := casper.NewRPCClient(handler)
+    result, err := client.PutDeploy(context.Background(), *newDeploy)
+
+    log.Println(result.DeployHash)
+}
+```

--- a/source/docs/casper/developers/dapps/sdk/go-sdk.md
+++ b/source/docs/casper/developers/dapps/sdk/go-sdk.md
@@ -5,8 +5,8 @@
 This section includes some examples of how to use Go SDK:
 
 -   [Get a _Deploy_ from the Network](#get-a-deploy-from-the-network)
--   [Handle the deploy processed event](#handle-the-deploy-processed-event)
--   [Sending a transfer](#sending-a-transfer)
+-   [Handle the Deploy Processed Event](#handle-the-deploy-processed-event)
+-   [Sending a Transfer](#sending-a-transfer)
 
 ### Get a Deploy from the Network
 
@@ -33,7 +33,7 @@ func main() {
 }
 ```
 
-### Handle the deploy processed event
+### Handle the Deploy Processed Event
 
 ```go
 package main
@@ -63,7 +63,7 @@ func main() {
 }
 ```
 
-### Sending a transfer
+### Sending a Transfer
 
 ```go
 package main

--- a/source/docs/casper/developers/dapps/sdk/index.md
+++ b/source/docs/casper/developers/dapps/sdk/index.md
@@ -16,7 +16,7 @@ Each such third party is solely responsible for the SDK it provides, any warrant
 |[JavaScript/TypeScript](./script-sdk.md) | [casper-js-sdk](https://github.com/casper-ecosystem/casper-js-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
 |Java SDK | [casper-java-sdk](https://github.com/casper-network/casper-java-sdk/)| [Casper Association](https://github.com/casper-network)|
 |[C# SDK](./csharp-sdk.md)|[casper-net-sdk](https://github.com/make-software/casper-net-sdk)| [MAKE](https://github.com/make-software) |
-|[Golang SDK](./go-sdk.md) |[casper-golang-sdk](https://github.com/casper-ecosystem/casper-golang-sdk/)| [Casper Ecosystem](https://github.com/casper-ecosystem) |
+|[Go SDK](./go-sdk.md) | [casper-go-sdk](https://github.com/make-software/casper-go-sdk) | [MAKE](https://github.com/make-software) |
 |[Python SDK](./python-sdk.md) |[casper-python-sdk](https://github.com/casper-network/casper-python-sdk/)| [Casper Association](https://github.com/casper-network) |
 |PHP SDK|[casper-php-sdk](https://github.com/make-software/casper-php-sdk)| [MAKE](https://github.com/make-software) |
 | Scala SDK | [casper-scala-sdk](https://github.com/abahmanem/casper-scala-sdk) | [M. Abahmane](https://github.com/abahmanem) |

--- a/source/docs/casper/resources/build-on-casper/casper-open-source-software.md
+++ b/source/docs/casper/resources/build-on-casper/casper-open-source-software.md
@@ -15,7 +15,7 @@ Name | Description | Author | Language | License | Last Update Date | Type
 [Casper Contract Upgrade](https://github.com/casper-ecosystem/contract-upgrade-example) | Example contract to demonstrate the general way of upgrading a contract and the necessary steps | Casper Labs | Rust | Apache-2.0 license | 2022-06-21 | Example Contracts
 [Casper Dart SDK](https://github.com/cdolaz/casper_dart_sdk) | Casper Dart SDK is for interacting with the Casper Blockchain using RPC. | Temiltas | Dart | Apache-2.0 license | 2022-06-26 | Client SDK
 [Friendly Market's Casper variant of ERC20](https://github.com/FriendlyMarket/casper-erc20) | Implementation of the ERC20 standard for Casper networks | Friendly Market | Rust | Apache-2.0 license | 2022-08-10 | Tokens
-[Casper Go SDK](https://github.com/casper-ecosystem/casper-golang-sdk) | Casper Go SDK | Yaroslav Panasenko | Go | Apache-2.0 license | 2022-01-31 | Client SDK
+[Casper Go SDK](https://github.com/make-software/casper-go-sdk) | Casper Go SDK | Ilya Koltsov | Go | Apache-2.0 license | 2023-06-01 | Client SDK
 [Casper Hello World Contract](https://github.com/casper-ecosystem/hello-world) | This example demonstrates the session code that accepts a message string and stores it in the calling account under the special_value NamedKey | Casper Labs | Rust | NA | 2022-07-13 | Example contracts
 [Casper JavaScript SDK](https://github.com/casper-ecosystem/casper-js-sdk) | Casper Client JavaScript SDK | Casper Labs | TypeScript-JavaScript | Apache-2.0 license | 2022-09-13 | Client SDK
 [Casper Kotlin SDK](https://github.com/tqhuy2018/Casper-Kotlin-sdk) | Casper Kotlin Client SDK to interact with a Casper network. | tqhuy2018 | Kotlin | MIT license | 2022-07-21 | Client SDK

--- a/source/docs/casper/resources/build-on-casper/casper-open-source-software.md
+++ b/source/docs/casper/resources/build-on-casper/casper-open-source-software.md
@@ -15,7 +15,7 @@ Name | Description | Author | Language | License | Last Update Date | Type
 [Casper Contract Upgrade](https://github.com/casper-ecosystem/contract-upgrade-example) | Example contract to demonstrate the general way of upgrading a contract and the necessary steps | Casper Labs | Rust | Apache-2.0 license | 2022-06-21 | Example Contracts
 [Casper Dart SDK](https://github.com/cdolaz/casper_dart_sdk) | Casper Dart SDK is for interacting with the Casper Blockchain using RPC. | Temiltas | Dart | Apache-2.0 license | 2022-06-26 | Client SDK
 [Friendly Market's Casper variant of ERC20](https://github.com/FriendlyMarket/casper-erc20) | Implementation of the ERC20 standard for Casper networks | Friendly Market | Rust | Apache-2.0 license | 2022-08-10 | Tokens
-[Casper Go SDK](https://github.com/make-software/casper-go-sdk) | Casper Go SDK | Ilya Koltsov | Go | Apache-2.0 license | 2023-06-01 | Client SDK
+[Casper Go SDK](https://github.com/make-software/casper-go-sdk) | Casper Go SDK | MAKE Software | Go | Apache-2.0 license | 2023-06-01 | Client SDK
 [Casper Hello World Contract](https://github.com/casper-ecosystem/hello-world) | This example demonstrates the session code that accepts a message string and stores it in the calling account under the special_value NamedKey | Casper Labs | Rust | NA | 2022-07-13 | Example contracts
 [Casper JavaScript SDK](https://github.com/casper-ecosystem/casper-js-sdk) | Casper Client JavaScript SDK | Casper Labs | TypeScript-JavaScript | Apache-2.0 license | 2022-09-13 | Client SDK
 [Casper Kotlin SDK](https://github.com/tqhuy2018/Casper-Kotlin-sdk) | Casper Kotlin Client SDK to interact with a Casper network. | tqhuy2018 | Kotlin | MIT license | 2022-07-21 | Client SDK


### PR DESCRIPTION
### Change links and examples for the new Go SDK
Replaced the old SDK with the one created at MAKE in the official Casper documentation:

### Additional context
The documentation is available under the following links:
- [SDK Client Libraries | Casper](https://docs.casper.network/sdk/) 
- [Ecosystem Open-Source Software | Casper](https://docs.casper.network/resources/build-on-casper/casper-open-source-software/) 
- [Golang SDK | Casper](https://docs.casper.network/developers/dapps/sdk/go-sdk/) 
The old SDK entries should be fully replaced

### Checklist

- [ ] Docs are successfully building - `yarn install && yarn run build`.
- [ ] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [ ] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [ ] All technical procedures have been tested.

### Reviewers
