### PR TITLE
Correct Image Paths for the Block Explorer Transfer Tutorial

### DIFF
--- a/source/docs/casper/users/token-transfer.md
+++ b/source/docs/casper/users/token-transfer.md
@@ -13,11 +13,11 @@ To transfer tokens, follow these steps:
 3. Enter the recipient's public key, the amount you wish to transfer, and an optional Transfer ID for reference. If you do not provide an ID, the system will auto-generate one.
 4. Click **Next** to proceed.
 
-<img src={useBaseUrl("/image/transfer/1.transfer-details.png")} alt="Transfer details" width="500" />
+<img src={useBaseUrl("/image/tutorials/transfer/1.transfer-details.png")} alt="Transfer details" width="500" />
 
 5. A confirmation window appears to verify the details entered. Click **Confirm and transfer** to proceed to the next step.
 
-<img src={useBaseUrl("/image/transfer/2.confirm-transfer.png")} alt="Confirm transfer" width="500" />
+<img src={useBaseUrl("/image/tutorials/transfer/2.confirm-transfer.png")} alt="Confirm transfer" width="500" />
 
 6. Review the following important fields:
 
@@ -28,14 +28,14 @@ To transfer tokens, follow these steps:
 
 Sign the transaction by selecting the **Sign with Casper Wallet** button to proceed to the next step. 
 
-<img src={useBaseUrl("/image/transfer/3.sign-transfer.png")} alt="Sign the transfer" width="500" />
+<img src={useBaseUrl("/image/tutorials/transfer/3.sign-transfer.png")} alt="Sign the transfer" width="500" />
 
 7. Once the Casper Wallet opens, **check the deploy hash**. Ensure the deploy hash in the "Signature Request" window matches the deploy hash in the "Sign transaction" window before continuing. Click **Sign** in the Signature Request window to complete the transaction.
     
-<img src={useBaseUrl("/image/transfer/4.wallet-window.png")} alt="Review the transaction" width="500" />
+<img src={useBaseUrl("/image/tutorials/transfer/4.wallet-window.png")} alt="Review the transaction" width="500" />
 
 8. You completed the transaction and successfully transferred tokens.
 
-<img src={useBaseUrl("/image/transfer/5.transfer-completed.png")} alt="Transfer completed window" width="500" />
+<img src={useBaseUrl("/image/tutorials/transfer/5.transfer-completed.png")} alt="Transfer completed window" width="500" />
 
 9. View the updated CSPR balance in the account's main purse next.


### PR DESCRIPTION
### What does this PR fix/introduce?
Image paths were broken during restructuring at some point. This PR fixes said paths.

Closes #1156

### Additional context
[Correct Image Paths for Transfer Tutorial #1156](https://github.com/casper-network/docs/issues/1156)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ShalmaliCL 
