### PR TITLE
999 - Update docs.rs links for 1.5 release

### DIFF
--- a/source/docs/casper/concepts/callstack.md
+++ b/source/docs/casper/concepts/callstack.md
@@ -12,15 +12,17 @@ When the session code within a Deploy interacts with one or more contracts, this
 
 ## The Caller
 
-In every instance of a call stack, the originating caller is the session code within the account's context that began the interaction. Contract code cannot spontaneously act without session code to activate it. As such, the session code represents the *zeroth* entity in each call stack.
+In every instance of a call stack, the originating caller is the session code within the account's context that began the interaction. Contract code cannot spontaneously act without session code to activate it. As such, the session code represents the *zeroth* entity in each call stack. The account that initiated the deploy can be retrieved with the [contract_api::runtime::get_caller](https://docs.rs/casper-contract/3.0.0/casper_contract/contract_api/runtime/fn.get_caller.html) function.
 
-## The Immediate Caller
+## The Call Stack
 
-The [immediate caller](https://docs.rs/casper-types/1.5.0/casper_types/system/mint/trait.RuntimeProvider.html#tymethod.get_immediate_caller) is the caller that interacted directly with the contract in question.
+Developers can access the call stack with the [contract_api::runtime::get_call_stack](https://docs.rs/casper-contract/3.0.0/casper_contract/contract_api/runtime/fn.get_call_stack.html) function.
 
 If session code calls a contract, which in turn calls another contract, then the session code would represent the *zeroth* entity in the stack, the contract called by the initiating session code would be the *first* and the contract called by the first contract would be the *second*.
 
-In this example, the first contract would be the `immediate caller` of the second contract. The session code would remain the `caller`.
+In this example, the first contract would be the `immediate caller` of the second contract, meaning it interacted directly with it. The session code would remain the `caller`.
+
+<!--TODO: simplify this diagram to remove the immediate caller concept.-->
 
 <img class="align-center" src={useBaseUrl("/image/callstack.png")} width="450" alt="Call Stack" />
 

--- a/source/docs/casper/concepts/callstack.md
+++ b/source/docs/casper/concepts/callstack.md
@@ -22,8 +22,6 @@ If session code calls a contract, which in turn calls another contract, then the
 
 In this example, the first contract would be the `immediate caller` of the second contract, meaning it interacted directly with it. The session code would remain the `caller`.
 
-<!--TODO: simplify this diagram to remove the immediate caller concept.-->
-
 <img class="align-center" src={useBaseUrl("/image/callstack.png")} width="450" alt="Call Stack" />
 
 ## Limitations

--- a/source/docs/casper/concepts/design/casper-design.md
+++ b/source/docs/casper/concepts/design/casper-design.md
@@ -154,7 +154,7 @@ A Wasm module is not natively able to create any effects outside of reading or w
 
 ![Casper Network Runtime](/image/design/casper-runtime.png)
 
-All these features are accessible via functions in the [Casper External FFI](https://docs.rs/casper-contract/1.4.4/casper_contract/ext_ffi/index.html).
+All these features are accessible via functions in the [Casper External FFI](https://docs.rs/casper-contract/latest/casper_contract/ext_ffi/index.html).
 
 #### Generating `URef`s {#execution-semantics-urefs}
 

--- a/source/docs/casper/concepts/design/networking-protocol.md
+++ b/source/docs/casper/concepts/design/networking-protocol.md
@@ -83,7 +83,7 @@ Any other use of `bincode` encoding (e.g. for GetRequest payloads, see below) MU
 
 Unless noted otherwise, any structure encoded as MessagePack or bincode is serialized using the standard  [`serde`](https://serde.rs)-derived encoding. For `bytesrepr` serialization refer to the specific implementations in the `bytesrepr` crate.
 
-Any data types given from here on out are described using simplified [Rust](https://rust-lang.org/) structure definitions.
+Any data types given from here on out are described using simplified [Rust](https://www.rust-lang.org/) structure definitions.
 
 ## The `Message` Type
 

--- a/source/docs/casper/concepts/design/networking-protocol.md
+++ b/source/docs/casper/concepts/design/networking-protocol.md
@@ -63,7 +63,7 @@ A node receiving a message length header that exceeds the maximum message size s
 
 ## Encoding
 
-The node uses three encoding schemes: Handshakes (see below) are encoded using [MessagePack](https://msgpack.org), while regular messages are encoded using [bincode](https://docs.rs/bincode). Many (but not all) data objects use [`bytesrepr`](https://docs.rs/casper-types/1.5.0/casper_types/bytesrepr/index.html) for serialization.
+The node uses three encoding schemes: Handshakes (see below) are encoded using [MessagePack](https://msgpack.org), while regular messages are encoded using [bincode](https://docs.rs/bincode). Many (but not all) data objects use [`bytesrepr`](https://docs.rs/casper-types/latest/casper_types/bytesrepr/index.html) for serialization.
 
 The node uses the [`rmp-serde`](https://docs.rs/rmp-serde/0.14.4/rmp_serde/index.html) crate, version `0.14.4`, which is kept fixed to ensure handshake compatibility with protocol version 1.0 of the node.
 
@@ -114,7 +114,7 @@ struct ConsensusCertificate {
 struct Digest([u8; 32]);
 ```
 
-For [`String`](https://doc.rust-lang.org/std/string/struct.String.html), [`SocketAddr`](https://doc.rust-lang.org/std/net/enum.SocketAddr.html), [`ProtocolVersion`](https://docs.rs/casper-types/1.5.0/casper_types/struct.ProtocolVersion.html), [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html), [`PublicKey`](https://docs.rs/casper-types/1.5.0/casper_types/crypto/enum.PublicKey.html), [`Signature`](https://docs.rs/casper-types/1.5.0/casper_types/crypto/enum.Signature.html) see the respective docs and details below.
+For [`String`](https://doc.rust-lang.org/std/string/struct.String.html), [`SocketAddr`](https://doc.rust-lang.org/std/net/enum.SocketAddr.html), [`ProtocolVersion`](https://docs.rs/casper-types/latest/casper_types/struct.ProtocolVersion.html), [`Option`](https://doc.rust-lang.org/std/option/enum.Option.html), [`PublicKey`](https://docs.rs/casper-types/latest/casper_types/crypto/enum.PublicKey.html), [`Signature`](https://docs.rs/casper-types/latest/casper_types/crypto/enum.Signature.html) see the respective docs and details below.
 
 ## Handshake Behavior
 

--- a/source/docs/casper/concepts/dictionaries.md
+++ b/source/docs/casper/concepts/dictionaries.md
@@ -89,7 +89,7 @@ fn update_ledger_record(dictionary_item_key: String) {
 
 ```
 
-The second section uses [`dictionary_get`](https://docs.rs/casper-contract/1.4.4/casper_contract/contract_api/storage/fn.dictionary_get.html) to read an entry within the `LEDGER` dictionary. If the entry does not exist on global state, it will create the entry. If it already exists, the entry is updated with the current value using a [`dictionary_put`](https://docs.rs/casper-contract/1.4.4/casper_contract/contract_api/storage/fn.dictionary_put.html) operation. As stated above, regardless of the size of the change within the entry, the entire dictionary entry will need to be overwritten and will incur the associated cost.
+The second section uses [`dictionary_get`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_get.html) to read an entry within the `LEDGER` dictionary. If the entry does not exist on global state, it will create the entry. If it already exists, the entry is updated with the current value using a [`dictionary_put`](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.dictionary_put.html) operation. As stated above, regardless of the size of the change within the entry, the entire dictionary entry will need to be overwritten and will incur the associated cost.
 
 ```rust
 

--- a/source/docs/casper/concepts/list-auth-keys.md
+++ b/source/docs/casper/concepts/list-auth-keys.md
@@ -57,7 +57,7 @@ Here is a sample JSON representation of a Deploy's authorization keys:
 
 ## Accessing Authorization Keys from a Smart Contract
 
-Contract code can retrieve the set of authorization keys for a given deploy by calling the `runtime::list_authorization_keys` function, which returns the set of account hashes representing the keys used to sign the deploy. <!-- TODO add a link to docs.rs when it is available as part of 1.5.-->
+Contract code can retrieve the set of authorization keys for a given deploy by calling the [contract_api::runtime::list_authorization_keys](https://docs.rs/casper-contract/latest/casper_contract/contract_api/runtime/fn.list_authorization_keys.html) function, which returns the set of account hashes representing the keys used to sign the deploy.
 
 ## When to Use Authorization Keys
 

--- a/source/docs/casper/developers/dapps/sdk/script-sdk.md
+++ b/source/docs/casper/developers/dapps/sdk/script-sdk.md
@@ -8,19 +8,12 @@ The Casper team has implemented specific JS clients to support interaction with 
 
 ### Repository & Client Packages {#repository-7-client-packages}
 
-We provide you with a repository that will help you create clients for Casper contracts. The [casper-contracts-js-clients](https://github.com/casper-network/casper-contracts-js-clients/) repository contains details to create clients for Casper contracts and usage examples of such clients dedicated to interacting with smart contracts on Casper.
+We provide repositories to create clients for Casper contracts and usage examples of such clients dedicated to interacting with smart contracts on Casper:
 
-The two primary clients in this repository are:
-
--   The [Casper ERC-20 Client](https://github.com/casper-network/casper-contracts-js-clients/tree/master/packages/erc20-client) (casper-erc20-js-client)
--   The [Casper CEP-47 (NFT) Client](https://github.com/casper-network/casper-contracts-js-clients/blob/master/packages/cep47-client/README.md) (casper-cep47-js-client)
+- The [Casper CEP-78 (NFT) Client](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/client-js/README.md)
+- The [Casper CEP-18 Client](https://github.com/casper-ecosystem/cep18/tree/master/client-js#readme)
 
 These packages give you an easy way to install and interact with the corresponding Casper contract.
-
-| Package | Description |
-| --- | --- |
-| **_casper-erc20-js-client_** | Supports installation of the Casper ERC-20 contract and includes usage examples for creating client instances, installing contracts, and handling transfers, balances, allowances, and more through code examples |
-| **_casper-cep47-js-client_** | Supports installation of the Casper CEP-47 (NFT) smart contract along with installation, usage, and method details; it also includes steps to track events via the event stream |
 
 ## Casper SDK for JavaScript {#casper-sdk-for-javascript}
 

--- a/source/docs/casper/developers/writing-onchain-code/getting-started.md
+++ b/source/docs/casper/developers/writing-onchain-code/getting-started.md
@@ -40,7 +40,7 @@ A crate is a compilation unit, which can be compiled into a binary or a library.
 
 **API Documentation for Smart Contracts**
 
-Each of the Casper crates comes with API documentation and examples for each function, located at [https://docs.rs](https://docs.rs/releases/search?query=casper). The contract API documentation is specific for a given version. For example, you can find documentation for version **0.7.6** at <https://docs.rs/casper-contract/0.7.6>.
+Each of the Casper crates comes with API documentation and examples for each function, located at [https://docs.rs](https://docs.rs/releases/search?query=casper). The contract API documentation is specific for a given version. For example, you can find documentation for version **3.0.0** at <https://docs.rs/casper-contract/3.0.0/casper_contract/index.html>.
 
 ### Installing Dependencies {#installing-dependencies}
 

--- a/source/docs/casper/resources/tutorials/advanced/list-cspr.md
+++ b/source/docs/casper/resources/tutorials/advanced/list-cspr.md
@@ -126,7 +126,7 @@ casper-client transfer \
 
 ### Bulk or batched Wasm transfer
 
-Bulk or batched Wasm transfers allow you to apply some logic before or after the transfer. They also allow for conditional transfers. You may also use them if you are doing a series of transfers between multiple purses. Listed below are five methods for the [Rust contract API](https://docs.rs/casper-contract/1.4.4/casper_contract/contract_api/system/index.html), which can be used in session code to achieve batched Wasm transfer:
+Bulk or batched Wasm transfers allow you to apply some logic before or after the transfer. They also allow for conditional transfers. You may also use them if you are doing a series of transfers between multiple purses. Listed below are five methods for the [Rust contract API](https://docs.rs/casper-contract/latest/casper_contract/contract_api/system/index.html), which can be used in session code to achieve batched Wasm transfer:
 
 -   `transfer_to_account`: Transfers amount of motes from the main purse of the account to the purse of a target account. If the target purse does not exist, the transfer process will create one. Can be called from session code only and not a contract as a contract doesn't have a main purse.
 -   `transfer_to_public_key`: Transfers amount of motes from the main purse of the caller’s account to the main purse of the target. If the account referenced by the target does not exist, the transfer will create a new account. Can be called from session code only and not from a contract as a contract doesn't have a main purse.


### PR DESCRIPTION
### What does this PR fix/introduce?

- Updates docs.rs links to the latest version. I have checked all docs.rs links and TODOs.
- Removes the link to [get_immediate_caller](https://docs.rs/casper-types/1.5.0/casper_types/system/mint/trait.RuntimeProvider.html#tymethod.get_immediate_caller), which is not available in the latest version. We can point to [get_call_stack](https://docs.rs/casper-contract/3.0.0/casper_contract/contract_api/runtime/fn.get_call_stack.html) instead. Adding @deuszex for a quick technical check here.
- Removed link and content related to the erc20 client that breaks the build. Point to the cep78 client instead of the cep47 client since we are changing this file.

Closes #999

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL and @deuszex 
