### PR TITLE
1148 Reintroduce `query_balance` endpoint to `feat-1.5` docs branch

### DIFF
--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -185,6 +185,137 @@ This method returns all native transfers within a given [Block](../../concepts/d
 
 </details>
 
+## chain_get_era_summary {#chain-get-era-summary}
+
+This method returns the era summary at a given [Block](../../concepts/design/casper-design.md#block-structure-head). If you do not specify a `block_identifier`, you will receive the era summary at the highest state root hash.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|[block_identifier](./types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
+
+<details>
+
+<summary><b>Example chain_get_era_summary request</b></summary>
+
+```bash
+
+{
+  "id": 1,
+  "jsonrpc":"2.0",
+  "method":"chain_get_era_summary",
+  "params": [
+    {
+      "Hash":"9bfa58709058935882a095ca6adf844b72a2ddf0f49b8575ef1ceda987452fb8"
+    }
+  ]
+}
+
+```
+
+</details>
+
+### `chain_get_era_summary_result`
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|api_version|String|The RPC API version.|
+|[era_summary](./types_chain.md#erasummary)|Object|The era summary (if found).|
+
+<details>
+
+<summary><b>Example chain_get_era_summary result</b></summary>
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "api_version": "1.0.0",
+    "era_summary": {
+      "block_hash": "9bfa58709058935882a095ca6adf844b72a2ddf0f49b8575ef1ceda987452fb8",
+      "era_id": 1,
+      "stored_value": {
+        "EraInfo": {
+          "seigniorage_allocations": [
+            {
+              "Delegator": {
+                "delegator_public_key": "01c08939bf1ecd1139448d435989a761c975466d30b96c2dd74e9d23c7b12bc9ff",
+                "validator_public_key": "01039c258651e04597d786142d9749922245cf44b6cc0c93c58bd6c1783ac3be9b",
+                "amount": "53472520551166781393617756"
+              }
+            },
+            {
+              "Validator": {
+                "validator_public_key": "01039c258651e04597d786142d9749922245cf44b6cc0c93c58bd6c1783ac3be9b",
+                "amount": "54552773491594393138943367"
+              }
+            },
+            {
+              "Delegator": {
+                "delegator_public_key": "01264689a5b4c57dac1088cd0aae8074de105f2269f6041e2c120e80df7a95e6b5",
+                "validator_public_key": "013e193dec433a73a0b41b924243c62311689648a10b4468f9c609c75674c18726",
+                "amount": "51312014670568117976319374"
+              }
+            },
+            {
+              "Validator": {
+                "validator_public_key": "013e193dec433a73a0b41b924243c62311689648a10b4468f9c609c75674c18726",
+                "amount": "56713279372733183026458256"
+              }
+            },
+            {
+              "Delegator": {
+                "delegator_public_key": "016f571eaf1d3a442e684ecdb31d00a51448dcbaa06d00b340983311f0ba3e76db",
+                "validator_public_key": "0186d12379939682ae9669b354f7a637ec106369074d567b969cc0e2127c904f12",
+                "amount": "51852141140784624481333262"
+              }
+            },
+            {
+              "Validator": {
+                "validator_public_key": "0186d12379939682ae9669b354f7a637ec106369074d567b969cc0e2127c904f12",
+                "amount": "56173152902516676521444368"
+              }
+            },
+            {
+              "Delegator": {
+                "delegator_public_key": "0161e7ed5c592f16b507b9dd196662b530f9bde6c5b2cfd957fe8d0700ecfbe20b",
+                "validator_public_key": "01d4cbef55ed9968171102aa136c9564286211ee46c5ab65b6fd68fab5b14d4c4b",
+                "amount": "52392267611001130986347150"
+              }
+            },
+            {
+              "Validator": {
+                "validator_public_key": "01d4cbef55ed9968171102aa136c9564286211ee46c5ab65b6fd68fab5b14d4c4b",
+                "amount": "55633026432300170016430480"
+              }
+            },
+            {
+              "Delegator": {
+                "delegator_public_key": "01b1339a1d114036d84d7b65c804669166d38456114657abbb0e53e67bf1667c60",
+                "validator_public_key": "01dbce10c8418c21daf16bc1052a486cdb557ba66b09a84605bc1f4b3df364960f",
+                "amount": "52932394080952975520954950"
+              }
+            },
+            {
+              "Validator": {
+                "validator_public_key": "01dbce10c8418c21daf16bc1052a486cdb557ba66b09a84605bc1f4b3df364960f",
+                "amount": "55092899961808199011606173"
+              }
+            }
+          ]
+        }
+      },
+      "state_root_hash": "918abd1973171867e03c1e6e56fd7dd9da35c92461784f9a15c0df23e437d850",
+      "merkle_proof": "010000000e0000000000000000000000000000000000000000000000000000000000000000070a0000000101c08939bf1ecd1139448d435989a761c975466d30b96c2dd74e9d23c7b12bc9ff01039c258651e04597d786142d9749922245cf44b6cc0c93c58bd6c1783ac3be9b0b5c4316483512c2253f3b2c0001039c258651e04597d786142d9749922245cf44b6cc0c93c58bd6c1783ac3be9b0b87d59268bf17d8c6ff1f2d0101264689a5b4c57dac1088cd0aae8074de105f2269f6041e2c120e80df7a95e6b5013e193dec433a73a0b41b924243c62311689648a10b4468f9c609c75674c187260b8e45261378f096e3bd712a00013e193dec433a73a0b41b924243c62311689648a10b4468f9c609c75674c187260b90eee69bba24050981e92e01016f571eaf1d3a442e684ecdb31d00a51448dcbaa06d00b340983311f0ba3e76db0186d12379939682ae9669b354f7a637ec106369074d567b969cc0e2127c904f120b0ef09fedb1f521341ee42a000186d12379939682ae9669b354f7a637ec106369074d567b969cc0e2127c904f120b10446dc1801f7ab820772e010161e7ed5c592f16b507b9dd196662b530f9bde6c5b2cfd957fe8d0700ecfbe20b01d4cbef55ed9968171102aa136c9564286211ee46c5ab65b6fd68fab5b14d4c4b0b8e9a19c8ebfaac847e562b0001d4cbef55ed9968171102aa136c9564286211ee46c5ab65b6fd68fab5b14d4c4b0b9099f3e6461aef67c0042e0101b1339a1d114036d84d7b65c804669166d38456114657abbb0e53e67bf1667c6001dbce10c8418c21daf16bc1052a486cdb557ba66b09a84605bc1f4b3df364960f0b46fad737700f37d5dec82b0001dbce10c8418c21daf16bc1052a486cdb557ba66b09a84605bc1f4b3df364960f0b9d1ed178841a631760922d01000000000e060000000001fb7043fe388fef916937aa899a0dda9b042168149e600fb068ecb16839d545d60101a0676758b903440b28c8f4a1d46404e9879fcfc0b90dad20962536de493aecc302013584bc9d5c00ac639fe14410b4cfa480b12eddd8f3dce08d7b76ae47977c1c680601664224aca1272e2a5632da4a56399dee6c585318ebbb7bb4040039792d3ad33c07013b48237cd26eb35ec3c864e1ae250ca656d00893de1dfc4c951e0d779adeda1d0a002c722cac61792676eb19d773fd3c41e37a63f54f78bdf7712ca96a5c5e5c4986"
+    }
+  }
+}
+
+```
+
+</details>
+
 ## chain_get_state_root_hash {#chain-get-state-root-hash} 
 
 This method returns a state root hash at a given [Block](../../concepts/design/casper-design.md#block-structure-head). If you do not specify a `block_identifier`, you will receive the highest state root hash.
@@ -234,58 +365,6 @@ This method returns a state root hash at a given [Block](../../concepts/design/c
     "api_version": "1.4.13",
     "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808"
   }
-}
-
-```
-
-</details>
-
-## info_get_chainspec {#info-get-chainspec}
-
-This method returns raw bytes for chainspec files.
-
-<details>
-
-<summary><b>Example info_get_chainspec request</b></summary>
-
-```bash
-
-{
-  "jsonrpc": "2.0",
-  "method": "info_get_chainspec",
-  "id": 5510244237763930243
-}
-
-```
-
-</details>
-
-### `info_get_chainspec_result`
-
-|Parameter|Type|Description|
-|---------|----|-----------| 
-|api_version|String|The RPC API version.|
-|[chainspec_bytes](./types_chain.md#ChainspecRawBytes)|Object|The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.|
-
-<details>
-
-<summary><b>Example info_get_chainspec result</b></summary>
-
-Please note that adding a `--vv` flag will return the full chainspec bytes.
-
-```bash
-
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "api_version": "1.5.0",
-    "chainspec_bytes": {
-      "chainspec_bytes": "[22040 hex chars]",
-      "maybe_genesis_accounts_bytes": null,
-      "maybe_global_state_bytes": null
-    }
-  },
-  "id": 5510244237763930243
 }
 
 ```
@@ -439,11 +518,76 @@ If the `execution_results` field is empty, it means that the network processed t
 
 </details>
 
+## query_balance {#query-balance}
+
+This method allows you to query for the balance of a purse using a `PurseIdentifier` and `StateIdentifier`.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|[purse_identifier](/dapp-dev-guide/sdkspec/types_chain#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
+|[state_identifier](/dapp-dev-guide/sdkspec/types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
+
+<details>
+
+<summary><b>Example query_balance request</b></summary>
+
+```bash
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "query_balance",
+  "params": [
+      {
+        "name": "state_identifier",
+        "value": {
+          "BlockHash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
+        }
+    },
+      {
+        "name": "purse_identifier",
+        "value": {
+          "main_purse_under_account_hash": "account-hash-0909090909090909090909090909090909090909090909090909090909090909"
+        }
+      }
+    ]
+}
+
+```
+
+</details>
+
+
+### `query_balance_result`
+
+|Parameter|Type|Description|
+|---------|----|-----------|     
+|api_version|String|The RPC API version.|
+|[balance](/dapp-dev-guide/sdkspec/types_chain#u512)|Object|The balance represented in motes.|
+
+<details>
+
+<summary><b>Example query_balance result</b></summary>
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "id": -6143675785141640608,
+  "result": {
+    "api_version": "1.0.0",
+    "balance": "1000000000000000000000000000000000"
+  }
+}
+
+```
+
+</details>
+
 ## query_global_state {#query-global-state}
 
 This method allows for you to query for a value stored under certain keys in global state. You may query using either a [Block hash](../../concepts/design/casper-design.md#block_hash) or state root hash.
 
-* Note: Querying a purse's balance requires the use of `state_get_balance` rather than any iteration of `query_global_state`.
+* Note: Querying a purse's balance requires the use of `state_get_balance` or `query_balance`, rather than any iteration of `query_global_state`.
 
 |Parameter|Type|Description|
 |---------|----|-----------|   
@@ -851,16 +995,12 @@ This method returns the current status of a node.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[available_block_range](./types_chain.md#AvailableBlockRange)|Object|The available block range in storage.|
-|[block_sync](./types_chain.md#BlockSynchronizerStatus)|Object|The status of the block synchronizer builders.|
 |build_version|String|The compiled node version.|
 |chainspec_name|String|The chainspec name, used to identify the currently connected network.|
 |[last_added_block_info](./types_chain.md#minimalblockinfo)|Object|The minimal info of the last Block from the linear chain.|
-|[last_progress](./types_chain.md#timestamp)|String|Timestamp of the last recorded progress in the reactor.|
 |[next_upgrade](./types_chain.md#nextupgrade)|Object|Information about the next scheduled upgrade.|
 |[our_public_signing_key](./types_chain.md#publickey)|String|Our public signing key.|
 |[peers](./types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
-|[reactor_state](./types_chain.md#reactorstate)|String|The current state of the node reactor.|
 |[round_length](./types_chain.md#timediff)|Integer|The next round length if this node is a validator. A round length is the amount of time it takes to reach consensus on proposing a Block.|
 |[starting_state_root_hash](./types_chain.md#digest)|String|The state root hash used at the start of the current session.|
 |[uptime](./types_chain.md#timediff)|Integer|Time that passed since the node has started.|
@@ -872,56 +1012,55 @@ This method returns the current status of a node.
 ```bash
 
 {
-              "name": "info_get_status_example",
-              "params": [],
-              "result": {
-                "name": "info_get_status_example_result",
-                "value": {
-                  "peers": [
-                    {
-                      "node_id": "tls:0101..0101",
-                      "address": "127.0.0.1:54321"
-                    }
-                  ],
-                  "api_version": "1.4.8",
-                  "build_version": "1.0.0-xxxxxxxxx@DEBUG",
-                  "chainspec_name": "casper-example",
-                  "starting_state_root_hash": null,
-                  "last_added_block_info": {
-                    "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
-                    "timestamp": "2020-11-17T00:39:24.072Z",
-                    "era_id": 1,
-                    "height": 10,
-                    "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
-                    "creator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
-                  },
-                  "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-                  "round_length": "1m 5s 536ms",
-                  "next_upgrade": {
-                    "activation_point": 42,
-                    "protocol_version": "2.0.1"
-                  },
-                  "uptime": "13s",
-                  "reactor_state": "Initialize",
-                  "last_progress": "1970-01-01T00:00:00.000Z",
-                  "available_block_range": {
-                    "low": 0,
-                    "high": 0
-                  },
-                  "block_sync": {
-                    "historical": {
-                      "block_hash": "16ddf28e2b3d2e17f4cef36f8b58827eca917af225d139b0c77df3b4a67dc55e",
-                      "block_height": 40,
-                      "acquisition_state": "have strict finality(40) for: block hash 16dd..c55e"
-                    },
-                    "forward": {
-                      "block_hash": "59907b1e32a9158169c4d89d9ce5ac9164fc31240bfcfb0969227ece06d74983",
-                      "block_height": 6701,
-                      "acquisition_state": "have block body(6701) for: block hash 5990..4983"
-                    }
-                  }
-                }
-              }
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "name": "info_get_status_result",
+    "value": {
+      "peers": [
+      {
+        "node_id": "tls:0101..0101",
+        "address": "127.0.0.1:54321"
+      }
+    ],
+    "api_version": "1.4.8",
+    "build_version": "1.0.0-xxxxxxxxx@DEBUG",
+    "chainspec_name": "casper-example",
+    "starting_state_root_hash": null,
+    "last_added_block_info": {
+      "hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
+      "timestamp": "2020-11-17T00:39:24.072Z",
+      "era_id": 1,
+      "height": 10,
+      "state_root_hash": "0808080808080808080808080808080808080808080808080808080808080808",
+      "creator": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+    },
+    "our_public_signing_key": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+    "round_length": "1m 5s 536ms",
+    "next_upgrade": {
+      "activation_point": 42,
+      "protocol_version": "2.0.1"
+    },
+    "uptime": "13s",
+    "reactor_state": "Initialize",
+    "last_progress": "1970-01-01T00:00:00.000Z",
+    "available_block_range": {
+      "low": 0,
+      "high": 0
+    },
+    "block_sync": {
+      "historical": {
+        "block_hash": "16ddf28e2b3d2e17f4cef36f8b58827eca917af225d139b0c77df3b4a67dc55e",
+        "block_height": 40,
+        "acquisition_state": "have strict finality(40) for: block hash 16dd..c55e"
+      },
+      "forward": {
+        "block_hash": "59907b1e32a9158169c4d89d9ce5ac9164fc31240bfcfb0969227ece06d74983",
+        "block_height": 6701,
+        "acquisition_state": "have block body(6701) for: block hash 5990..4983"
+      }
+    }
+  }
 }
 
 ```

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -1047,12 +1047,16 @@ This method returns the current status of a node.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
+|[available_block_range](./types_chain.md#AvailableBlockRange)|Object|The available block range in storage.|
+|[block_sync](./types_chain.md#BlockSynchronizerStatus)|Object|The status of the block synchronizer builders.|
 |build_version|String|The compiled node version.|
 |chainspec_name|String|The chainspec name, used to identify the currently connected network.|
 |[last_added_block_info](./types_chain.md#minimalblockinfo)|Object|The minimal info of the last Block from the linear chain.|
+|[last_progress](./types_chain.md#timestamp)|String|Timestamp of the last recorded progress in the reactor.|
 |[next_upgrade](./types_chain.md#nextupgrade)|Object|Information about the next scheduled upgrade.|
 |[our_public_signing_key](./types_chain.md#publickey)|String|Our public signing key.|
 |[peers](./types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
+|[reactor_state](./types_chain.md#reactorstate)|String|The current state of the node reactor.|
 |[round_length](./types_chain.md#timediff)|Integer|The next round length if this node is a validator. A round length is the amount of time it takes to reach consensus on proposing a Block.|
 |[starting_state_root_hash](./types_chain.md#digest)|String|The state root hash used at the start of the current session.|
 |[uptime](./types_chain.md#timediff)|Integer|Time that passed since the node has started.|

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -11,7 +11,7 @@ This method returns the JSON representation of a [Block](../../concepts/design/c
 
 |Parameter|Type|Description|
 |---------|----|-----------| 
-|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash or the Block height.|
+|[block_identifier](types_chain.md#blockidentifier)|Object|The Block hash or the Block height.|
 
 <details>
 
@@ -41,7 +41,7 @@ The result from `chain_get_block` depends on block availability from a given nod
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[block](../types_chain.md#jsonblock)|Object|The Block, if found. (Not required)|
+|[block](types_chain.md#jsonblock)|Object|The Block, if found. (Not required)|
 
 <details>
 
@@ -124,7 +124,7 @@ This method returns all native transfers within a given [Block](../../concepts/d
 
 |Parameter|Type|Description|
 |---------|----|-----------| 
-|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash.|
+|[block_identifier](types_chain.md#blockidentifier)|Object|The Block hash.|
 
 <details>
 
@@ -151,8 +151,8 @@ This method returns all native transfers within a given [Block](../../concepts/d
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[block_hash](../types_chain.md#blockhash)|Object|The Block hash, if found.|
-|[transfers](../types_chain.md#transfer)|Array|The Block's transfers, if found.|
+|[block_hash](types_chain.md#blockhash)|Object|The Block hash, if found.|
+|[transfers](types_chain.md#transfer)|Array|The Block's transfers, if found.|
 
 <details>
 
@@ -191,7 +191,7 @@ This method returns the era summary at a given [Block](../../concepts/design/cas
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
+|[block_identifier](types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
 
 <details>
 
@@ -219,7 +219,7 @@ This method returns the era summary at a given [Block](../../concepts/design/cas
 |Parameter|Type|Description|
 |---------|----|-----------|
 |api_version|String|The RPC API version.|
-|[era_summary](../types_chain.md#erasummary)|Object|The era summary (if found).|
+|[era_summary](types_chain.md#erasummary)|Object|The era summary (if found).|
 
 <details>
 
@@ -322,7 +322,7 @@ This method returns a state root hash at a given [Block](../../concepts/design/c
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
+|[block_identifier](types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
 
 <details>
 
@@ -350,7 +350,7 @@ This method returns a state root hash at a given [Block](../../concepts/design/c
 |Parameter|Type|Description|
 |---------|----|-----------|
 |api_version|String|The RPC API version.|
-|[state_root_hash](../types_chain.md#digest)|String| Hex-encoded hash of the state root.|
+|[state_root_hash](types_chain.md#digest)|String| Hex-encoded hash of the state root.|
 
 <details>
 
@@ -396,7 +396,7 @@ This method returns raw bytes for chainspec files.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[chainspec_bytes](../types_chain.md#ChainspecRawBytes)|Object|The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.|
+|[chainspec_bytes](types_chain.md#ChainspecRawBytes)|Object|The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.|
 
 <details>
 
@@ -429,8 +429,8 @@ This method retrieves a [Deploy](../../concepts/design/casper-design.md#executio
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[deploy_hash](../types_chain.md#deployhash)|String|The Deploy hash.|
-|[finalized_approvals](../types_chain.md#finalizedapprovals)|Boolean|Determines whether to return the Deploy with the finalized approvals substituted. (Optional)|
+|[deploy_hash](types_chain.md#deployhash)|String|The Deploy hash.|
+|[finalized_approvals](types_chain.md#finalizedapprovals)|Boolean|Determines whether to return the Deploy with the finalized approvals substituted. (Optional)|
 
 <details>
 
@@ -461,8 +461,8 @@ If the `execution_results` field is empty, it means that the network processed t
 |Parameter|Type|Description|
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
-|[deploy](../types_chain.md#deploy)|Object|The Deploy.|
-|[execution_results](../types_chain.md#jsonexecutionresult)|Object|The map of Block hash to execution result.|
+|[deploy](types_chain.md#deploy)|Object|The Deploy.|
+|[execution_results](types_chain.md#jsonexecutionresult)|Object|The map of Block hash to execution result.|
 
 <details>
 
@@ -576,8 +576,8 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[purse_identifier](../types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
-|[state_identifier](../types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
+|[purse_identifier](types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
+|[state_identifier](types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
 
 <details>
 
@@ -614,7 +614,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 |Parameter|Type|Description|
 |---------|----|-----------|     
 |api_version|String|The RPC API version.|
-|[balance](../types_chain#u512)|Object|The balance represented in motes.|
+|[balance](types_chain#u512)|Object|The balance represented in motes.|
 
 <details>
 
@@ -643,7 +643,7 @@ This method allows for you to query for a value stored under certain keys in glo
 
 |Parameter|Type|Description|
 |---------|----|-----------|   
-|[state_identifier](../types_chain.md#globalstateidentifier)|Object|The identifier used for the query.|
+|[state_identifier](types_chain.md#globalstateidentifier)|Object|The identifier used for the query.|
 |key|String|`casper_types::Key` as a formatted string.|
 |path|Array|The path components starting from the key as base.|
 
@@ -675,9 +675,9 @@ This method allows for you to query for a value stored under certain keys in glo
 |Parameter|Type|Description|
 |---------|----|-----------|     
 |api_version|String|The RPC API version.|
-|[block_header](../types_chain.md#jsonblockheader)|Object|The Block header if a Block hash was provided. (Not required)|
-|[stored_value](../types_chain.md#storedvalue)|Object|The stored value.|
-|[merkle_proof](../types_chain.md#merkle-proof)|String|The merkle proof.|
+|[block_header](types_chain.md#jsonblockheader)|Object|The Block header if a Block hash was provided. (Not required)|
+|[stored_value](types_chain.md#storedvalue)|Object|The stored value.|
+|[merkle_proof](types_chain.md#merkle-proof)|String|The merkle proof.|
 
 <details>
 
@@ -762,8 +762,8 @@ This method returns a JSON representation of an [Account](../../concepts/design/
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[public_key](../types_chain.md#publickey)|String|The public key of the Account.|
-|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block identifier.|
+|[public_key](types_chain.md#publickey)|String|The public key of the Account.|
+|[block_identifier](types_chain.md#blockidentifier)|Object|The Block identifier.|
 
 <details>
 
@@ -792,8 +792,8 @@ This method returns a JSON representation of an [Account](../../concepts/design/
 |Parameter|Type|Description|
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
-|[account](../types_chain.md#account)|Object|A JSON representation of the Account structure.| 
-|[merkle_proof](../types_chain.md#merkleproof)|String|The merkle proof.|
+|[account](types_chain.md#account)|Object|A JSON representation of the Account structure.| 
+|[merkle_proof](types_chain.md#merkleproof)|String|The merkle proof.|
 
 <details>
 
@@ -839,7 +839,7 @@ For instance, one native layer-1 token of the Casper Mainnet [CSPR](../../concep
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[state_root_hash](../types_chain.md#digest)|String|The hash of state root.|
+|[state_root_hash](types_chain.md#digest)|String|The hash of state root.|
 |purse_uref|String|Formatted URef.|
 
 <details>
@@ -866,8 +866,8 @@ For instance, one native layer-1 token of the Casper Mainnet [CSPR](../../concep
 |Parameter|Type|Description|
 |---------|----|-----------|
 |api_version|String|The RPC API version.|
-|[balance_value](../types_chain.md#u512)|String|The balance value in motes.|
-|[merkle_proof](../types_chain.md#merkle-proof)|String|The merkle proof.|
+|[balance_value](types_chain.md#u512)|String|The balance value in motes.|
+|[merkle_proof](types_chain.md#merkle-proof)|String|The merkle proof.|
 
 <details>
 <summary><b>Example state_get_balance result</b></summary>
@@ -896,8 +896,8 @@ You may query a stored value directly using the dictionary address.
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[state_root_hash](../types_chain.md#digest)|String|Hash of the state root.|
-|[dictionary_identifier](../types_chain.md#dictionaryidentifier)|Object|The Dictionary query identifier.|
+|[state_root_hash](types_chain.md#digest)|String|Hash of the state root.|
+|[dictionary_identifier](types_chain.md#dictionaryidentifier)|Object|The Dictionary query identifier.|
 
 <details>
 
@@ -930,8 +930,8 @@ You may query a stored value directly using the dictionary address.
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
 |dictionary_key|String|The key under which the value is stored.|
-|[stored_value](../types_chain.md#storedvalue)|Object|The stored value.|
-|[merkle_proof](../types_chain.md#merkle-proof)|String|The merkle proof.|
+|[stored_value](types_chain.md#storedvalue)|Object|The stored value.|
+|[merkle_proof](types_chain.md#merkle-proof)|String|The merkle proof.|
 
 <details>
 
@@ -995,7 +995,7 @@ This method returns a list of peers connected to the node.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[peers](../types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
+|[peers](types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
 
 <details>
 
@@ -1047,19 +1047,19 @@ This method returns the current status of a node.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[available_block_range](../types_chain.md#AvailableBlockRange)|Object|The available block range in storage.|
-|[block_sync](../types_chain.md#BlockSynchronizerStatus)|Object|The status of the block synchronizer builders.|
+|[available_block_range](types_chain.md#AvailableBlockRange)|Object|The available block range in storage.|
+|[block_sync](types_chain.md#BlockSynchronizerStatus)|Object|The status of the block synchronizer builders.|
 |build_version|String|The compiled node version.|
 |chainspec_name|String|The chainspec name, used to identify the currently connected network.|
-|[last_added_block_info](../types_chain.md#minimalblockinfo)|Object|The minimal info of the last Block from the linear chain.|
-|[last_progress](../types_chain.md#timestamp)|String|Timestamp of the last recorded progress in the reactor.|
-|[next_upgrade](../types_chain.md#nextupgrade)|Object|Information about the next scheduled upgrade.|
-|[our_public_signing_key](../types_chain.md#publickey)|String|Our public signing key.|
-|[peers](../types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
-|[reactor_state](../types_chain.md#reactorstate)|String|The current state of the node reactor.|
-|[round_length](../types_chain.md#timediff)|Integer|The next round length if this node is a validator. A round length is the amount of time it takes to reach consensus on proposing a Block.|
-|[starting_state_root_hash](../types_chain.md#digest)|String|The state root hash used at the start of the current session.|
-|[uptime](../types_chain.md#timediff)|Integer|Time that passed since the node has started.|
+|[last_added_block_info](types_chain.md#minimalblockinfo)|Object|The minimal info of the last Block from the linear chain.|
+|[last_progress](types_chain.md#timestamp)|String|Timestamp of the last recorded progress in the reactor.|
+|[next_upgrade](types_chain.md#nextupgrade)|Object|Information about the next scheduled upgrade.|
+|[our_public_signing_key](types_chain.md#publickey)|String|Our public signing key.|
+|[peers](types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
+|[reactor_state](types_chain.md#reactorstate)|String|The current state of the node reactor.|
+|[round_length](types_chain.md#timediff)|Integer|The next round length if this node is a validator. A round length is the amount of time it takes to reach consensus on proposing a Block.|
+|[starting_state_root_hash](types_chain.md#digest)|String|The state root hash used at the start of the current session.|
+|[uptime](types_chain.md#timediff)|Integer|Time that passed since the node has started.|
 
 <details>
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -11,7 +11,7 @@ This method returns the JSON representation of a [Block](../../concepts/design/c
 
 |Parameter|Type|Description|
 |---------|----|-----------| 
-|[block_identifier](./types_chain.md#blockidentifier)|Object|The Block hash or the Block height.|
+|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash or the Block height.|
 
 <details>
 
@@ -41,7 +41,7 @@ The result from `chain_get_block` depends on block availability from a given nod
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[block](./types_chain.md#jsonblock)|Object|The Block, if found. (Not required)|
+|[block](../types_chain.md#jsonblock)|Object|The Block, if found. (Not required)|
 
 <details>
 
@@ -124,7 +124,7 @@ This method returns all native transfers within a given [Block](../../concepts/d
 
 |Parameter|Type|Description|
 |---------|----|-----------| 
-|[block_identifier](./types_chain.md#blockidentifier)|Object|The Block hash.|
+|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash.|
 
 <details>
 
@@ -151,8 +151,8 @@ This method returns all native transfers within a given [Block](../../concepts/d
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[block_hash](./types_chain.md#blockhash)|Object|The Block hash, if found.|
-|[transfers](./types_chain.md#transfer)|Array|The Block's transfers, if found.|
+|[block_hash](../types_chain.md#blockhash)|Object|The Block hash, if found.|
+|[transfers](../types_chain.md#transfer)|Array|The Block's transfers, if found.|
 
 <details>
 
@@ -191,7 +191,7 @@ This method returns the era summary at a given [Block](../../concepts/design/cas
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[block_identifier](./types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
+|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
 
 <details>
 
@@ -219,7 +219,7 @@ This method returns the era summary at a given [Block](../../concepts/design/cas
 |Parameter|Type|Description|
 |---------|----|-----------|
 |api_version|String|The RPC API version.|
-|[era_summary](./types_chain.md#erasummary)|Object|The era summary (if found).|
+|[era_summary](../types_chain.md#erasummary)|Object|The era summary (if found).|
 
 <details>
 
@@ -322,7 +322,7 @@ This method returns a state root hash at a given [Block](../../concepts/design/c
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[block_identifier](./types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
+|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block hash. (Optional)|
 
 <details>
 
@@ -350,7 +350,7 @@ This method returns a state root hash at a given [Block](../../concepts/design/c
 |Parameter|Type|Description|
 |---------|----|-----------|
 |api_version|String|The RPC API version.|
-|[state_root_hash](./types_chain.md#digest)|String| Hex-encoded hash of the state root.|
+|[state_root_hash](../types_chain.md#digest)|String| Hex-encoded hash of the state root.|
 
 <details>
 
@@ -396,7 +396,7 @@ This method returns raw bytes for chainspec files.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[chainspec_bytes](./types_chain.md#ChainspecRawBytes)|Object|The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.|
+|[chainspec_bytes](../types_chain.md#ChainspecRawBytes)|Object|The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.|
 
 <details>
 
@@ -429,8 +429,8 @@ This method retrieves a [Deploy](../../concepts/design/casper-design.md#executio
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[deploy_hash](./types_chain.md#deployhash)|String|The Deploy hash.|
-|[finalized_approvals](./types_chain.md#finalizedapprovals)|Boolean|Determines whether to return the Deploy with the finalized approvals substituted. (Optional)|
+|[deploy_hash](../types_chain.md#deployhash)|String|The Deploy hash.|
+|[finalized_approvals](../types_chain.md#finalizedapprovals)|Boolean|Determines whether to return the Deploy with the finalized approvals substituted. (Optional)|
 
 <details>
 
@@ -461,8 +461,8 @@ If the `execution_results` field is empty, it means that the network processed t
 |Parameter|Type|Description|
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
-|[deploy](./types_chain.md#deploy)|Object|The Deploy.|
-|[execution_results](./types_chain.md#jsonexecutionresult)|Object|The map of Block hash to execution result.|
+|[deploy](../types_chain.md#deploy)|Object|The Deploy.|
+|[execution_results](../types_chain.md#jsonexecutionresult)|Object|The map of Block hash to execution result.|
 
 <details>
 
@@ -576,8 +576,8 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[purse_identifier](./types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
-|[state_identifier](./types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
+|[purse_identifier](../types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
+|[state_identifier](../types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
 
 <details>
 
@@ -614,7 +614,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 |Parameter|Type|Description|
 |---------|----|-----------|     
 |api_version|String|The RPC API version.|
-|[balance](./types_chain#u512)|Object|The balance represented in motes.|
+|[balance](../types_chain#u512)|Object|The balance represented in motes.|
 
 <details>
 
@@ -643,7 +643,7 @@ This method allows for you to query for a value stored under certain keys in glo
 
 |Parameter|Type|Description|
 |---------|----|-----------|   
-|[state_identifier](./types_chain.md#globalstateidentifier)|Object|The identifier used for the query.|
+|[state_identifier](../types_chain.md#globalstateidentifier)|Object|The identifier used for the query.|
 |key|String|`casper_types::Key` as a formatted string.|
 |path|Array|The path components starting from the key as base.|
 
@@ -675,9 +675,9 @@ This method allows for you to query for a value stored under certain keys in glo
 |Parameter|Type|Description|
 |---------|----|-----------|     
 |api_version|String|The RPC API version.|
-|[block_header](./types_chain.md#jsonblockheader)|Object|The Block header if a Block hash was provided. (Not required)|
-|[stored_value](./types_chain.md#storedvalue)|Object|The stored value.|
-|[merkle_proof](./types_chain.md#merkle-proof)|String|The merkle proof.|
+|[block_header](../types_chain.md#jsonblockheader)|Object|The Block header if a Block hash was provided. (Not required)|
+|[stored_value](../types_chain.md#storedvalue)|Object|The stored value.|
+|[merkle_proof](../types_chain.md#merkle-proof)|String|The merkle proof.|
 
 <details>
 
@@ -762,8 +762,8 @@ This method returns a JSON representation of an [Account](../../concepts/design/
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[public_key](./types_chain.md#publickey)|String|The public key of the Account.|
-|[block_identifier](./types_chain.md#blockidentifier)|Object|The Block identifier.|
+|[public_key](../types_chain.md#publickey)|String|The public key of the Account.|
+|[block_identifier](../types_chain.md#blockidentifier)|Object|The Block identifier.|
 
 <details>
 
@@ -792,8 +792,8 @@ This method returns a JSON representation of an [Account](../../concepts/design/
 |Parameter|Type|Description|
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
-|[account](./types_chain.md#account)|Object|A JSON representation of the Account structure.| 
-|[merkle_proof](./types_chain.md#merkleproof)|String|The merkle proof.|
+|[account](../types_chain.md#account)|Object|A JSON representation of the Account structure.| 
+|[merkle_proof](../types_chain.md#merkleproof)|String|The merkle proof.|
 
 <details>
 
@@ -839,7 +839,7 @@ For instance, one native layer-1 token of the Casper Mainnet [CSPR](../../concep
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[state_root_hash](./types_chain.md#digest)|String|The hash of state root.|
+|[state_root_hash](../types_chain.md#digest)|String|The hash of state root.|
 |purse_uref|String|Formatted URef.|
 
 <details>
@@ -866,8 +866,8 @@ For instance, one native layer-1 token of the Casper Mainnet [CSPR](../../concep
 |Parameter|Type|Description|
 |---------|----|-----------|
 |api_version|String|The RPC API version.|
-|[balance_value](./types_chain.md#u512)|String|The balance value in motes.|
-|[merkle_proof](./types_chain.md#merkle-proof)|String|The merkle proof.|
+|[balance_value](../types_chain.md#u512)|String|The balance value in motes.|
+|[merkle_proof](../types_chain.md#merkle-proof)|String|The merkle proof.|
 
 <details>
 <summary><b>Example state_get_balance result</b></summary>
@@ -896,8 +896,8 @@ You may query a stored value directly using the dictionary address.
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[state_root_hash](./types_chain.md#digest)|String|Hash of the state root.|
-|[dictionary_identifier](./types_chain.md#dictionaryidentifier)|Object|The Dictionary query identifier.|
+|[state_root_hash](../types_chain.md#digest)|String|Hash of the state root.|
+|[dictionary_identifier](../types_chain.md#dictionaryidentifier)|Object|The Dictionary query identifier.|
 
 <details>
 
@@ -930,8 +930,8 @@ You may query a stored value directly using the dictionary address.
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
 |dictionary_key|String|The key under which the value is stored.|
-|[stored_value](./types_chain.md#storedvalue)|Object|The stored value.|
-|[merkle_proof](./types_chain.md#merkle-proof)|String|The merkle proof.|
+|[stored_value](../types_chain.md#storedvalue)|Object|The stored value.|
+|[merkle_proof](../types_chain.md#merkle-proof)|String|The merkle proof.|
 
 <details>
 
@@ -995,7 +995,7 @@ This method returns a list of peers connected to the node.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[peers](./types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
+|[peers](../types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
 
 <details>
 
@@ -1047,19 +1047,19 @@ This method returns the current status of a node.
 |Parameter|Type|Description|
 |---------|----|-----------| 
 |api_version|String|The RPC API version.|
-|[available_block_range](./types_chain.md#AvailableBlockRange)|Object|The available block range in storage.|
-|[block_sync](./types_chain.md#BlockSynchronizerStatus)|Object|The status of the block synchronizer builders.|
+|[available_block_range](../types_chain.md#AvailableBlockRange)|Object|The available block range in storage.|
+|[block_sync](../types_chain.md#BlockSynchronizerStatus)|Object|The status of the block synchronizer builders.|
 |build_version|String|The compiled node version.|
 |chainspec_name|String|The chainspec name, used to identify the currently connected network.|
-|[last_added_block_info](./types_chain.md#minimalblockinfo)|Object|The minimal info of the last Block from the linear chain.|
-|[last_progress](./types_chain.md#timestamp)|String|Timestamp of the last recorded progress in the reactor.|
-|[next_upgrade](./types_chain.md#nextupgrade)|Object|Information about the next scheduled upgrade.|
-|[our_public_signing_key](./types_chain.md#publickey)|String|Our public signing key.|
-|[peers](./types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
-|[reactor_state](./types_chain.md#reactorstate)|String|The current state of the node reactor.|
-|[round_length](./types_chain.md#timediff)|Integer|The next round length if this node is a validator. A round length is the amount of time it takes to reach consensus on proposing a Block.|
-|[starting_state_root_hash](./types_chain.md#digest)|String|The state root hash used at the start of the current session.|
-|[uptime](./types_chain.md#timediff)|Integer|Time that passed since the node has started.|
+|[last_added_block_info](../types_chain.md#minimalblockinfo)|Object|The minimal info of the last Block from the linear chain.|
+|[last_progress](../types_chain.md#timestamp)|String|Timestamp of the last recorded progress in the reactor.|
+|[next_upgrade](../types_chain.md#nextupgrade)|Object|Information about the next scheduled upgrade.|
+|[our_public_signing_key](../types_chain.md#publickey)|String|Our public signing key.|
+|[peers](../types_chain.md#peersmap)|Array|The node ID and network address of each connected peer.|
+|[reactor_state](../types_chain.md#reactorstate)|String|The current state of the node reactor.|
+|[round_length](../types_chain.md#timediff)|Integer|The next round length if this node is a validator. A round length is the amount of time it takes to reach consensus on proposing a Block.|
+|[starting_state_root_hash](../types_chain.md#digest)|String|The state root hash used at the start of the current session.|
+|[uptime](../types_chain.md#timediff)|Integer|Time that passed since the node has started.|
 
 <details>
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -576,7 +576,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[purse_identifier](types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
+|[purse_identifier](types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to the balance query.|
 |[state_identifier](types_chain.md#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
 
 <details>

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -576,8 +576,8 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[purse_identifier](/types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
-|[state_identifier](/types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
+|[purse_identifier](./types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
+|[state_identifier](./types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
 
 <details>
 
@@ -614,7 +614,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 |Parameter|Type|Description|
 |---------|----|-----------|     
 |api_version|String|The RPC API version.|
-|[balance](/types_chain#u512)|Object|The balance represented in motes.|
+|[balance](./types_chain#u512)|Object|The balance represented in motes.|
 
 <details>
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -371,6 +371,58 @@ This method returns a state root hash at a given [Block](../../concepts/design/c
 
 </details>
 
+## info_get_chainspec {#info-get-chainspec}
+
+This method returns raw bytes for chainspec files.
+
+<details>
+
+<summary><b>Example info_get_chainspec request</b></summary>
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "method": "info_get_chainspec",
+  "id": 5510244237763930243
+}
+
+```
+
+</details>
+
+### `info_get_chainspec_result`
+
+|Parameter|Type|Description|
+|---------|----|-----------| 
+|api_version|String|The RPC API version.|
+|[chainspec_bytes](./types_chain.md#ChainspecRawBytes)|Object|The raw bytes of the chainspec.toml, genesis accounts.toml, and global_state.toml files.|
+
+<details>
+
+<summary><b>Example info_get_chainspec result</b></summary>
+
+Please note that adding a `--vv` flag will return the full chainspec bytes.
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.5.0",
+    "chainspec_bytes": {
+      "chainspec_bytes": "[22040 hex chars]",
+      "maybe_genesis_accounts_bytes": null,
+      "maybe_global_state_bytes": null
+    }
+  },
+  "id": 5510244237763930243
+}
+
+```
+
+</details>
+
 ## info_get_deploy {#info-get-deploy}
 
 This method retrieves a [Deploy](../../concepts/design/casper-design.md#execution-semantics-deploys) from a network. It requires a `deploy_hash` to query the Deploy.

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -577,7 +577,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 |Parameter|Type|Description|
 |---------|----|-----------|
 |[purse_identifier](types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
-|[state_identifier](types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
+|[state_identifier](types_chain.md#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
 
 <details>
 
@@ -614,7 +614,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 |Parameter|Type|Description|
 |---------|----|-----------|     
 |api_version|String|The RPC API version.|
-|[balance](types_chain#u512)|Object|The balance represented in motes.|
+|[balance](types_chain.md#u512)|Object|The balance represented in motes.|
 
 <details>
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -576,8 +576,8 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[purse_identifier](/dapp-dev-guide/sdkspec/types_chain#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
-|[state_identifier](/dapp-dev-guide/sdkspec/types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
+|[purse_identifier](/types_chain.md#purseidentifier)|Object|The identifier to obtain the purse corresponding to balance query.|
+|[state_identifier](/types_chain#globalstateidentifier)|Object|The state identifier used for the query; if none is passed the tip of the chain will be used.|
 
 <details>
 
@@ -614,7 +614,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 |Parameter|Type|Description|
 |---------|----|-----------|     
 |api_version|String|The RPC API version.|
-|[balance](/dapp-dev-guide/sdkspec/types_chain#u512)|Object|The balance represented in motes.|
+|[balance](/types_chain#u512)|Object|The balance represented in motes.|
 
 <details>
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This reintroduces the `query_balance` endpoint into the `feat-1.5.0` branch, alongside some additional fixes necessary for the 1.5 update.

Closes #1148

### Additional context
[Reintroduce query_balance end point to 1.5 branch and check CHANGELOG for more changes. #1148](https://github.com/casper-network/docs/issues/1148)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
Editing: @ipopescu / Tech: @darthsiroftardis 
