### PR TITLE
1147 - Operators:  use the "activate_bid" entrypoint

### DIFF
--- a/source/docs/casper/operators/becoming-a-validator/bonding.md
+++ b/source/docs/casper/operators/becoming-a-validator/bonding.md
@@ -67,35 +67,7 @@ Next, [check the status of the auction](#check-the-status-of-the-bid-in-the-auct
 
 ## Method 2: Bonding with Compiled Wasm {#bonding-compiled-wasm}
 
-Another way to send a bonding transaction is to compile the `add_bid.wasm` and send it to the network via a deploy. Here are the steps to compile the contract yourself:
-
-1. Clone the [`casper-node` repository](https://github.com/casper-network/casper-node)
-2. Install these prerequisites, which are also listed [here](https://github.com/casper-network/casper-node#pre-requisites-for-building).
-
-- [Rust](../../developers/writing-onchain-code/getting-started.md#installing-rust)
-- [CMake](https://cgold.readthedocs.io/en/latest/first-step/installation.html)
-- `pkg-config` - On Ubuntu, use `sudo apt-get install pkg-config`
-- `openssl` - On Ubuntu, use `sudo apt-get install openssl`
-- `libssl-dev` - On Ubuntu, use `sudo apt-get install libssl-dev`
-
-3. Install the [Rust casper-client](../../developers/prerequisites.md#the-casper-command-line-client) and fund the [keys](../setup/basic-node-configuration.md#create-fund-keys) you will use for bonding 
-4. [Build the contracts](#build-contracts)
-5. [Send the bonding request](#example-bonding-transaction)
-6. [Check the status of the auction](#check-the-status-of-the-bid-in-the-auction) to see if you have won a validator slot
-
-### Building the contracts {#build-contracts}
-
-Using this method, you must build the contract that submits the bid. Build the following client contracts in release mode:
-
-```bash
-cd casper-node
-make setup-rs
-make build-client-contracts
-```
-
-These commands build all the necessary contracts, including `add_bid.wasm` for placing a bid. 
-
-### Submitting the bonding request {#example-bonding-request}
+Another way to send a bonding transaction is to use the compiled `add_bid.wasm` and send it to the network via a deploy. For details, refer to [Building the Required Contracts](../setup/joining.md#step-3-build-contracts).
 
 The following deploy is a template for sending a bonding request:
 
@@ -146,6 +118,8 @@ sudo -u casper casper-client put-deploy \
 --session-arg "amount:U512='$[10000 * 1000000000]'" \
 --session-arg="delegation_rate:u8='10'"
 ```
+
+Next, check the bid status to see if you have won a validator slot.
 
 ## Checking the Bid Status {#check-the-status-of-the-bid-in-the-auction}
 

--- a/source/docs/casper/operators/becoming-a-validator/bonding.md
+++ b/source/docs/casper/operators/becoming-a-validator/bonding.md
@@ -67,7 +67,7 @@ Next, [check the status of the auction](#check-the-status-of-the-bid-in-the-auct
 
 ## Method 2: Bonding with Compiled Wasm {#bonding-compiled-wasm}
 
-Another way to send a bonding transaction is to use the compiled `add_bid.wasm` and send it to the network via a deploy. For details, refer to [Building the Required Contracts](../setup/joining.md#step-3-build-contracts).
+Another way to send a bonding transaction to the network is via a deploy containing the compiled `add_bid.wasm`. For details, refer to [Building the Required Contracts](../setup/joining.md#step-3-build-contracts).
 
 The following deploy is a template for sending a bonding request:
 

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -58,20 +58,6 @@ curl -s localhost:8888/status | jq .last_added_block_info
 
 If you cannot figure out the issue, ask for help in the node-tech-support channel on [Discord](https://discord.com/invite/Q38s3Vh).
 
-## Re-building the Contracts for Bonding
-
-Next, you need to re-build the smart contracts required for [bonding](./bonding.md) by following these steps:
-
-1. Navigate to the `casper-node` directory 
-2. Check out the current default release branch
-3. Re-build the contracts required for bonding
-
-```bash
-cd casper-node
-git checkout <replace with current default branch>
-make setup-rs
-make build-client-contracts 
-```
 
 ## Activating the Bid
 

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -65,7 +65,7 @@ Once your node is in sync and ready to validate again, you must activate your in
 
 Run the following transaction to re-activate your bid and rejoin the network. You will require a balance of at least 5 CSPR for this contract. 
 
-<!-- TODO We are seeing some variability with this gas cost as of 1.4.9 and will dive into this and try to get better docs on this. -->
+<!-- TODO We are seeing some variability with this gas cost as of 1.4.9 and will dive into this and try to get better docs on this. Update by ipopescu 6/24/23: it is best to use the activate_bid entrypoint in the system auction, which is much cheaper and has fixed cost. So this TODO does not need to be completed and will be removed. -->
 
 ```bash
 casper-client put-deploy \

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -65,10 +65,8 @@ Once your node is in sync and ready to validate again, you must activate your in
 
 Run the following transaction to re-activate your bid and rejoin the network. You will require a balance of at least 5 CSPR for this contract. 
 
-<!-- TODO We are seeing some variability with this gas cost as of 1.4.9 and will dive into this and try to get better docs on this. Update by ipopescu 6/24/23: it is best to use the activate_bid entrypoint in the system auction, which is much cheaper and has fixed cost. So this TODO does not need to be completed and will be removed. -->
 
-```bash
-casper-client put-deploy \
+sudo -u casper casper-client put-deploy \
 --secret-key /etc/casper/validator_keys/secret_key.pem \
 --chain-name casper \
 --session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm" \
@@ -76,7 +74,7 @@ casper-client put-deploy \
 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"
 ```
 
-Check that the deploy was successful with the `casper-client get-deploy <deploy_hash>` or by searching for the deploy hash on [https://cspr.live/](https://cspr.live/).
+Check that the deploy was successful with the `casper-client get-deploy <deploy_hash>` or by searching for the deploy hash on [https://cspr.live/](https://cspr.live/). Next, check the bid activation status.
 
 ## Checking the Bid Activation
 

--- a/source/docs/casper/operators/becoming-a-validator/recovering.md
+++ b/source/docs/casper/operators/becoming-a-validator/recovering.md
@@ -56,27 +56,120 @@ To check if your node is in sync, compare the current block height at [https://c
 curl -s localhost:8888/status | jq .last_added_block_info
 ```
 
-If you cannot figure out the issue, ask for help in the node-tech-support channel on [Discord](https://discord.com/invite/Q38s3Vh).
+If you cannot figure out the issue, ask for help in the *node-tech-support* channel on [Discord](https://discord.com/invite/Q38s3Vh).
 
 
 ## Activating the Bid
 
-Once your node is in sync and ready to validate again, you must activate your invalid bid with the `activate_bid.wasm` contract. This should be part of the compiled contracts required to join the network in [Step 3: Build the Required Contracts](../setup/joining.md#step-3-build-the-required-contracts-step-3-build-contracts).
+Once your node is in sync and ready to validate again, you must activate your invalid bid. There are two ways to reactivate your bid. The recommended and cheaper method is to call the `activate_bid` entry point from the system auction contract. The second method involves building the `activate_bid.wasm` contract as explained in [Building the Required Contracts](../setup/joining.md#step-3-build-contracts).
 
-Run the following transaction to re-activate your bid and rejoin the network. You will require a balance of at least 5 CSPR for this contract. 
+We recommend testing the following steps on the official Testnet before performing them in a live environment like the Casper Mainnet.
 
+### Method 1: Activating the Bid with the System Auction Contract {#activating-system-auction}
 
+This method calls the existing `activate_bid` entry point from the system auction contract. Using this method, you do not need to build any contracts, reducing costs and complexity.
+
+```bash
 sudo -u casper casper-client put-deploy \
---secret-key /etc/casper/validator_keys/secret_key.pem \
---chain-name casper \
---session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm" \
---payment-amount 5000000000 \
+--node-address <HOST:PORT> \
+--secret-key <PATH> \
+--chain-name <CHAIN_NAME> \
+--payment-amount <PAYMENT_AMOUNT_IN_MOTES> \
+--session-hash <SESSION_HASH> \
+--session-entry-point activate_bid \
 --session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"
 ```
 
-Check that the deploy was successful with the `casper-client get-deploy <deploy_hash>` or by searching for the deploy hash on [https://cspr.live/](https://cspr.live/). Next, check the bid activation status.
+1. `node-address` - An IP address of a peer on the network. The default port of nodes' JSON-RPC servers on Mainnet and Testnet is 7777
+2. `secret-key` - The file name containing the secret key of the account paying for the Deploy
+3. `chain-name` - The chain-name to the network where you wish to send the Deploy. For Mainnet, use *casper*. For Testnet, use *casper-test*
+4. `payment-amount` - The payment for the Deploy in motes. You must check the network's chainspec. For example, this entry point call needs 10,000 motes for node version [1.5.1](https://github.com/casper-network/casper-node/blob/release-1.5.1/resources/production/chainspec.toml)
+5. `session-hash` - Hex-encoded hash of the stored auction contract, which depends on the network you are using. For Casper's Mainnet and Testnet, the hashes are:
 
-## Checking the Bid Activation
+- **Testnet**: `hash-93d923e336b20a4c4ca14d592b60e5bd3fe330775618290104f9beb326db7ae2`
+- **Mainnet**: `hash-ccb576d6ce6dec84a551e48f0d0b7af89ddba44c7390b690036257a04a3ae9ea`
+
+6. `session-entry-point` - Name of the entry point that will be used when calling the system auction contract. In this case, it is `activate_bid`
+
+The `activate_bid` entry point expects one argument:
+
+7. `validator_public_key`: The hexadecimal public key of the validator reactivating its bid. **This key must match the secret key that signs the bid activation request**
+
+The command will return a deploy hash, which is needed to verify the deploy's processing results. Refer to the [Deploy Status](../../resources/tutorials/beginner/querying-network.md#deploy-status) section for more details.
+
+:::tip
+
+Calling the `activate_bid` entry point on the auction contract has a fixed cost of 10,000 motes.
+
+:::
+
+**Example:**
+
+This example uses the Casper Testnet to reactivate a bid:
+
+```bash
+sudo -u casper casper-client put-deploy \
+--node-address http://65.21.75.254:7777  \
+--secret-key /etc/casper/validator_keys/secret_key.pem \
+--chain-name casper-test \
+--payment-amount 10000 \
+--session-hash hash-93d923e336b20a4c4ca14d592b60e5bd3fe330775618290104f9beb326db7ae2 \
+--session-entry-point activate_bid \
+--session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"
+```
+
+Next, [check the bid activation](#checking-the-bid-activation) status.
+
+### Method 2: Activating the Bid with Compiled Wasm {#activating-compiled-wasm}
+
+The second method to rejoin the network is to reactivate your bid using the `activate_bid.wasm`.
+
+
+```bash
+sudo -u casper casper-client put-deploy \
+--node-address <HOST:PORT> \
+--secret-key <PATH> \
+--chain-name <CHAIN_NAME> \
+--payment-amount <PAYMENT_AMOUNT_IN_MOTES> \
+--session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm" \
+--session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"
+```
+
+1. `node-address` - An IP address of a peer on the network. The default port of nodes' JSON-RPC servers on Mainnet and Testnet is 7777
+2. `secret-key` - The file name containing the secret key of the account paying for the Deploy
+3. `chain-name` - The chain-name to the network where you wish to send the Deploy. For Mainnet, use *casper*. For Testnet, use *casper-test*
+4. `payment-amount` - The payment for the Deploy in motes
+5. `session-path` - The path to the compiled Wasm on your computer
+
+The `activate_bid.wasm` expects one argument:
+
+6. `validator_public_key`: The hexadecimal public key of the validator reactivating its bid. **This key must match the secret key that signs the bid activation request**
+
+The command will return a deploy hash, which is needed to verify the deploy's processing results.
+
+:::note
+
+As described above, this method is much more expensive than calling the `activate_bid` entry point.
+
+:::
+
+**Example:**
+
+Here is an example that reactivates a bid using the `activate_bid.wasm`. You must modify the payment and other values in the deploy based on your environment and the network's [chainspec.toml](../../concepts/glossary/C.md#chainspec). For example, if you use the `activate_bid.wasm` on a network with node version [1.4.9](https://github.com/casper-network/casper-node/blob/release-1.4.9/resources/production/chainspec.toml), you will require a balance of at least 5 CSPR for this contract. 
+
+```bash
+sudo -u casper casper-client put-deploy \
+--node-address http://65.21.75.254:7777  \
+--secret-key /etc/casper/validator_keys/secret_key.pem \
+--chain-name casper-test \
+--payment-amount 5000000000 \
+--session-path "$HOME/casper-node/target/wasm32-unknown-unknown/release/activate_bid.wasm" \
+--session-arg "validator_public_key:public_key='$(cat /etc/casper/validator_keys/public_key_hex)'"
+```
+
+Check that the deploy was successful with the `casper-client get-deploy <deploy_hash>` or by searching for the deploy hash on [https://cspr.live/](https://cspr.live/). Also, check the bid activation status as shown below.
+
+## Checking the Bid Activation {#checking-the-bid-activation}
 
 Once your deploy processes, you can [check your bid](recovering.md#detecting-the-eviction-using-the-casper-client) again. You should now see `"inactive": false` in the output.
 

--- a/source/docs/casper/operators/setup/joining.md
+++ b/source/docs/casper/operators/setup/joining.md
@@ -2,15 +2,15 @@
 
 Each Casper network is permissionless, enabling new validators to join the network and provide additional security to the system. This page outlines the sequence of recommended steps to spin up a validating node and join an existing network.
 
-## Step 1: Provision Hardware {#step-1-provision-hardware}
+## Step 1: Provisioning Hardware {#step-1-provision-hardware}
 
 Visit the [Hardware Specifications](./hardware.md) section and provision your node hardware.
 
-## Step 2: Set Up the Node {#step-2-set-up-the-node}
+## Step 2: Setting Up the Node {#step-2-set-up-the-node}
 
 Follow the instructions on the [Node Setup](./install-node.md) page. 
 
-## Step 3: Build the Required Contracts {#step-3-build-contracts}
+## Step 3: Building the Required Contracts {#step-3-build-contracts}
 
 Use the commands below to build all the necessary contracts for bonding, retrieving rewards, and unbonding.
 
@@ -20,7 +20,17 @@ Use the commands below to build all the necessary contracts for bonding, retriev
 git clone https://github.com/casper-network/casper-node
 ```
 
-2. Use the following commands to build the contracts in release mode. Make sure you have [installed Rust](../../developers/writing-onchain-code/getting-started.md#installing-rust).
+2. Install these prerequisites, which are also listed [here](https://github.com/casper-network/casper-node#pre-requisites-for-building).
+
+- [Rust](../../developers/writing-onchain-code/getting-started.md#installing-rust)
+- [CMake](https://cgold.readthedocs.io/en/latest/first-step/installation.html)
+- `pkg-config` - On Ubuntu, use `sudo apt-get install pkg-config`
+- `openssl` - On Ubuntu, use `sudo apt-get install openssl`
+- `libssl-dev` - On Ubuntu, use `sudo apt-get install libssl-dev`
+
+3. Install the [Rust casper-client](../../developers/prerequisites.md#the-casper-command-line-client) and fund the [keys](../setup/basic-node-configuration.md#create-fund-keys) you will use for bonding.
+
+4. Use the following commands to build the contracts in release mode. Make sure you have [installed Rust](../../developers/writing-onchain-code/getting-started.md#installing-rust).
 
 ```bash
 cd casper-node
@@ -35,17 +45,17 @@ These commands will build all the necessary Wasm contracts for operating as a va
 - `undelegate.wasm` - Undelegates stake
 - `withdraw_bid.wasm` - Enables unbonding for validator stake
 
-## Step 4: Create and Fund Keys for Bonding {#step-4-create--fund-keys-for-bonding}
+## Step 4: Creating and Fund Keys for Bonding {#step-4-create--fund-keys-for-bonding}
 
 See the [Node Setup](./basic-node-configuration.md#create-fund-keys) instructions if you have not generated and funded your validator keys.
 
-## Step 5: Update the Trusted Hash {#step-5-update-the-trusted-hash}
+## Step 5: Updating the Trusted Hash {#step-5-update-the-trusted-hash}
 
 The node's `config.toml` needs to be updated with a recent trusted hash. 
 
 See the [Trusted Hash for Synchronizing](./basic-node-configuration.md#trusted-hash-for-synchronizing) instructions if you have not set up a trusted hash during node installation.
 
-## Step 6: Start the Node {#step-6-start-the-node}
+## Step 6: Starting the Node {#step-6-start-the-node}
 
 Start the node with the `casper-node-launcher`:
 
@@ -57,7 +67,7 @@ The above Debian package installs a casper-node service for systemd.
 
 For more information, visit [GitHub](https://github.com/casper-network/casper-node/wiki#node-operators).
 
-## Step 7: Confirm the Node is Synchronized {#step-7-confirm-the-node-is-synchronized}
+## Step 7: Confirming the Node is Synchronized {#step-7-confirm-the-node-is-synchronized}
 
 While the node is synchronizing, the `/status` endpoint is available. You will be able to compare this to another node's status endpoint `era_id` and `height` to determine if you are caught up. You will not be able to perform any `casper-client` calls to your `7777` RPC port until your node is fully caught up.
 
@@ -101,7 +111,7 @@ Towards the end of the following output, notice the `era_id` and `height` that y
 ```
 </details>
 
-## Step 8: Send the Bonding Request {#step-7-send-the-bonding-request}
+## Step 8: Sending the Bonding Request {#step-7-send-the-bonding-request}
 
 You can submit a [bonding request](../becoming-a-validator/bonding.md) to change your synchronized node to a validating node.
 


### PR DESCRIPTION
### What does this PR fix/introduce?

Adds information on the activate_bid entrypoint when validators are recovering from eviction. The current [documentation](https://docs.casper.network/operators/becoming-a-validator/recovering/#activating-the-bid) only mentions the "activate_bid.wasm", which is more expensive.

Closes #1147 

### Testing

I haven’t been able to test the "activate_bid" entry point yet. It takes time to simulate the eviction.
However, I am pretty confident that the instructions are correct. I will attempt to run them before the sprint ends (in parallel with the review). It would be great to get a tech reviewer to confirm their correctness, in case I cannot simulate the eviction.
I relied on the instructions that were already documented, and followed the same pattern as in the `bonding.md` file. I’ve also checked the code to make sure the parameters and costs are correct.

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [ ] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL: editing
@sacherjj: tech review
