### PR TITLE
1180 Guide for use of Speculative Execution

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -142,7 +142,7 @@ module.exports = {
                 //"developers/dapps/template-frontend", // NEW CONTENT WILL BE HERE
                 "developers/dapps/signing-a-deploy",
                 "developers/dapps/sending-deploys",
-                "developers/dapps/speculative-exec.md",
+                "developers/dapps/speculative-exec",
                 //"developers/dapps/using-casper-signer", // NEW CONTENT WILL BE HERE
                 //"developers/dapps/callstack-based", // NEW CONTENT WILL BE HERE
                 //"developers/dapps/explanation-session-and-contract", // NEW CONTENT WILL BE HERE

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -142,6 +142,7 @@ module.exports = {
                 //"developers/dapps/template-frontend", // NEW CONTENT WILL BE HERE
                 "developers/dapps/signing-a-deploy",
                 "developers/dapps/sending-deploys",
+                "developers/dapps/speculative-exec.md",
                 //"developers/dapps/using-casper-signer", // NEW CONTENT WILL BE HERE
                 //"developers/dapps/callstack-based", // NEW CONTENT WILL BE HERE
                 //"developers/dapps/explanation-session-and-contract", // NEW CONTENT WILL BE HERE

--- a/source/docs/casper/developers/dapps/speculative-exec.md
+++ b/source/docs/casper/developers/dapps/speculative-exec.md
@@ -1,0 +1,51 @@
+# Estimating Gas Costs with Speculative Execution
+
+Version 1.5 of the Casper Node includes a new JSON RPC endpoint called [`speculative_exec`](../json-rpc/json-rpc-transactional.md#speculative_exec-speculative_exec). This endpoint allows developers to send a [Deploy](../../concepts/glossary/D.md#deploy-deploy) to a single node, which will execute the Deploy without committing the results to global state and therefore not incurring the associated costs. Observing the execution results of the Deploy gives a rough estimate of the potential cost for a sending the Deploy without speculative execution.
+
+In addition to the Deploy in question, `speculative_exec` also accepts a [`block_identifier`] for a specific block height or hash to speculate on.
+
+## Sending a Speculative Execution Deploy using the Rust CLI Casper Client
+
+The [Rust CLI Casper client](../dapps/sending-deploys.md) includes a `speculative-exec` option that will flag a normal `put-deploy` for execution but not commitment to global state. The following command shows an example:
+
+```bash
+
+casper client put-deploy /
+--node-address <HOST:PORT> /
+--chain-name <CHAIN_NAME> /
+--secret-key <PATH> /
+--session-path <PATH>  /
+--payment-amount <PAYMENT_AMOUNT_IN_MOTES>
+--speculative-exec <BLOCK HEIGHT OR HASH>
+
+```
+
+You should recieve `execution_result`s that show a `cost`.
+
+```bash
+
+{
+  "jsonrpc": "2.0",
+  "id": -4571113357017152230,
+  "result": {
+    "api_version": "1.0.0",
+    "block_hash": "6ca035b08de092e7f5e8fff771b880c5b4d7463a8f7a9b108888aaad958e5b0f",
+    "execution_result": {
+      "Success": {
+        "effect": {
+          <Deploy effects removed for conciseness.>
+        },
+        "transfers": [],
+        "cost": "87300473670"
+      }
+    }
+  }
+}
+
+```
+
+:::note
+
+Cost estimates acquired through `speculative_exec` may vary from the cost of sending the same Deploy to a Casper network. Speculative execution is a tool to help narrow down the potential cost of sending a Deploy, but many factors can cause the actual cost to vary.
+
+:::

--- a/source/docs/casper/developers/dapps/speculative-exec.md
+++ b/source/docs/casper/developers/dapps/speculative-exec.md
@@ -1,6 +1,6 @@
 # Estimating Gas Costs with Speculative Execution
 
-Version 1.5 of the Casper Node includes a new JSON RPC endpoint called [`speculative_exec`](../json-rpc/json-rpc-transactional.md#speculative_exec-speculative_exec). This endpoint allows developers to send a [Deploy](../../concepts/glossary/D.md#deploy-deploy) to a single node, which will execute the Deploy without committing the results to global state and therefore not incurring the associated costs. Observing the execution results of the Deploy gives a rough estimate of the potential cost for a sending the Deploy without speculative execution.
+Version 1.5 of the Casper Node includes a new JSON RPC endpoint called [`speculative_exec`](../json-rpc/json-rpc-transactional.md#speculative_exec-speculative_exec). This endpoint allows developers to send a [Deploy](../../concepts/glossary/D.md#deploy-deploy) to a single node, which will execute the Deploy without committing the results to global state and, therefore, not incurring the associated costs. Observing the execution results of the Deploy gives a rough estimate of the potential cost for sending the Deploy without speculative execution.
 
 In addition to the Deploy in question, `speculative_exec` also accepts a [`block_identifier`] for a specific block height or hash to speculate on.
 
@@ -20,7 +20,7 @@ casper client put-deploy /
 
 ```
 
-You should recieve `execution_result`s that show a `cost`.
+You should receive `execution_result`s that show a `cost`.
 
 ```bash
 

--- a/source/docs/casper/developers/dapps/speculative-exec.md
+++ b/source/docs/casper/developers/dapps/speculative-exec.md
@@ -2,7 +2,7 @@
 
 Version 1.5 of the Casper Node includes a new JSON RPC endpoint called [`speculative_exec`](../json-rpc/json-rpc-transactional.md#speculative_exec-speculative_exec). This endpoint allows developers to send a [Deploy](../../concepts/glossary/D.md#deploy-deploy) to a single node, which will execute the Deploy without committing the results to global state and, therefore, not incurring the associated costs. Observing the execution results of the Deploy gives a rough estimate of the potential cost for sending the Deploy without speculative execution.
 
-In addition to the Deploy in question, `speculative_exec` also accepts a [`block_identifier`] for a specific block height or hash to speculate on.
+In addition to the Deploy in question, `speculative_exec` also accepts a [`block_identifier`] for a specific block height or hash to speculate on. If you do not provide a block identifier, the Deploy will be executed on the most recent block.
 
 ## Sending a Speculative Execution Deploy using the Rust CLI Casper Client
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR introduces a guide for use of the `speculative_exec` endpoint in the Casper client.

Closes #1180 

### Additional context
[Create a Guide to using the speculative_exec endpoint #1180](https://github.com/casper-network/docs/issues/1180)

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
Editing: @ipopescu / Tech @bpr or assignee.
