### PR TITLE
Editing pass for PR 1178

### DIFF
--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -1,29 +1,22 @@
 ---
-title: Migrate from other chains
+title: Moving to Casper from another Blockchain
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Moving from other chains to Casper{#migrate-to-casper}
+# Moving to Casper {#moving-to-casper}
 
-There are several blockchain projects available in different technologies. It's important to choose the right blockchain for a particular task. 
-The most popular blockchain projects in the market include:
+This page covers various considerations for moving to Casper from another blockchain by comparing Casper to Ethereum, Near, Aptos, and Solana in these aspects:
 
-- `Ethereum` 
-- `Near` 
-- `Aptos` 
-- `Solana`
+- [Contract Lifecycle](#contract-lifecycle)
+- [Variable Storage](#variable-storage)
+- [Public Methods](#public-methods)
+- [Passing Arguments](#passing-arguments)
+- [State Management](#state-management)
 
-We will compare them to Casper based on the following parameters:
-
-- Contract Lifecycle
-- Variable Storage
-- Public Methods
-- Passing Arguments
-- State Management
-
+Since other blockchain projects use different technologies, it is essential to consider how those technologies serve your use case.
 
 ## Contract Lifecycle{#contract-lifecycle}
 

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -118,27 +118,25 @@ In terms of storage, the actual data is stored in the Account. It is organized a
 <Tabs>
 <TabItem value="Casper" label="Casper">
 
-Entry points are declared within the 'call' routine. To declare a public entry point, the following format is used:
+For Casper smart contracts, public methods are called entry points. To declare them, the following format is used:
 
 ```rust
 #[no_mangle]
 pub extern "C" fn counter_inc() {
-    let uref: URef = runtime::get_key(COUNT_KEY)
-        .unwrap_or_revert_with(ApiError::MissingKey)
-        .into_uref()
-        .unwrap_or_revert_with(ApiError::UnexpectedKeyVariant);
     
-    storage::add(uref, 1); // Increment the count by 1.
+    // Entry point body
 }
 ```
 
-It's important to note that entry points do not inherently have input arguments in their definition. If a return value is needed, it should be declared using the following syntax:
+It's important to note that entry points do not have input arguments in their definition, but the arguments can be accessed using the [RuntimeArgs](https://docs.rs/casper-types/latest/casper_types/struct.RuntimeArgs.html) passed to the contract. Entry points are instantiated within the `call` entry point.
+
+If a return value is needed, it should be declared using the following syntax described in the [Interacting with Runtime Return Values](../resources/tutorials/advanced/return-values-tutorial.md) tutorial.
 
 ```rust
 runtime::ret(value);
 ```
 
-In the Casper networks, each call to an entry point is treated as a [Deploy](../concepts/deploy-and-deploy-lifecycle.md) to the network, and therefore, each call incurs a certain amount of mots (the network's native currency).
+Each call to an entry point is treated as a [Deploy](../concepts/deploy-and-deploy-lifecycle.md) to the network, and therefore, each call incurs a cost paid in motes (the network's native accounting unit).
 
 </TabItem>
 <TabItem value="Ethereum" label="Ethereum">

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -47,9 +47,13 @@ Solidity smart contracts adhere to object-oriented programming principles and su
 </TabItem>
 <TabItem value="Near" label="Near">
 
-Near smart contracts can be written in either JavaScript or Rust. Regardless of the chosen language, the Near SDK compiles the code to WebAssembly. In the Near ecosystem, smart contracts function as classes. The constructor, referred to as the "init" method, can receive attributes required for initializing the contract's initial state.
+Near smart contracts can be written in JavaScript or Rust, and the Near SDK compiles the code to WebAssembly. 
 
-All public methods defined within the contract serve as the contract's interface, exposing its functionalities. In the Near blockchain, there are various capabilities for versioning. Examples of how updates are handled include state migrations, state versioning, and contract self-updates.
+In the Near ecosystem, smart contracts function as classes. The constructor, referred to as the "init" method, can receive attributes required for initializing the contract's initial state.
+
+All public methods defined within the contract serve as its interface, exposing its functionality. 
+
+The Near blockchain provides various capabilities for versioning, including state migrations, state versioning, and contract self-updates.
 
 </TabItem>
 <TabItem value="Aptos" label="Aptos">

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -81,8 +81,9 @@ It is worth noting that Solana programs can be updated using an authority known 
 <Tabs>
 <TabItem value="Casper" label="Casper">
 
+Variables can be stored as Named Keys or Dictionaries as described in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
 
-The variables can be stored either as Named Keys or [Dictionaries](../concepts/dictionaries.md). Additionally, local variables are available within the entry points and can be utilized to perform necessary actions or computations within the scope of each entry point.
+Additionally, local variables are available within the entry points and can be utilized to perform necessary actions or computations within the scope of each entry point.
 
 </TabItem>
 <TabItem value="Ethereum" label="Ethereum">
@@ -92,17 +93,19 @@ The variables within the contract are responsible for storing the state of the c
 </TabItem>
 <TabItem value="Near" label="Near">
 
-The variables in the contract can be stored as native types, SDK collections, or internal structures. It is recommended to use SDK collections whenever feasible, as they offer advantages over native types. Additionally, there is a distinction between class attributes and local variables. Class attributes represent the state of the contract, while local variables are specific to the invocation of a function and have no impact on the contract's overall state.
+The variables in the contract can be stored as native types, SDK collections, or internal structures. SDK collections offer advantages over native types. 
+
+Additionally, there is a distinction between class attributes and local variables. Class attributes represent the state of the contract, while local variables are specific to the invocation of a function and have no impact on the contract's overall state.
 
 </TabItem>
 <TabItem value="Aptos" label="Aptos">
 
-Aptos employs primitive types, such as integers, booleans, and addresses, to represent variables. These elementary types can be combined to create structures, but it's important to note that struct definitions are only permitted within Modules. For storing important or relevant data, Aptos encourages the use of Resources. Resources serve as a specialized type for managing and storing significant data in an efficient manner.
+Aptos employs primitive types, such as integers, booleans, and addresses, to represent variables. These elementary types can be combined to create structures, but it's important to note that struct definitions are only permitted within Modules. For storing important or relevant data, Aptos encourages using Resources, which are specialized types for managing and storing important data efficiently.
 
 </TabItem>
 <TabItem value="Solana" label="Solana">
 
-Variables can be utilized locally within the context of a specific entry point being executed. They are limited to the scope of that entry point and not accessible outside of it. These variables can be defined as elementary types such as bool, String, int, and so on.
+Variables can be utilized locally within the execution context of a specific entry point. They are limited to the scope of that entry point and not accessible outside of it. These variables can be defined as elementary types such as bool, String, int, etc.
 
 In terms of storage, the actual data is stored in the Account. It is organized as a struct comprising related variables, allowing for efficient management and retrieval of the stored information.
 

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -164,11 +164,9 @@ It is worth noting that public view methods on Ethereum, which solely retrieve d
 
 In the Near blockchain, there are three types of public functions:
 
-`Init Methods`: These are used as the class constructors to initialize the state of the contract.
-
-`View Methods`: These functions are used to read the state of the contract variables.
-
-`Call Methods`: These methods can mutate the state of the contract and perform specific actions, such as calling another contract.
+- **Init Methods** - These are used as the class constructors to initialize the state of the contract.
+- **View Methods** - These functions are used to read the state of the contract variables.
+- **Call Methods** - These methods can mutate the state of the contract and perform specific actions, such as calling another contract.
 
 The definition of public methods in Near is as follows:
 
@@ -182,7 +180,7 @@ For public methods that return variables, the definition would be:
 pub fn get_messages(&self, from_index: Option<U128>, limit: Option<u64>) -> Vec<PostedMessage> { }
 ```
 
-The actual implementation of the functions may include the necessary parameters and logic based on the specific requirements of the contract.
+The actual implementation of the functions may include the necessary parameters and logic based on the contract's specific requirements.
 
 </TabItem>
 <TabItem value="Aptos" label="Aptos">
@@ -199,7 +197,7 @@ For public functions that return variables, the definition would be as follows:
 public fun max(a: u8, b: u8): (u8, bool) {}
 ```
 
-In the Aptos Blockchain, it is possible to return one or more values from a function.
+In the Aptos blockchain, it is possible to return one or more values from a function.
 
 </TabItem>
 <TabItem value="Solana" label="Solana">

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -25,9 +25,13 @@ When choosing a blockchain, it is also essential to compare consensus mechanisms
 <Tabs>
 <TabItem value="Casper" label="Casper">
 
-Casper smart contracts are written in Rust. In Casper, variables defined within the smart contract can be stored as either Named Keys or [Dictionaries](../concepts/dictionaries.md). The `call` function serves as the constructor of the smart contract on the Casper network. It automatically executes when the smart contract is deployed, setting the initial state of the contract and defining all entry points.
+Casper smart contracts are written in Rust. 
 
-It's worth noting that Casper only supports public entry points for [contracts](../developers/writing-onchain-code/simple-contract.md). Additionally, contracts can be defined as either immutable or upgradable.
+Variables defined within the smart contract can be stored as either [Named Keys](../developers/json-rpc/types_chain.md#namedkey) or [Dictionaries](../concepts/dictionaries.md) as described in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
+
+The `call` function serves as the main entry point of the [smart contract](../developers/writing-onchain-code/simple-contract.md). It automatically executes when the smart contract is installed, setting the initial state of the contract and defining all other entry points.
+
+It's worth noting that Casper only supports public entry points for contracts. Additionally, contracts can be defined as upgradable or immutable as described [here](../developers/writing-onchain-code/upgrading-contracts.md).
 
 </TabItem>
 <TabItem value="Ethereum" label="Ethereum">

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -93,7 +93,7 @@ The variables within the contract are responsible for storing the state of the c
 </TabItem>
 <TabItem value="Near" label="Near">
 
-The variables in the contract can be stored as native types, SDK collections, or internal structures. SDK collections offer advantages over native types. 
+Variables in the contract can be stored as native types, SDK collections, or internal structures. SDK collections offer advantages over native types. 
 
 Additionally, there is a distinction between class attributes and local variables. Class attributes represent the state of the contract, while local variables are specific to the invocation of a function and have no impact on the contract's overall state.
 

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -1,12 +1,12 @@
 ---
-title: Moving to Casper from another Blockchain
+title: Moving to Casper
 ---
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Moving to Casper {#moving-to-casper}
+# Moving to Casper from another Blockchain {#moving-to-casper}
 
 This page covers various considerations for moving to Casper from another blockchain by comparing Casper to Ethereum, Near, Aptos, and Solana in these aspects:
 

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -250,37 +250,29 @@ In the contract, you can access the session arguments as follows:
 let uref: URef = runtime::get_key(Key_Name)
 ```
 
-The `get_key` function can be used to retrieve the desired session argument by specifying its name or key.
+Use the `get_key` function to retrieve the desired session argument by specifying the key's name. 
 
 </TabItem>
 <TabItem value="Ethereum" label="Ethereum">
 
-Strongly typed function arguments, where both the input and return variables need to be explicitly defined. The compiler checks the correctness of the arguments passed to the functions during runtime.
-
-This means that the types of the function arguments, as well as the return types, must be explicitly specified in the function signature. The compiler ensures that the provided arguments adhere to the specified types, helping to catch type-related errors and ensure type safety.
+Ethereum uses strongly typed function arguments, and developers must explicitly define the input and return variables. The compiler checks the correctness of the arguments passed to the functions during runtime. As a result, developers must explicitly specify the argument and return types in the function signature. The compiler ensures that the provided arguments adhere to the specified types, helping to catch type-related errors and ensure type safety.
 
 By enforcing strong typing, the compiler helps prevent potential runtime errors and enhances code reliability by verifying the compatibility of the passed arguments and expected return types.
 
 </TabItem>
 <TabItem value="Near" label="Near">
 
-Strongly typed function arguments require explicit definition of both the input and return variables.
-
-By enforcing strong typing, the programming language ensures that the arguments passed to a function match the expected types, preventing type-related errors and promoting code correctness. Strong typing provides additional clarity and safety by explicitly stating the data types of the function's inputs and outputs.
+Strongly typed function arguments require explicitly defining the input and return variables. By enforcing strong typing, the programming language ensures that the arguments passed to a function match the expected types, preventing type-related errors and promoting code correctness. Strong typing provides additional clarity and safety by explicitly stating the data types of the function's inputs and outputs.
 
 </TabItem>
 <TabItem value="Aptos" label="Aptos">
 
-Strongly typed function arguments require explicit definition of both the input and return variables.
-
-By enforcing strong typing, the programming language ensures that the arguments passed to a function match the expected types, preventing type-related errors and promoting code correctness. Strong typing provides additional clarity and safety by explicitly stating the data types of the function's inputs and outputs.
+Like Near, Aptos requires strongly typed function arguments, thus, preventing type-related errors and promoting code correctness.
 
 </TabItem>
 <TabItem value="Solana" label="Solana">
 
-Strongly typed function arguments require explicit definition of both the input and return variables.
-
-By enforcing strong typing, the programming language ensures that the arguments passed to a function match the expected types, preventing type-related errors and promoting code correctness. Strong typing provides additional clarity and safety by explicitly stating the data types of the function's inputs and outputs.
+Like Near and Aptos, Solana requires strongly typed function arguments, thus, preventing type-related errors and promoting code correctness.
 
 </TabItem>
 </Tabs>
@@ -313,63 +305,8 @@ Aptos advises developers to cluster related data into Resources for efficient da
 Data persists in structs within the account. The Binary Object Representation Serializer for Hashing (Borsh) facilitates the serialization and deserialization of these structs. The process involves reading the data from the account, deserializing it to obtain the values it contains, updating the values, and then serializing the modified data to save the new values back into the account.
 
 </TabItem>
-</Tabs>## State Management {#state-management}
-
-<Tabs>
-<TabItem value="Casper" label="Casper">
-
-Data persists in Named Keys and Dictionaries in a contract or an account's context. See more details in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
- 
-</TabItem>
-<TabItem value="Ethereum" label="Ethereum">
-
-Data persists in state variables within the smart contract. These state variables must be strongly typed so that the smart contract compiler can enforce type consistency and ensure the storage space aligns with the declared data types. Strong typing promotes code correctness and prevents potential data corruption or memory-related issues related to the contract's state variables.
-
-</TabItem>
-<TabItem value="Near" label="Near">
-
-SDK Collections are typical when creating state variables because they provide convenient data structures such as lists, maps, and sets. These data structures can organize and manage complex data within the contract's storage. Utilizing SDK Collections ensures efficient storage and facilitates easier access and data management in the smart contract.
-
-</TabItem>
-<TabItem value="Aptos" label="Aptos">
-
-Aptos advises developers to cluster related data into Resources for efficient data management and organization. Resources represent assets or specific data entities on the blockchain. By grouping data into Resources, you can maintain logical coherence and improve the readability and maintainability of the code.
-
-</TabItem>
-<TabItem value="Solana" label="Solana">
-
-Data persists in structs within the account. The Binary Object Representation Serializer for Hashing (Borsh) facilitates the serialization and deserialization of these structs. The process involves reading the data from the account, deserializing it to obtain the values it contains, updating the values, and then serializing the modified data to save the new values back into the account.
-
-</TabItem>
-</Tabs>## State Management {#state-management}
-
-<Tabs>
-<TabItem value="Casper" label="Casper">
-
-Data persists in Named Keys and Dictionaries in a contract or an account's context. See more details in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
- 
-</TabItem>
-<TabItem value="Ethereum" label="Ethereum">
-
-Data persists in state variables within the smart contract. These state variables must be strongly typed so that the smart contract compiler can enforce type consistency and ensure the storage space aligns with the declared data types. Strong typing promotes code correctness and prevents potential data corruption or memory-related issues related to the contract's state variables.
-
-</TabItem>
-<TabItem value="Near" label="Near">
-
-SDK Collections are typical when creating state variables because they provide convenient data structures such as lists, maps, and sets. These data structures can organize and manage complex data within the contract's storage. Utilizing SDK Collections ensures efficient storage and facilitates easier access and data management in the smart contract.
-
-</TabItem>
-<TabItem value="Aptos" label="Aptos">
-
-Aptos advises developers to cluster related data into Resources for efficient data management and organization. Resources represent assets or specific data entities on the blockchain. By grouping data into Resources, you can maintain logical coherence and improve the readability and maintainability of the code.
-
-</TabItem>
-<TabItem value="Solana" label="Solana">
-
-Data persists in structs within the account. The Binary Object Representation Serializer for Hashing (Borsh) facilitates the serialization and deserialization of these structs. The process involves reading the data from the account, deserializing it to obtain the values it contains, updating the values, and then serializing the modified data to save the new values back into the account.
-
-</TabItem>
 </Tabs>
+
 
 ## Additional Considerations {#additional-considerations}
 

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -18,7 +18,9 @@ This page covers various considerations for moving to Casper from another blockc
 
 Since other blockchain projects use different technologies, it is essential to consider how those technologies serve your use case.
 
-## Contract Lifecycle{#contract-lifecycle}
+When choosing a blockchain, it is also essential to compare consensus mechanisms, tokenomics, cross-contract capabilities, contract upgradability, and software development kits (SDKs) as described [here](#additional-considerations).
+
+## Contract Lifecycle {#contract-lifecycle}
 
 <Tabs>
 <TabItem value="Casper" label="Casper">
@@ -61,7 +63,7 @@ In Solana, smart contracts are commonly referred to as on-chain programs. These 
 </TabItem>
 </Tabs>
 
-## Variable Storage{#variable-storage}
+## Variable Storage {#variable-storage}
 
 <Tabs>
 <TabItem value="Casper" label="Casper">
@@ -95,7 +97,7 @@ In terms of storage, the actual data is stored in the Account. It is organized a
 </Tabs>
 
 
-## Public Methods{#public-methods}
+## Public Methods {#public-methods}
 
 <Tabs>
 <TabItem value="Casper" label="Casper">
@@ -226,7 +228,7 @@ Within the entry point function, the necessary parameters are specified, such as
 </TabItem>
 </Tabs>
 
-## Passing Arguments{#passing-arguments}
+## Passing Arguments {#passing-arguments}
 
 <Tabs>
 <TabItem value="Casper" label="Casper">
@@ -292,7 +294,7 @@ By enforcing strong typing, the programming language ensures that the arguments 
 </TabItem>
 </Tabs>
 
-## State Management{#state-management}
+## State Management {#state-management}
 
 <Tabs>
 <TabItem value="Casper" label="Casper">
@@ -324,21 +326,20 @@ Data is stored in structs within the account. These structs should be serialized
 </TabItem>
 </Tabs>
 
-## Summary{#summary}
+## Additional Considerations {#additional-considerations}
 
-While choosing a blockchain, there are additional aspects that need to be considered. These include consensus mechanisms, tokenomics, cross-contract capabilities, contract upgradability, and the availability of software development kits (SDKs).
+When choosing a blockchain, you may also look into the network's consensus mechanism, the tokenomics or economic model, cross-contract communication, smart contract upgrades, and the available software development kits (SDKs).
 
-`Consensus mechanism` refers to the algorithm used by the blockchain network to achieve agreement on the validity and ordering of transactions. Different blockchains employ various consensus mechanisms such as Proof of Work (PoW), Proof of Stake (PoS), or Delegated Proof of Stake (DPoS). The choice of consensus mechanism impacts factors like security, scalability, and energy efficiency.
+1. **Consensus mechanism** refers to the algorithm the blockchain network uses to achieve agreement on the validity and ordering of transactions. Different blockchains employ various consensus mechanisms such as Proof-of-Work (PoW), Proof-of-Stake (PoS), or Delegated Proof-of-Stake (DPoS). The choice of consensus mechanism impacts factors like security, scalability, and energy efficiency.
 
-`Tokenomics` relates to the economic model of the blockchain network and its native tokens. It involves aspects such as token distribution, inflation, utility, and governance. Understanding the tokenomics is crucial for evaluating the long-term viability and potential value of the blockchain ecosystem.
+2. **Tokenomics** relates to the economic model of the blockchain network and its native tokens, involving token distribution, inflation, utility, and governance. Understanding the tokenomics of the network is crucial for evaluating the ecosystem's long-term viability and potential value.
 
-`Cross-contract` capabilities refer to the ability of smart contracts to interact and communicate with each other within the blockchain network. This feature is essential for building complex decentralized applications (DApps) and implementing inter-contract functionality.
+3. **Cross-contract capabilities** refer to the ability of smart contracts to interact and communicate within the blockchain network. This feature is essential for building complex decentralized applications (dApps) and implementing inter-contract functionality.
 
-`Contract upgradability` determines whether the deployed smart contracts can be modified or updated after deployment. It is important to assess the flexibility of the chosen blockchain in terms of contract maintenance, bug fixes, and incorporating new features or improvements without disrupting the existing ecosystem.
+4. **Contract upgradability** determines whether the smart contracts installed on the network can be modified or updated after installation. It is essential to assess the flexibility of the chosen blockchain in terms of contract maintenance, bug fixes, and incorporating new features or improvements without disrupting the existing ecosystem.
 
-Lastly, the availability of software `development kits (SDKs)` plays a significant role in the development process. SDKs provide tools, libraries, and documentation to simplify the creation of applications and smart contracts on the blockchain. Evaluating the maturity, community support, and compatibility of the available SDKs is crucial for developers.
+5. **SDK availability** also plays a significant role in the development process. SDKs provide tools, libraries, and documentation to simplify the creation of applications and smart contracts on the blockchain. Evaluating the maturity, community support, and compatibility of the available SDKs is crucial for developers.
 
-Considering these aspects helps in making an informed decision when selecting a blockchain that aligns with the specific requirements and goals of the project or application.
+Considering these aspects helps when selecting a blockchain that aligns with a project or application's specific requirements and goals. 
 
-Since all of these aspects are the focus of `Casper` ecosystem, it is also a perfect choice even for Enterprise grade projects.
-
+The Casper ecosystem aims to fulfill all of these aspects, including supporting enterprise-grade projects.

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -58,14 +58,20 @@ The Near blockchain provides various capabilities for versioning, including stat
 </TabItem>
 <TabItem value="Aptos" label="Aptos">
 
-The Aptos programming language is known as Move. Its primary concepts revolve around scripts and modules. Scripts enable developers to incorporate additional logic into transactions, while modules allow them to expand blockchain functionality or create custom smart contracts. A distinctive feature of Move is the concept of Resources, which are specialized structures representing assets. This design allows resources to be managed similarly to other data types in Aptos, such as vectors or structs.
+The Aptos programming language is known as Move. Its primary concepts revolve around scripts and modules. Scripts enable developers to incorporate additional logic into transactions, while modules allow them to expand blockchain functionality or create custom smart contracts. 
+
+A distinctive feature of Move is the concept of Resources, which are specialized structures representing assets. This design allows resources to be managed similarly to other data types in Aptos, such as vectors or structs.
 
 </TabItem>
 <TabItem value="Solana" label="Solana">
 
-Solana smart contracts are primarily written in Rust. Unlike some other blockchain platforms, Solana's smart contracts are stateless and solely focus on program logic. The management of the contract state is handled at the account level. This means that there is a clear separation between the state stored within the account and the contract logic defined in the programs.
+Solana smart contracts are primarily written in Rust. 
 
-In Solana, smart contracts are commonly referred to as on-chain programs. These programs expose their interface as a public entry point, allowing external interaction. It is worth noting that Solana programs can be updated through the use of an authority known as the "update authority," which holds the necessary permissions for making modifications to the program.
+Unlike other blockchain platforms, Solana's smart contracts are stateless and solely focus on program logic. The management of the contract state is handled at the account level, separating the state stored within the account and the contract logic defined in the programs.
+
+Smart contracts are commonly referred to as on-chain programs. These programs expose their interface as a public entry point, allowing external interaction. 
+
+It is worth noting that Solana programs can be updated using an authority known as the "update authority," which holds the necessary permissions for making modifications to the program.
 
 </TabItem>
 </Tabs>

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -105,7 +105,6 @@ In terms of storage, the actual data is stored in the Account. It is organized a
 Entry points are declared within the 'call' routine. To declare a public entry point, the following format is used:
 
 ```rust
-
 #[no_mangle]
 pub extern "C" fn counter_inc() {
     let uref: URef = runtime::get_key(COUNT_KEY)
@@ -115,7 +114,6 @@ pub extern "C" fn counter_inc() {
     
     storage::add(uref, 1); // Increment the count by 1.
 }
-
 ```
 
 It's important to note that entry points do not inherently have input arguments in their definition. If a return value is needed, it should be declared using the following syntax:
@@ -134,19 +132,15 @@ On Ethereum, public methods serve two purposes: they can be used to execute cont
 The declaration of public methods in Ethereum follows the format:
 
 ```bash
-
 function update_name(string value) public {
     dapp_name = value;
 }
-
 ```
 
 In cases where a public method only returns a value without modifying the state, it should be defined as follows:
 
 ```bash
-
 function balanceOf(address _owner) public view returns (uint256 return_parameter) { }
-
 ```
 
 It is worth noting that public view methods on Ethereum, which solely retrieve data without making state changes, do not consume gas.
@@ -165,17 +159,13 @@ In the Near blockchain, there are three types of public functions:
 The definition of public methods in Near is as follows:
 
 ```rust
-
 pub fn add_message(&mut self, ...) { }
-
 ```
 
 For public methods that return variables, the definition would be:
 
 ```rust
-
 pub fn get_messages(&self, from_index: Option<U128>, limit: Option<u64>) -> Vec<PostedMessage> { }
-
 ```
 
 The actual implementation of the functions may include the necessary parameters and logic based on the specific requirements of the contract.
@@ -186,17 +176,13 @@ The actual implementation of the functions may include the necessary parameters 
 Public functions in Aptos are similar to public methods or functions found in other blockchain networks. The definition of a public function in Aptos appears as follows:
 
 ```rust
-
 public fun start_collection(account: &signer) {}
-
 ```
 
 For public functions that return variables, the definition would be as follows:
 
 ```rust
-
 public fun max(a: u8, b: u8): (u8, bool) {}
-
 ```
 
 In the Aptos Blockchain, it is possible to return one or more values from a function.
@@ -207,9 +193,7 @@ In the Aptos Blockchain, it is possible to return one or more values from a func
 In Solana, functions are defined as public entry points that act as interfaces visible to the network. The declaration of an entry point follows this format:
 
 ```rust
-
 entrypoint!(process_instruction);
-
 ```
 
 The implementation of the entry point may resemble the following:
@@ -220,7 +204,6 @@ pub fn process_instruction(
     accounts: &[AccountInfo],
     _instruction_data: &[u8],
 ) -> ProgramResult {}
-
 ```
 
 Within the entry point function, the necessary parameters are specified, such as `program_id`, which represents the program's identifier, `accounts`, an array of `AccountInfo` providing account details, and `_instruction_data`, representing the instruction data received. The function returns a `ProgramResult`, which indicates the success or failure of the instruction execution.
@@ -237,7 +220,6 @@ Within the entry point function, the necessary parameters are specified, such as
 Named arguments are passed as strings with type specifiers. To provide session arguments to the entry point during a Deploy, you can utilize the following approach:
 
 ```bash
-
 casper-client put-deploy \
   --node-address http://65.21.235.219:7777 \
   --chain-name casper-test \
@@ -248,15 +230,12 @@ casper-client put-deploy \
   --session-arg "validator:public_key='0145fb72c75e1b459839555d70356a5e6172e706efa204d86c86050e2f7878960f'" \
   --session-arg "amount:u512='500000000000'" \
   --session-arg "delegator:public_key='0154d828baafa6858b92919c4d78f26747430dcbecb9aa03e8b44077dc6266cabf'"
-
 ```
 
 In the contract, you can access the session arguments as follows:
 
 ```bash
-
 let uref: URef = runtime::get_key(Key_Name)
-
 ```
 
 The `get_key` function can be used to retrieve the desired session argument by specifying its name or key.

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -83,7 +83,7 @@ It is worth noting that Solana programs can be updated using an authority known 
 
 Variables can be stored as Named Keys or Dictionaries as described in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
 
-Additionally, local variables are available within the entry points and can be utilized to perform necessary actions or computations within the scope of each entry point.
+Additionally, local variables are available within the entry points and can be used to perform necessary actions or computations within the scope of each entry point.
 
 </TabItem>
 <TabItem value="Ethereum" label="Ethereum">

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -290,29 +290,83 @@ By enforcing strong typing, the programming language ensures that the arguments 
 <Tabs>
 <TabItem value="Casper" label="Casper">
 
-Data is persisted in Named Keys and [Dictionaries](../concepts/dictionaries.md) in the context of a contract or an account.
+Data persists in Named Keys and Dictionaries in a contract or an account's context. See more details in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
  
 </TabItem>
 <TabItem value="Ethereum" label="Ethereum">
 
-Data is persisted in a storage represented by state variables within the smart contract. These state variables need to be strongly typed to allocate the appropriate amount of space for them in the storage.
-
-By using strong typing, the smart contract compiler can enforce type consistency and ensure that the allocated storage space aligns with the declared data types. This promotes code correctness and prevents potential data corruption or memory-related issues when interacting with the contract's state variables.
+Data persists in state variables within the smart contract. These state variables must be strongly typed so that the smart contract compiler can enforce type consistency and ensure the storage space aligns with the declared data types. Strong typing promotes code correctness and prevents potential data corruption or memory-related issues related to the contract's state variables.
 
 </TabItem>
 <TabItem value="Near" label="Near">
 
-When creating state variables, it is advisable to use SDK Collections. SDK Collections provide convenient data structures, such as lists, maps, and sets, which can be used to organize and manage complex data within the contract's storage. Utilizing SDK Collections ensures efficient storage management and facilitates easier access and manipulation of data in the smart contract.
+SDK Collections are typical when creating state variables because they provide convenient data structures such as lists, maps, and sets. These data structures can organize and manage complex data within the contract's storage. Utilizing SDK Collections ensures efficient storage and facilitates easier access and data management in the smart contract.
 
 </TabItem>
 <TabItem value="Aptos" label="Aptos">
 
-To facilitate efficient data management and organization, it is advisable to cluster related data into Resources. Resources are a special type of structure that represent assets or specific data entities on the blockchain. By grouping data into Resources, you can maintain logical coherence and improve readability and maintainability of the code.
+Aptos advises developers to cluster related data into Resources for efficient data management and organization. Resources represent assets or specific data entities on the blockchain. By grouping data into Resources, you can maintain logical coherence and improve the readability and maintainability of the code.
 
 </TabItem>
 <TabItem value="Solana" label="Solana">
 
-Data is stored in structs within the account. These structs should be serialized and deserialized using Borsh. The process involves reading the data from the account, deserializing it to obtain the values, updating the values, and then serializing the modified data to save the new values back into the account.
+Data persists in structs within the account. The Binary Object Representation Serializer for Hashing (Borsh) facilitates the serialization and deserialization of these structs. The process involves reading the data from the account, deserializing it to obtain the values it contains, updating the values, and then serializing the modified data to save the new values back into the account.
+
+</TabItem>
+</Tabs>## State Management {#state-management}
+
+<Tabs>
+<TabItem value="Casper" label="Casper">
+
+Data persists in Named Keys and Dictionaries in a contract or an account's context. See more details in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
+ 
+</TabItem>
+<TabItem value="Ethereum" label="Ethereum">
+
+Data persists in state variables within the smart contract. These state variables must be strongly typed so that the smart contract compiler can enforce type consistency and ensure the storage space aligns with the declared data types. Strong typing promotes code correctness and prevents potential data corruption or memory-related issues related to the contract's state variables.
+
+</TabItem>
+<TabItem value="Near" label="Near">
+
+SDK Collections are typical when creating state variables because they provide convenient data structures such as lists, maps, and sets. These data structures can organize and manage complex data within the contract's storage. Utilizing SDK Collections ensures efficient storage and facilitates easier access and data management in the smart contract.
+
+</TabItem>
+<TabItem value="Aptos" label="Aptos">
+
+Aptos advises developers to cluster related data into Resources for efficient data management and organization. Resources represent assets or specific data entities on the blockchain. By grouping data into Resources, you can maintain logical coherence and improve the readability and maintainability of the code.
+
+</TabItem>
+<TabItem value="Solana" label="Solana">
+
+Data persists in structs within the account. The Binary Object Representation Serializer for Hashing (Borsh) facilitates the serialization and deserialization of these structs. The process involves reading the data from the account, deserializing it to obtain the values it contains, updating the values, and then serializing the modified data to save the new values back into the account.
+
+</TabItem>
+</Tabs>## State Management {#state-management}
+
+<Tabs>
+<TabItem value="Casper" label="Casper">
+
+Data persists in Named Keys and Dictionaries in a contract or an account's context. See more details in [Reading and Writing Data to the Blockchain](../concepts/design/reading-and-writing-to-the-blockchain.md).
+ 
+</TabItem>
+<TabItem value="Ethereum" label="Ethereum">
+
+Data persists in state variables within the smart contract. These state variables must be strongly typed so that the smart contract compiler can enforce type consistency and ensure the storage space aligns with the declared data types. Strong typing promotes code correctness and prevents potential data corruption or memory-related issues related to the contract's state variables.
+
+</TabItem>
+<TabItem value="Near" label="Near">
+
+SDK Collections are typical when creating state variables because they provide convenient data structures such as lists, maps, and sets. These data structures can organize and manage complex data within the contract's storage. Utilizing SDK Collections ensures efficient storage and facilitates easier access and data management in the smart contract.
+
+</TabItem>
+<TabItem value="Aptos" label="Aptos">
+
+Aptos advises developers to cluster related data into Resources for efficient data management and organization. Resources represent assets or specific data entities on the blockchain. By grouping data into Resources, you can maintain logical coherence and improve the readability and maintainability of the code.
+
+</TabItem>
+<TabItem value="Solana" label="Solana">
+
+Data persists in structs within the account. The Binary Object Representation Serializer for Hashing (Borsh) facilitates the serialization and deserialization of these structs. The process involves reading the data from the account, deserializing it to obtain the values it contains, updating the values, and then serializing the modified data to save the new values back into the account.
 
 </TabItem>
 </Tabs>

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -292,7 +292,7 @@ Data persists in state variables within the smart contract. These state variable
 </TabItem>
 <TabItem value="Near" label="Near">
 
-SDK Collections are typical when creating state variables because they provide convenient data structures such as lists, maps, and sets. These data structures can organize and manage complex data within the contract's storage. Utilizing SDK Collections ensures efficient storage and facilitates easier access and data management in the smart contract.
+SDK Collections are typical when creating state variables because they provide convenient data structures such as lists, maps, and sets. These data structures can organize and manage complex data within the contract's storage. Using SDK Collections ensures efficient storage and facilitates easier access and data management in the smart contract.
 
 </TabItem>
 <TabItem value="Aptos" label="Aptos">

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -38,12 +38,11 @@ It's worth noting that Casper only supports public entry points for contracts. A
 
 Ethereum smart contracts are primarily written in Solidity, a programming language specifically designed for this purpose. These contracts comprise a collection of global variables that persist on the blockchain and define the contract's state.
 
-Furthermore, Ethereum smart contracts feature a constructor that allows for the specification of an initial state after deployment on the blockchain. Public functions declared within the contract can be invoked from outside the blockchain.
+Furthermore, Ethereum smart contracts feature a constructor that specifies an initial state after deployment on the blockchain. Public functions declared within the contract can be invoked from outside the blockchain.
 
-In terms of immutability, Ethereum smart contracts are inherently immutable once deployed. However, there are design patterns available, such as "Proxy" or "Diamond," that facilitate versioning of contracts on the Ethereum blockchain.
+In terms of immutability, Ethereum smart contracts are inherently immutable once deployed. However, design patterns such as "Proxy" or "Diamond" facilitate versioning contracts on the Ethereum blockchain.
 
-Smart contracts written in Solidity adhere to object-oriented programming principles and support features such as inheritance and libraries.
-
+Solidity smart contracts adhere to object-oriented programming principles and support features such as inheritance and libraries.
 
 </TabItem>
 <TabItem value="Near" label="Near">

--- a/source/docs/casper/resources/migrate.md
+++ b/source/docs/casper/resources/migrate.md
@@ -10,11 +10,11 @@ import TabItem from '@theme/TabItem';
 
 This page covers various considerations for moving to Casper from another blockchain by comparing Casper to Ethereum, Near, Aptos, and Solana in these aspects:
 
-- [Contract Lifecycle](#contract-lifecycle)
-- [Variable Storage](#variable-storage)
-- [Public Methods](#public-methods)
-- [Passing Arguments](#passing-arguments)
-- [State Management](#state-management)
+1. [Contract Lifecycle](#contract-lifecycle)
+2. [Variable Storage](#variable-storage)
+3. [Public Methods](#public-methods)
+4. [Passing Arguments](#passing-arguments)
+5. [State Management](#state-management)
 
 Since other blockchain projects use different technologies, it is essential to consider how those technologies serve your use case.
 


### PR DESCRIPTION
### What does this PR fix/introduce?

Updates the content for PR #1178. A few callouts to keep in mind for the future:

- The summary at the end isn’t really a summary of the previous sections, so I renamed it
- In the Casper tab, I removed the repetition of Casper (ex “on the Casper Network”, or “in Casper”)
- The `call` function is like a main function, not a constructor. I rewrote this part.
- Removed passive voice when possible. Ex: “data persists” instead of “data is persisted”. Another ex: “These data structures can organize” vs. “These data structures can be used to organize”
- We should not advise on another chain. Ex for Near: “When creating state variables, it is advisable to use SDK Collections.” I tried to remove any recommendations for other chains.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@KMCreatesWorlds 

### Notes
@RitaMAllenCA I am not connecting an issue because the original issue should not be closed once this PR merges. It is an intermediary step.
