### PR TITLE
Make Algolia configurable via GitHub vars (not secrets)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,8 +47,8 @@ jobs:
           output_file: .env.production
         env:
           ALGOLIA_APP_ID: ${{ vars.ALGOLIA_APP_ID }}
-          ALGOLIA_INDEX_NAME: ${{ secrets.ALGOLIA_INDEX_NAME }}
-          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+          ALGOLIA_INDEX_NAME: ${{ vars.ALGOLIA_INDEX_NAME }}
+          ALGOLIA_API_KEY: ${{ vars.ALGOLIA_API_KEY }}
           CROWDIN_PERSONAL_ACCESS_TOKEN: ""
           GOOGLE_TAG_ANONYMIZE_IP: ${{ vars.GOOGLE_TAG_ANONYMIZE_IP }}
           GOOGLE_TAG_TRACKING_ID: ${{ vars.GOOGLE_TAG_TRACKING_ID }}
@@ -56,9 +56,9 @@ jobs:
           DIRECTUS_GRAPHQL_URL: ${{ secrets.DIRECTUS_GRAPHQL_URL }}
           DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_TOKEN }}
           SITE_URL: ${{ secrets.SITE_URL }}
-          ALGOLIA_SITE_APP_ID: ${{ secrets.ALGOLIA_SITE_APP_ID }}
-          ALGOLIA_SITE_API_KEY: ${{ secrets.ALGOLIA_SITE_API_KEY }}
-          ALGOLIA_SITE_INDEX_NAME: ${{ secrets.ALGOLIA_SITE_INDEX_NAME }}
+          ALGOLIA_SITE_APP_ID: ${{ vars.ALGOLIA_SITE_APP_ID }}
+          ALGOLIA_SITE_API_KEY: ${{ vars.ALGOLIA_SITE_API_KEY }}
+          ALGOLIA_SITE_INDEX_NAME: ${{ vars.ALGOLIA_SITE_INDEX_NAME }}
           BASE_URL: ${{ secrets.BASE_URL }}
 
       - name: Yarn install


### PR DESCRIPTION
### What does this PR fix?

Currently Algolia config is stored in repository secrets, although it is not secret at all:

![image](https://github.com/casper-network/docs/assets/121791569/ee6a293d-d2e0-4707-952f-502ea098587e)

That is why we should use variables instead - it will make configuration inspection easier.

### Checklist

- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested.

