### PR TITLE
Convert all public secrets to vars

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Docusaurus CICD
 
 env:
-  prod_pages_fqdn: ${{ secrets.PROD_PAGES_FQDN }}
+  prod_pages_fqdn: ${{ vars.PROD_PAGES_FQDN }}
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,11 @@ jobs:
           DIRECTUS_URL: ${{ secrets.DIRECTUS_URL }}
           DIRECTUS_GRAPHQL_URL: ${{ secrets.DIRECTUS_GRAPHQL_URL }}
           DIRECTUS_TOKEN: ${{ secrets.DIRECTUS_TOKEN }}
-          SITE_URL: ${{ secrets.SITE_URL }}
+          SITE_URL: ${{ vars.SITE_URL }}
           ALGOLIA_SITE_APP_ID: ${{ vars.ALGOLIA_SITE_APP_ID }}
           ALGOLIA_SITE_API_KEY: ${{ vars.ALGOLIA_SITE_API_KEY }}
           ALGOLIA_SITE_INDEX_NAME: ${{ vars.ALGOLIA_SITE_INDEX_NAME }}
-          BASE_URL: ${{ secrets.BASE_URL }}
+          BASE_URL: ${{ vars.BASE_URL }}
 
       - name: Yarn install
         run: |


### PR DESCRIPTION
### What does this PR fix/introduce?

Converts all repository's "_secrets_" that are public - `SITE_URL`, `BASE_URL` and `PROD_PAGES_FQDN` - into _variables_, as it will make configuration inspection easier.

This is **finalization** of the following work:
 - https://github.com/casper-network/docs/commit/be717324e3fd65e9d297b55ba8f6b9a31cd37d0b
 - https://github.com/casper-network/docs/pull/1184 

Repository variables are already created - according to the current "secrets":

![image](https://github.com/casper-network/docs/assets/121791569/32d75373-103a-4679-9f03-d15ba0c52b0a)

**Note:** `BASE_URL` is optional and it was not used yet.

**TODO:** Remove unnecessary secret, when this PR gets merged.

### Checklist

- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested.
