### PR TITLE
848 - Minor updates for generating keys

### DIFF
--- a/source/docs/casper/concepts/accounts-and-keys.md
+++ b/source/docs/casper/concepts/accounts-and-keys.md
@@ -10,7 +10,7 @@ By default, a transactional interaction with the blockchain takes the form of a 
 
 The Casper platform supports two types of keys for creating accounts and signing transactions: 
 - [Ed25519](#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66 bytes long
-- [Secp256k1](#ethereum-keys) keys, commonly known as Ethereum keys, which are 68 bytes long
+- [Secp256k1](#ecdsa-keys) keys, which use the  Elliptic Curve Digital Signature Algorithm (ECDSA) with the P-256 curve; they are 68 bytes long and are also found on the Ethereum blockchain
 
 You can generate keys using both formats, and it is also possible to [work with existing Ethereum keys](#working-with-existing-ethereum-keys).
 
@@ -26,7 +26,7 @@ SAVE your keys to a safe place, preferably offline.
 
 :::
 
-### Option 1: Generating Keys using the Casper Client {#option-1-key-generation-using-the-casper-client}
+### Option 1: Generating keys using the Casper Client {#option-1-key-generation-using-the-casper-client}
 
 This option describes how you can use the Casper command-line client to set up an account using either key type.
 
@@ -62,9 +62,9 @@ cat ed25519-keys/public_key_hex
 011724c5c8e2404ca01c872e1bbd9202a0114e5d143760f685086a5cffe261dabd
 ```
 
-#### Ethereum Keys {#ethereum-keys}
+#### ECDSA Keys {#ecdsa-keys}
 
-To create `Secp256k1` keys with the Casper command-line client, commonly known as Ethereum keys, follow these steps:
+To create `secp256k1` keys, which use the ECDSA algorithm with the P-256 curve, follow these steps:
 
 ```bash
 mkdir secp256k1-keys
@@ -95,7 +95,7 @@ After generating keys for the account, you may add funds to the account's purse 
 
 :::
 
-### Option 2: Generating Keys using a Block Explorer {#option-2-key-generation-using-a-block-explorer}
+### Option 2: Generating keys using a block explorer {#option-2-key-generation-using-a-block-explorer}
 
 This option is available on networks that have a block explorer.
 
@@ -196,7 +196,7 @@ tlKF2V5RFQn4rzkwipSYnrqaPf1pTA==
 -----END EC PRIVATE KEY-----
 ```
 
-### Option 3: Generating Keys using OpenSSL
+### Option 3: Generating keys using OpenSSL
 
 You can generate keys without the Casper client using the [openssl](https://www.openssl.org/) cryptography toolkit. The commands below are valid only for generating Ed25519 keys on a Linux operating system.
 

--- a/source/docs/casper/concepts/design/casper-design.md
+++ b/source/docs/casper/concepts/design/casper-design.md
@@ -58,7 +58,7 @@ The Casper blockchain uses an on-chain account-based model, uniquely identified 
 
 The Casper platform supports two types of keys for creating accounts and signing transactions: 
 - [ed25519](../accounts-and-keys.md#eddsa-keys) keys, which use the Edwards-curve Digital Signature Algorithm (EdDSA) and are 66 bytes long
-- [secp256k1](../accounts-and-keys.md#ethereum-keys) keys, commonly known as Ethereum keys, which are 68 bytes long
+- [secp256k1](../accounts-and-keys.md#ecdsa-keys) keys, commonly known as Ethereum keys, which are 68 bytes long
 
 By default, a transactional interaction with the blockchain takes the form of a Deploy cryptographically signed by the key-pair corresponding to the PublicKey used to create the account. All user activity on the Casper blockchain (i.e., "deploys") must originate from an account. Each account has its own context where it can locally store information (e.g., references to useful contracts, metrics, and aggregated data from other parts of the blockchain). Each account also has a "main purse" where it can hold Casper tokens (see [Tokens](#tokens-purses-and-accounts) for more information).
 

--- a/source/docs/casper/operators/setup/non-root-user.md
+++ b/source/docs/casper/operators/setup/non-root-user.md
@@ -2,7 +2,7 @@
 
 Operators may log into their servers remotely using a key. The following steps explain how to create a non-root user and log in using a private key instead of the root user. Replace `<username>` in the instructions below with your username.
 
-1. Use [ssh-keygen](https://www.ssh.com/ssh/keygen/) to generate a new SSH key.
+1. Use [ssh-keygen](https://www.ssh.com/ssh/keygen/) to generate a new SSH key. The Casper protocol supports the `ed25519` and `secp256k1` (ECDSA keys with the P-256 curve) algorithms. You can find more details [here](../../concepts/accounts-and-keys.md).
 
 2. Create the user with no password, as the key is your password.
 

--- a/source/docs/casper/operators/setup/non-root-user.md
+++ b/source/docs/casper/operators/setup/non-root-user.md
@@ -2,7 +2,7 @@
 
 Operators may log into their servers remotely using a key. The following steps explain how to create a non-root user and log in using a private key instead of the root user. Replace `<username>` in the instructions below with your username.
 
-1. Use [ssh-keygen](https://www.ssh.com/ssh/keygen/) to generate a new SSH key. The Casper protocol supports the `ed25519` and `secp256k1` (ECDSA keys with the P-256 curve) algorithms. You can find more details [here](../../concepts/accounts-and-keys.md).
+1. Use [ssh-keygen](https://www.ssh.com/ssh/keygen/) to generate a new SSH key.
 
 2. Create the user with no password, as the key is your password.
 


### PR DESCRIPTION
### What does this PR fix/introduce?

Minor updates in the `source/docs/casper/concepts/accounts-and-keys.md` file.
The content was already up-to-date, so I only made minor changes to the title casing and terminology to avoid saying "Ethereum keys".

I reverted commit 511e28f95d8f19a52a80ea96fdfd64d1552071dd because it wasn't correct. Those keys are created for the connection to the validator node, not for use on the Casper network.

Closes #848 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ACStoneCL 
