### PR TITLE
Add tips to reduce WASM size

### DIFF
--- a/source/docs/casper/developers/writing-onchain-code/best-practices.md
+++ b/source/docs/casper/developers/writing-onchain-code/best-practices.md
@@ -36,6 +36,39 @@ Computations occurring on-chain come with associated [gas costs](../../concepts/
 
 Further, there is a set cost of 2.5 CSPR to create a new purse. If possible, the [reuse of purses](../../resources/tutorials/advanced/transfer-token-to-contract.md#scenario2) should be considered to reduce this cost. If reusing purses, proper access management must be maintained to prevent lapses in security. Ultimately, any choices made in regards to security and contract safeguards rely on the smart contract author.
 
+### Tips to reduce WASM size
+
+Deploys have a maxim size specified in each network chainspec as `max_deploy_size`. For example, networks running [node version 1.5.1](https://github.com/casper-network/casper-node/blob/6873c86cc3ab3aae1c8187a7528f94da605e2669/resources/production/chainspec.toml#L101), have the following maximum deploy size in bytes:
+
+```
+max_deploy_size = 1_048_576
+```
+
+Here are a few tips to reduce the size of Wasm included in a deploy:
+
+1. Build the smart contract in release mode. You will find an example [here](https://github.com/casper-ecosystem/cep18/blob/2c702e23497d2c9493374466e7af0c002006cbda/Makefile#L10)
+
+    ```
+    cargo build --release --target wasm32-unknown-unknown
+    ```
+
+2. Run `wasm-strip` on the compiled code (see [WABT](https://github.com/WebAssembly/wabt)). You will find an example [here](https://github.com/casper-ecosystem/cep18/blob/2c702e23497d2c9493374466e7af0c002006cbda/Makefile#L12)
+
+    ```
+    wasm-strip target/wasm32-unknown-unknown/release/contract.wasm
+    ```
+
+3. Don't enable the `std` feature when linking to the `casper-contract` or `casper-types` crates using the `#![no_std]` attribute, which tells the program not to import the standard libraries. You will find an example [here](https://github.com/casper-ecosystem/cep18/blob/2c702e23497d2c9493374466e7af0c002006cbda/cep18/src/main.rs#L1) and further details [here](https://docs.rust-embedded.org/book/intro/no-std.html)
+	
+    ```rust
+    #![no_std]
+    ```
+
+4. Build the contract with `codegen-units` set to 1 by adding `codegen-units = 1` to the Cargo.toml under `[profile.release])`. You will find an example [here](https://github.com/casper-ecosystem/cep18/blob/2c702e23497d2c9493374466e7af0c002006cbda/Cargo.toml#L14)
+
+5. Build the contract with link-time optimizations enabled by adding `lto = true` to the Cargo.toml under `[profile.release]`. You will find an example [here](https://github.com/casper-ecosystem/cep18/blob/2c702e23497d2c9493374466e7af0c002006cbda/Cargo.toml#L15)
+
+
 ## Inlining
 
 As often as practicable, developers should inline functions by including the body of the function within their code rather than making `call` or `call_indirect` to the function. In the context of coding for Casper blockchain purposes, this reduces the overhead of executed Wasm and prevents unexpected errors due to exceeding resource tolerances.


### PR DESCRIPTION
### What does this PR fix/introduce?

An oldie but goldie--tips from Fraser on reducing Wasm size. I've added them to best practices, and linked to the cep18 contract.

Closes #112 

### Checklist
- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL 

### Preview

<img width="1580" alt="Screenshot 2023-07-10 at 15 36 29" src="https://github.com/casper-network/docs/assets/4185994/3f42f8f8-488f-4b4c-b247-40e397667889">
