### PR TITLE
Fix "edit this page" URL

### DIFF
--- a/src/utils/docs.js
+++ b/src/utils/docs.js
@@ -1,4 +1,4 @@
-const documentationRepoUrl = "https://github.com/casper-network/docs/tree/main/source";
+const documentationRepoUrl = "https://github.com/casper-network/docs/tree/dev/source";
 
 const getEditUrl = ({ versionDocsDirPath, docPath }) => {
     const segments = versionDocsDirPath.split("/");


### PR DESCRIPTION
### What does this PR fix?

Fix link used in "Edit this page" feature.

Closes [#815](https://github.com/casper-network/docs/issues/815).

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.

