### PR TITLE
Execution Results Fix

### DIFF
--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -410,7 +410,7 @@ If the `execution_results` field is empty, it means that the network processed t
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
 |[deploy](./types_chain.md#deploy)|Object|The Deploy.|
-|[execution_results](./types_chain.md#jsonexecutionresult)|Object|The map of Block hash to execution result.|
+|[execution_results](./types_chain.md#jsonexecutionresult)|Array|An array of execution results with Block hashes.|
 
 <details>
 


### PR DESCRIPTION
### What does this PR fix/introduce?
As per a note from @gyroflaw, `execution_results` within `info_get_deploy` is an array, not an object.

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@gyroflaw 
