### PR TITLE
Restore URL for begginer tutorials to fix Developer Portal link

### DIFF
--- a/source/docs/casper/resources/beginner/index.md
+++ b/source/docs/casper/resources/beginner/index.md
@@ -1,5 +1,5 @@
 ---
-slug: /resources/tutorials/beginner/
+slug: /resources/beginner/
 ---
 
 # Overview


### PR DESCRIPTION
### What does this PR fix?

After [recent changes](https://github.com/casper-network/docs/pull/1237/files#diff-ab216ac53fec2f26de47415fc525cc8f9dca8b0ed6c89a19e2cb6149dc06b550) the _Tutorials_ link on Developer Portal got invalid (_404 Not Found_), however all people with Directus access are on holidays, so we cannot update it. As a workaround, this PR restores old URL in the documentation side.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All technical procedures have been tested.
