### PR TITLE
Update Casper Snap URL

### DIFF
--- a/source/docs/casper/resources/build-on-casper.md
+++ b/source/docs/casper/resources/build-on-casper.md
@@ -24,7 +24,7 @@ The Casper Ecosystem is growing every day through the addition of new dApps and 
 - [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?docs=true)
 - [Tor.us](https://casper.tor.us)
 - [Casper Wallet](https://www.casperwallet.io)
-- [Metamask Flask](https://metamask.io/flask/) with [Casper Snap](https://github.com/casperholders/casper-snap)
+- [Metamask Flask](https://metamask.io/flask/) with [Casper Snap](https://github.com/casper-ecosystem/casper-manager)
 
 ### Block Explorers
 - [cspr.live](https://cspr.live)


### PR DESCRIPTION
Fix for [recently failing build](https://github.com/casper-network/docs/actions/runs/5893040610/job/16071744501):

![image](https://github.com/casper-network/docs/assets/121791569/5a950d7f-ae08-49c3-ab0f-1855f103a63d)

**Note:** I got new URL directly from @KillianH.