### PR TITLE
CI/CD: Setup preview deployments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,32 @@ jobs:
         curl --fail http://127.0.0.1:4000/concepts/serialization-standard/
       working-directory: ./docs
 
+  deploy-preview:
+    if: github.event_name == 'pull_request'
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/download-artifact@master
+      with:
+        name: gh-pages-depl-payload
+        path: ./docs
+
+    - name: Deploy to Netlify
+      uses: nwtgck/actions-netlify@v2.1
+      with:
+        publish-dir: 'docs'
+        production-deploy: false
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        deploy-message: ${{ github.event.pull_request.title }}
+        enable-pull-request-comment: true
+        enable-commit-comment: false
+        enable-github-deployment: false
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.PREVIEW_NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.PREVIEW_NETLIFY_SITE_ID }}
+      timeout-minutes: 1
+
   deploy-prod:
     if: ${{ github.ref == 'refs/heads/dev' && github.repository == 'casper-network/docs' }}
     needs: [backup, system-tests-predeployment]
@@ -203,5 +229,3 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs
-
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           node-version: ${{ env.selected_node_version }}
           cache: yarn
 
-      - name: Template credentials
+      - name: Template credentials - production
         if: github.ref == 'refs/heads/dev'
         uses: cuchi/jinja2-action@1149b92d9ea6db61d7f71c22e3d5028d8065f140
         with:
@@ -60,6 +60,19 @@ jobs:
           ALGOLIA_SITE_APP_ID: ${{ vars.ALGOLIA_SITE_APP_ID }}
           ALGOLIA_SITE_API_KEY: ${{ vars.ALGOLIA_SITE_API_KEY }}
           ALGOLIA_SITE_INDEX_NAME: ${{ vars.ALGOLIA_SITE_INDEX_NAME }}
+          BASE_URL: ${{ vars.BASE_URL }}
+
+      - name: Template credentials - preview
+        if: github.event_name == 'pull_request'
+        uses: cuchi/jinja2-action@1149b92d9ea6db61d7f71c22e3d5028d8065f140
+        with:
+          template: .github/templates/.env.production.j2
+          output_file: .env.production
+        env:
+          DIRECTUS_URL: ${{ secrets.PREVIEW_DIRECTUS_URL }}
+          DIRECTUS_GRAPHQL_URL: ${{ secrets.PREVIEW_DIRECTUS_GRAPHQL_URL }}
+          DIRECTUS_TOKEN: ${{ secrets.PREVIEW_DIRECTUS_TOKEN }}
+          SITE_URL: ${{ vars.SITE_URL }}
           BASE_URL: ${{ vars.BASE_URL }}
 
       - name: Yarn install


### PR DESCRIPTION
### What does this PR introduce?

Automatic preview for pull requests:

![image](https://github.com/casper-network/docs/assets/121791569/d859fe88-247e-4e49-8573-8735af18df8f)

![image](https://github.com/casper-network/docs/assets/121791569/fab64f73-c42f-47b5-85a6-933b9972d15a)

### Additional context

**Base part**

For every pull request `deploy-preview` job is executed, and with [nwtgck/actions-netlify@2.1](https://github.com/nwtgck/actions-netlify) action:
 - deployment is published to Netlify, then
 - comment with URL is added to pull request.

This part requires 2 new repository secrets (already filled):
- Netlify auth token: `PREVIEW_NETLIFY_AUTH_TOKEN`,
- Netlify site ID: `PREVIEW_NETLIFY_SITE_ID`.

**Directus part**

Since this deployment is exactly like the local one, it would not include site header/footer (as it requires Directus setup for getting text data). Therefore, I decided to go step further and overcome this bad design with a quick workaround. I introduced additional build step *Template credentials - preview*, that fills `.env` file with minimal configuration, using the 3 new repository secrets (already filled them with values from staging):
- `PREVIEW_DIRECTUS_URL`,
- `PREVIEW_DIRECTUS_GRAPHQL_URL`,
- `PREVIEW_DIRECTUS_TOKEN`.

With such change, preview builds include navbar and footer!