### PR TITLE
Removing a Method from the "Move A Node" Docs

### DIFF
--- a/source/docs/casper/operators/maintenance/moving-node.md
+++ b/source/docs/casper/operators/maintenance/moving-node.md
@@ -4,25 +4,11 @@ title: Move a Node
 
 #  Moving a Validating Node
 
-This guide is for active validators who want to move their node to another machine. There are two primary methods to achieve this, outlined below.
+This guide is for active validators who want to move their node to another machine.
 
-## Method One: Copying the Data to a New Location
+## Swapping Keys with a Hot Backup
 
-This method is simple but requires downtime. The node needs to download all the blocks generated while it is stopped.
-
-1. Stop the node.
-2. Copy the node's data to a new mount:
-
-    ```bash
-    rsync -av --inplace --sparse  /var/lib/casper/ /new_mount
-    ```
-
-3. Change the mount point.
-4. Restart the node.
-
-## Method Two: Swapping Keys with a Hot Backup
-
-This method is a safer option, limiting downtime and enabling a smooth transition from the old to the new node. It keeps the node in sync with the tip of the chain.
+This method limits downtime and enables a smooth transition from the old to the new node. It keeps the node in sync with the tip of the chain.
 
 1. Once a node is running (`current_node`), create a second node (`backup_node`) on another machine. These two nodes will run in parallel.
 2. When the `backup_node` is up to date, stop both nodes.

--- a/source/docs/casper/resources/advanced/list-cspr.md
+++ b/source/docs/casper/resources/advanced/list-cspr.md
@@ -6,7 +6,7 @@ slug: /resources/tutorials/advanced/list-cspr
 
 # Listing CSPR on an Exchange
 
-This topic describes how to list the Casper token (CSPR) on a cryptocurrency [exchange](https://tokenmarketcaps.com/coins/casper/market). 
+This topic describes how to list the Casper token (CSPR) on a cryptocurrency exchange.
 
 :::caution
 


### PR DESCRIPTION
### What does this PR fix/introduce?
Removing one of the methods for moving a node based on [this Slack message](https://casper-labs-team.slack.com/archives/C0135SDEGUC/p1692907983926009)

### Additional context
N/A

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [ ] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@sacherjj 
