### PR TITLE
CI/CD: Allow external links failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Docusaurus CICD
 
 env:
   prod_pages_fqdn: ${{ vars.PROD_PAGES_FQDN }}
+  selected_node_version: 16.14
 
 on:
   push:
@@ -26,9 +27,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-
-    env:
-      selected_node_version: 16.14
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,10 +81,6 @@ jobs:
         run: |
           yarn format
 
-      - name: Validate external links
-        run: |
-          yarn check:externals
-
       - name: Clear Docusaurus cache
         run: |
           yarn clear
@@ -103,6 +99,27 @@ jobs:
         with:
           name: gh-pages-depl-payload
           path: ./docs
+
+  validate-external-links:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ env.selected_node_version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.selected_node_version }}
+          cache: yarn
+
+      - name: Yarn install
+        run: |
+          yarn install
+
+      - name: Validate external links
+        run: |
+          yarn check:externals
 
   system-tests-predeployment:
     needs: build


### PR DESCRIPTION
### What does this PR fix/introduce?

_We often experience broken external link and this really affects our CI/CD pipeline, that we cannot build/merge until such link is changed/removed. Then all PRs must be updated to include such fix, and this unnecessarily slows us down._

Therefore, I moved external links validation to separate job, so this would not affect `build` and still allow to merge PR.

**Demo:**

![image](https://github.com/casper-network/docs/assets/121791569/340e9216-7337-4d66-9fe9-05e8fda5f480)


### Checklist

- [x] All technical procedures have been tested.