### PR TITLE
PublicKey Updates

### DIFF
--- a/source/docs/casper/concepts/hash-types.md
+++ b/source/docs/casper/concepts/hash-types.md
@@ -34,7 +34,7 @@ For the sake of user convenience and compatibility, we expect the delivery of ha
 
 ## Hash and Key Explanations {#hash-and-key-explanations}
 
-`PublicKey` is a 32 byte asymmetric public key, preceded by a one-byte prefix that tells whether the key is `ed25519` or `secp256k1`. There is a third type of `PublicKey` that refers to system contracts and it is a single `00`.
+`PublicKey` is a 32 byte asymmetric public key, preceded by a one-byte prefix that tells whether the key is `ed25519` or `secp256k1`. There is a third type of `PublicKey` that refers to the system and it is a single `00`.
 
 `AccountHash` is a 32 byte hash of the `PublicKey` serving to identify user accounts.
 

--- a/source/docs/casper/concepts/hash-types.md
+++ b/source/docs/casper/concepts/hash-types.md
@@ -34,7 +34,7 @@ For the sake of user convenience and compatibility, we expect the delivery of ha
 
 ## Hash and Key Explanations {#hash-and-key-explanations}
 
-`PublicKey` is a 32 byte asymmetric public key, preceded by a one-byte prefix that tells whether the key is `ed25519` or `secp256k1`.
+`PublicKey` is a 32 byte asymmetric public key, preceded by a one-byte prefix that tells whether the key is `ed25519` or `secp256k1`. There is a third type of `PublicKey` that refers to system contracts and it is a single `00`.
 
 `AccountHash` is a 32 byte hash of the `PublicKey` serving to identify user accounts.
 

--- a/source/docs/casper/concepts/serialization-standard.md
+++ b/source/docs/casper/concepts/serialization-standard.md
@@ -745,6 +745,7 @@ A `Map` serializes as a list of key-value tuples. There must be a well-defined o
 
 `PublicKey` serializes as a single byte tag representing the algorithm followed by 32 bytes of the `PublicKey` itself:
 
+-   If the `PublicKey` is a `System` key, the single tag byte is `0`. With this variant, the single byte of `0` is the entire key.
 -   If the `PublicKey` is an `Ed25519` key, the single tag byte is `1` followed by the individual bytes of the serialized key.
 -   If the `PublicKey` is a `Secp256k1` key, the single tag byte is a `2` followed by the individual bytes of the serialized key.
 


### PR DESCRIPTION
### What does this PR fix/introduce?
As discussed in the L1 Daily Standup, there is a third type of `PublicKey` that was not externally facing until the release of 1.5. This PR updates instances of `PublicKey` information.

Closes #1270 

### Additional context
[Update PublicKey info to include System #1270](https://github.com/casper-network/docs/issues/1270)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
Editor: @ipopescu Tech: @darthsiroftardis 
