### PR TITLE
Hotfix Trusted Hash Instructions for Node Operators

### DIFF
--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -119,10 +119,10 @@ For more details, see the [Node Setup](./basic-node-configuration.md#create-fund
 
 ## Getting a Trusted Hash
 
-To get a trusted hash, use the command below. Replace the node address with an address from a node on the network of your choice.
+To get a trusted hash, use the command below. Replace the node address with an address from a node on the network of your choice. In the past, we have used a lower `trusted_hash`. Connecting at the tip, we now use as high of a `trusted_hash` as possible.
 
 ```bash
-sudo sed -i "/trusted_hash =/c\trusted_hash = '$(casper-client get-block --node-address http://3.14.161.135:7777 -b 20 | jq -r .result.block.hash | tr -d '\n')'" /etc/casper/1_0_0/config.toml
+sudo sed -i "/trusted_hash =/c\trusted_hash = '$(casper-client get-block --node-address $NODE_ADDR | jq -r .result.block.hash | tr -d '\n')'" /etc/casper/$PROTOCOL/config.toml
 ```
 
 You can find active peers at https://cspr.live/tools/peers or you can use Casper Labs' public nodes:

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -133,7 +133,7 @@ You can find active peers at https://cspr.live/tools/peers or use the following 
 
 ### Protocol Version
 
-Protocol version should be set to the largest available protocol version you see in `ls /etc/casper` Currently, it should be:
+Protocol version should be set to the largest available protocol version you see in `ls /etc/casper`.  As of writing this, it was 1_5_2:
 
 ```bash
 PROTOCOL=1_5_2
@@ -144,7 +144,7 @@ PROTOCOL=1_5_2
 The following command uses the previously established NODE_ADDR and PROTOCOL to load the `trusted_hash`:
 
 ```bash
-NODE_ADDR=https://rpc.testnet.casperlabs.io
+NODE_ADDR=https://rpc.mainnet.casperlabs.io
 PROTOCOL=1_5_2
 sudo sed -i "/trusted_hash =/c\trusted_hash = '$(casper-client get-block --node-address $NODE_ADDR | jq -r .result.block.hash | tr -d '\n')'" /etc/casper/$PROTOCOL/config.toml
 ```

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -119,24 +119,34 @@ For more details, see the [Node Setup](./basic-node-configuration.md#create-fund
 
 ## Getting a Trusted Hash
 
-To get a trusted hash, use the command below. Replace the node address with an address from a node on the network of your choice. In the past, we have used a lower `trusted_hash`. Connecting at the tip, we now use as high of a `trusted_hash` as possible.
+In the past, we have used a lower `trusted_hash`. Connecting at the tip, we now use as high of a `trusted_hash` as possible.
 
-```bash
-sudo sed -i "/trusted_hash =/c\trusted_hash = '$(casper-client get-block --node-address $NODE_ADDR | jq -r .result.block.hash | tr -d '\n')'" /etc/casper/$PROTOCOL/config.toml
-```
+### Node Address
 
-You can find active peers at https://cspr.live/tools/peers or you can use Casper Labs' public nodes:
+NODE_ADDR can be set to an IP of a trusted node, or to Casper Labs' public nodes
+
+You can find active peers at https://cspr.live/tools/peers or use the following Casper Labs public nodes:
 
 * Testnet - NODE_ADDR=https://rpc.testnet.casperlabs.io
 
 * Mainnet - NODE_ADDR=https://rpc.mainnet.casperlabs.io
 
-## Protocol Version
+### Protocol Version
 
 Protocol version should be set to the largest available protocol version you see in `ls /etc/casper` Currently, it should be:
 
 ```bash
 PROTOCOL=1_5_2
+```
+
+### Load `trusted_hash` in Config.toml of the Protocol Version
+
+The following command uses the previously established NODE_ADDR and PROTOCOL to load the `trusted_hash`:
+
+```bash
+NODE_ADDR=https://rpc.testnet.casperlabs.io
+PROTOCOL=1_5_2
+sudo sed -i "/trusted_hash =/c\trusted_hash = '$(casper-client get-block --node-address $NODE_ADDR | jq -r .result.block.hash | tr -d '\n')'" /etc/casper/$PROTOCOL/config.toml
 ```
 
 ## Syncing to Genesis


### PR DESCRIPTION
### What does this PR fix/introduce?
Based on a Slack conversation, the `trusted_hash` information in the Installing a Node document needs to be updated.

### Additional context
[Slack Conversation](https://casper-labs-team.slack.com/archives/C0135SDEGUC/p1693581449564239?thread_ts=1693581449.564239&cid=C0135SDEGUC)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@sacherjj 
