### PR TITLE
Fast sync intro

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -225,6 +225,7 @@ module.exports = {
                 "operators/setup/basic-node-configuration",
                 "operators/setup/node-endpoints",
                 "operators/setup/install-node",
+                "operators/setup/fast-sync",
                 "operators/setup/open-files",
                 "operators/setup/upgrade",
                 "operators/setup/joining",

--- a/source/docs/casper/operators/becoming-a-validator/fast-sync.md
+++ b/source/docs/casper/operators/becoming-a-validator/fast-sync.md
@@ -1,18 +1,20 @@
 ---
-title: Fast-Sync
+title: Fast Sync
 ---
 
-# Introducing Fast-Sync
+# Introducing Fast Sync
 
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
-The Casper Network is a smart contract platform. It requires new nodes to download and execute each and every block to join the network. Starting from genesis (start of the Mainnet), the node executes each deploy in every block. This process continues until the node has arrived at the current state of the blockchain. This process to sync a node with the blockchain can take a very long time.
+A Casper Network requires new nodes to download and execute every block to join the network. From genesis (start of the Mainnet), the node executes each deploy in every block. This process continues until the node has arrived at the current state of the blockchain. Syncing a node this way can take a very long time.
 
-To provide an alternative and faster approach to joining a Casper network, we have introduced fast‑sync. Fast-sync does not start syncing at the genesis block; instead, the user verifies a recent block, e.g. using block explorers, and provides its hash to the node software. The network [global state](../../concepts/design/casper-design.md#global-state-head) — smart contract data, account balances and all other on-chain information — is the storage layer of the blockchain and is massive in size, so fast-sync downloads the global state of only the most recent block. The following section briefly describes the fast-sync process.
+We have introduced a fast syncing process (fast sync) to provide a faster alternative to joining a Casper network. Fast sync does not start syncing at the genesis block; instead, the operator verifies a recent block and provides a [trusted hash](../setup/basic-node-configuration.md#trusted-hash-for-synchronizing) to the node software. The global state, account balances, and all other on-chain information is the storage layer of the blockchain and is massive in size, so fast sync downloads the global state of only the most recent block. The following section briefly describes the fast sync process.
 
 ## How Fast-sync Works
 
 <img src={useBaseUrl("/image/fast-sync-process.png")} class="Fast-sync process" width="500"/>
 
-For fast-sync, you need to provide the trusted hash of a block on a Casper network in the config.toml file. Fast-sync uses this trusted block as part of the cryptographic verification for the later blocks. This trusted block is downloaded, as are all newer blocks up to and including the most recent block from the current era. For example, if the trusted block hash is 5 hours old, it will first download that block, then newer blocks until it arrives at one that is only a few minutes old. It then downloads the newer block's global state. Finally, it executes all blocks the network created while the download was in progress, until it is fully in sync.
+For fast sync, operators must provide the trusted hash of a block in the `config.toml` file. An example can be found [here]().
+
+Fast sync uses this trusted block as part of the cryptographic verification for the later blocks. The node downloads the trusted block first, then newer blocks up to and including the most recent block from the current era. For example, if the trusted hash is 5 hours old, it will first download that block, then newer blocks, until it arrives at one that is only a few minutes old. It then downloads the newer block's global state. Finally, it executes all the blocks the network created while the download was in progress until it is entirely in sync.
 

--- a/source/docs/casper/operators/setup/fast-sync.md
+++ b/source/docs/casper/operators/setup/fast-sync.md
@@ -10,11 +10,11 @@ A Casper Network requires new nodes to download and execute every block to join 
 
 We have introduced a fast syncing process (fast sync) to provide a faster alternative to joining a Casper network. Fast sync does not start syncing at the genesis block; instead, the operator verifies a recent block and provides a [trusted hash](../setup/basic-node-configuration.md#trusted-hash-for-synchronizing) to the node software. The global state, account balances, and all other on-chain information is the storage layer of the blockchain and is massive in size, so fast sync downloads the global state of only the most recent block. The following section briefly describes the fast sync process.
 
-## How Fast-sync Works
+## How Fast Sync Works
 
 <img src={useBaseUrl("/image/fast-sync-process.png")} class="Fast-sync process" width="500"/>
 
-For fast sync, operators must provide the trusted hash of a block in the `config.toml` file. An example can be found [here]().
+For fast sync, operators must provide the trusted hash of a block in the `config.toml` file. An example can be found [here](https://github.com/casper-network/casper-node/blob/f7d8228de3cb56a3fe705f5a787d3dbf03ff7998/resources/production/config-example.toml#L7).
 
 Fast sync uses this trusted block as part of the cryptographic verification for the later blocks. The node downloads the trusted block first, then newer blocks up to and including the most recent block from the current era. For example, if the trusted hash is 5 hours old, it will first download that block, then newer blocks, until it arrives at one that is only a few minutes old. It then downloads the newer block's global state. Finally, it executes all the blocks the network created while the download was in progress until it is entirely in sync.
 

--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -119,7 +119,7 @@ For more details, see the [Node Setup](./basic-node-configuration.md#create-fund
 
 ## Getting a Trusted Hash
 
-In the past, we have used a lower `trusted_hash`. Connecting at the tip, we now use as high of a `trusted_hash` as possible.
+In the past, we have used a lower `trusted_hash`. Connecting at the tip, we now use as high of a `trusted_hash` as possible. Find out more about [Fast Sync](./fast-sync.md).
 
 ### Node Address
 


### PR DESCRIPTION
### What does this PR fix/introduce?

While working on something else, I realized we forgot to expose the fast sync introduction when we released 1.5. I refreshed the file and added it in the setup section.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ACStoneCL 

<img width="1123" alt="Screenshot 2023-09-11 at 12 18 40" src="https://github.com/casper-network/docs/assets/4185994/0b3d5917-6e29-43a4-9d23-e00b4173116f">

