### PR TITLE
Replace state_get_balance with query_balance

### DIFF
--- a/source/docs/casper/developers/cli/transfers/verify-transfer.md
+++ b/source/docs/casper/developers/cli/transfers/verify-transfer.md
@@ -105,7 +105,7 @@ casper-client get-state-root-hash --node-address [NODE_SERVER_ADDRESS]
   "jsonrpc": "2.0",
   "result": {
     "api_version": "1.4.13",
-    "state_root_hash": "a1f11692c5adc0e8b0a3f83e34d5831593a39ba03c8be73a0ebf7e9d9aadd76b"
+    "state_root_hash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
   }
 }
 ```
@@ -250,18 +250,22 @@ casper-client query-global-state \
 
 </details>
 
-## Get Purse Balance {#get-purse-balance}
+## Query Purse Balance {#get-purse-balance}
 
-All accounts on a Casper network have a purse associated with the Casper system mint, which we call the _main purse_. The balance associated with a given purse is recorded in global state, and the value can be queried using the `URef` associated with the purse.
+All accounts on a Casper network have a purse associated with the Casper system mint, which we call the _main purse_. The balance associated with a given purse is recorded in global state, and the value can be queried using the `query-balance` command and the purse identifier, which can be a public key or account hash, implying the main purse of the given account should be used. Alternatively, the purse's URef can be used. For full details, run the following help command:
+
+```bash
+casper-client query-balance --help
+```
 
 Now that we have the source purse address, we can verify its balance using the `get-balance` command:
 
 ```bash
-casper-client get-balance \
+casper-client query-balance \
 --id 6 \
 --node-address http://<node-ip-address>:7777 \
 --state-root-hash <state-root-hash> \
---purse-uref <source-account-purse-uref>
+--purse-identifier <source-account>
 ```
 
 **Request fields:**
@@ -269,22 +273,37 @@ casper-client get-balance \
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
 -   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
--   `purse-uref` - The URef under which the purse is stored, following the format "uref-<hex_value>".
+-   `purse-identifier` - A public key or account hash, implying the main purse of the given account should be used. Alternatively, the purse's URef.
+
+The `-v` option generates verbose output, printing the RPC request and response generated. Let's explore an example below.
+
+**Query Source Account Example:**
+
+```bash
+casper-client query-balance -v --id 6 \
+--node-address http://<node-ip-address>:7777 \
+--state-root-hash cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3 \
+--purse-identifier account-hash-b0049301811f23aab30260da66927f96bfae7b99a66eb2727da23bf1427a38f5
+```
 
 <details>
-<summary>Explore the JSON-RPC request and response generated.</summary>
+<summary>Explore the sample JSON-RPC request and response generated.</summary>
 
 **JSON-RPC Request**:
 
 ```json
 {
-    "id": 6,
-    "jsonrpc": "2.0",
-    "method": "state_get_balance",
-    "params": {
-        "purse_uref": "uref-6f4026262a505d5e1b0e03b1e3b7ab74a927f8f2868120cf1463813c19acb71e-007",
-        "state_root_hash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
+  "jsonrpc": "2.0",
+  "method": "query_balance",
+  "params": {
+    "state_identifier": {
+      "StateRootHash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
+    },
+    "purse_identifier": {
+       "main_purse_under_account_hash": "account-hash-b0049301811f23aab30260da66927f96bfae7b99a66eb2727da23bf1427a38f5"
     }
+  },
+  "id": 6
 }
 ```
 
@@ -292,42 +311,54 @@ casper-client get-balance \
 
 ```json
 {
-    "id": 6,
-    "jsonrpc": "2.0",
-    "result": {
-        "api_version": "1.0.0",
-        "balance_value": "5000000000",
-        "merkle_proof": "2502 chars"
-    }
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.5.2",
+    "balance": "164000000000"
+  },
+  "id": 6
 }
 ```
 
 </details>
 
-Similarly, we have the address of the target purse, so we can get its balance.
+Similarly, we have the public key of the target purse, so we can get its balance.
 
 ```bash    
 casper-client get-balance \
 --id 7 \
 --node-address http://<node-ip-address>:7777 \
 --state-root-hash <state-root-hash> \
---purse-uref <target-account-purse-uref>
+--purse-identifier <target-account>
+```
+
+**Target Account Example:**
+
+```bash
+casper-client query-balance -v --id 7 \
+--node-address http://<node-ip-address>:7777 \
+--state-root-hash cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3 \
+--purse-identifier account-hash-8ae68a6902ff3c029cea32bb67ae76b25d26329219e4c9ceb676745981fd3668
 ```
 
 <details>
-<summary>Explore the JSON-RPC request and response generated.</summary>
+<summary>Explore the sample JSON-RPC request and response generated.</summary>
 
 **JSON-RPC Request**:
 
 ```json
 {
-    "id": 7,
-    "jsonrpc": "2.0",
-    "method": "state_get_balance",
-    "params": {
-        "purse_uref": "uref-6f4026262a505d5e1b0e03b1e3b7ab74a927f8f2868120cf1463813c19acb71e-007",
-        "state_root_hash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
+  "jsonrpc": "2.0",
+  "method": "query_balance",
+  "params": {
+    "state_identifier": {
+      "StateRootHash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
+    },
+    "purse_identifier": {
+        "main_purse_under_account_hash": "account-hash-8ae68a6902ff3c029cea32bb67ae76b25d26329219e4c9ceb676745981fd3668"
     }
+  },
+  "id": 7
 }
 ```
 
@@ -335,13 +366,12 @@ casper-client get-balance \
 
 ```json
 {
-    "id": 7,
-    "jsonrpc": "2.0",
-    "result": {
-        "api_version": "1.0.0",
-        "balance_value": "5000000000",
-        "merkle_proof": "2502 chars"
-    }
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.5.2",
+    "balance": "5000000000"
+  },
+  "id": 7
 }
 ```
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -639,7 +639,7 @@ This method allows you to query for the balance of a purse using a `PurseIdentif
 
 This method allows for you to query for a value stored under certain keys in global state. You may query using either a [Block hash](../../concepts/design/casper-design.md#block_hash) or state root hash.
 
-* Note: Querying a purse's balance requires the use of `state_get_balance` or `query_balance`, rather than any iteration of `query_global_state`.
+* Note: Querying a purse's balance requires the use of `query_balance`, rather than any iteration of `query_global_state`.
 
 |Parameter|Type|Description|
 |---------|----|-----------|   
@@ -821,65 +821,6 @@ This method returns a JSON representation of an [Account](../../concepts/design/
       "named_keys": []
     },
     "api_version": "1.4.13",
-    "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
-  }
-}
-
-```
-
-</details>
-
-## state_get_balance {#state-get-balance}
-
-This method returns a purse's balance from a network. The request takes in the formatted representation of a purse URef as a parameter.
-
-To query for the balance of an Account, you must provide the formatted representation of the Account's main purse URef, which can be obtained from the  [`state_get_account_info`](#stategetaccountinfo-state-get-account-info) response. The response contains the balance of a purse in motes.
-
-For instance, one native layer-1 token of the Casper Mainnet [CSPR](../../concepts/glossary/C.md#cspr) is comprised of 1,000,000,000 motes. On a different Casper network, the representation of token-to-motes may differ.
-
-|Parameter|Type|Description|
-|---------|----|-----------|
-|[state_root_hash](types_chain.md#digest)|String|The hash of state root.|
-|purse_uref|String|Formatted URef.|
-
-<details>
-<summary>Example state_get_balance request</summary>
-
-```bash
-
-{
-  "id": 1,
-  "jsonrpc": "2.0",
-  "method": "state_get_balance",
-  "params": [
-    "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-    "0808080808080808080808080808080808080808080808080808080808080808"
-  ]
-}
-
-```
-
-</details>
-
-### `state_get_balance_result`
-
-|Parameter|Type|Description|
-|---------|----|-----------|
-|api_version|String|The RPC API version.|
-|[balance_value](types_chain.md#u512)|String|The balance value in motes.|
-|[merkle_proof](types_chain.md#merkle-proof)|String|The merkle proof.|
-
-<details>
-<summary>Example state_get_balance result</summary>
-
-```bash
-
-{
-  "id": 1,
-  "jsonrpc": "2.0",
-  "result": {
-    "api_version": "1.4.13",
-    "balance_value": "123456",
     "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
   }
 }

--- a/source/docs/casper/developers/json-rpc/minimal-compliance.md
+++ b/source/docs/casper/developers/json-rpc/minimal-compliance.md
@@ -8,11 +8,11 @@ The methods included in this document represent the most basic, fundamental endp
 
 * [`account_put_deploy`](./json-rpc-transactional.md#account-put-deploy) - This method allows users to send their compiled Wasm (as part of a Deploy) to a node on a Casper network. Deploys represent the only means by which a user can perform computation on the platform, without which their interaction with a Casper network will be entirely passive.
 
-* [`chain_get_state_root_hash`](./json-rpc-informational.md#chain-get-state-root-hash) - The state root hash is one of the several [global state identifiers](./types_chain.md#globalstateidentifier) used to query the network state after deployments, and the only way to do so in the context of `state_get_balance` and `state_get_dictionary_item`. A minimal SDK requires both dependent methods.
+* [`chain_get_state_root_hash`](./json-rpc-informational.md#chain-get-state-root-hash) - The state root hash is one of the several [global state identifiers](./types_chain.md#globalstateidentifier) used to query the network state after sending deploys.
 
 * [`state_get_account_info`](./json-rpc-informational.md#state-get-account-info) - This method returns a JSON representation of an Account from the network. `state_get_account_info` is required to view associated account information, including any associated keys, named keys, action thresholds and the main purse.
 
-* [`state_get_balance`](./json-rpc-informational.md#state-get-balance) - This method returns a purse's balance from a network. This is the only method to return a purse's balance in a human-readable format.
+* [`query_balance`](./json-rpc-informational.md#query-balance) - This method returns a purse's balance from a network. This is the only method to return a purse's balance in a human-readable format. The deprecated method `state_get_balance` should not be used.
 
 * [`state_get_dictionary_item`](./json-rpc-informational.md#state-get-dictionary-item) - This method returns an item from a Dictionary. Dictionaries represent a more efficient means of tracking large amounts of state.
 

--- a/source/docs/casper/developers/json-rpc/minimal-compliance.md
+++ b/source/docs/casper/developers/json-rpc/minimal-compliance.md
@@ -12,10 +12,16 @@ The methods included in this document represent the most basic, fundamental endp
 
 * [`state_get_account_info`](./json-rpc-informational.md#state-get-account-info) - This method returns a JSON representation of an Account from the network. `state_get_account_info` is required to view associated account information, including any associated keys, named keys, action thresholds and the main purse.
 
-* [`query_balance`](./json-rpc-informational.md#query-balance) - This method returns a purse's balance from a network. This is the only method to return a purse's balance in a human-readable format. The deprecated method `state_get_balance` should not be used.
+* [`query_balance`](./json-rpc-informational.md#query-balance) - This method returns a purse's balance from a network. This is the only method to return a purse's balance in a human-readable format.
 
 * [`state_get_dictionary_item`](./json-rpc-informational.md#state-get-dictionary-item) - This method returns an item from a Dictionary. Dictionaries represent a more efficient means of tracking large amounts of state.
 
 * [`query_global_state`](./json-rpc-informational.md#query-global-state) - This method allows for querying values stored under certain keys in global state. Aside from purse balances, this is the main means of recovering stored data from a Casper network.
+
+:::note
+
+The deprecated method `state_get_balance` should not be used.
+
+:::
 
 In addition to these methods, a minimally compliant Casper SDK must account for the [types](./types_chain.md) associated with each method. Each method above links to the expanded information available within the larger JSON RPC method pages, which includes the necessary associated types.

--- a/source/docs/casper/resources/beginner/querying-network.md
+++ b/source/docs/casper/resources/beginner/querying-network.md
@@ -87,21 +87,33 @@ casper-client query-global-state \
 
 -   `"result"."stored_value"."Account"."main_purse"` - the address of the main purse containing the sender's tokens. This purse is the source of the tokens transferred in this example
 
+**Example Account Query with Verbose Output:**
+
+```bash
+casper-client query-global-state -v \
+  --id 4 \
+  --node-address https://rpc.testnet.casperlabs.io/ \
+  --state-root-hash a306a9cf869e52fe9eacdc28aade94215112cc04b6737b3669c35568a47a7dc2 \
+  --key 01360af61b50cdcb7b92cffe2c99315d413d34ef77fadee0c105cc4f1d4120f986
+```
+
 <details>
-<summary>Explore the JSON-RPC request and response generated.</summary>
+<summary>Explore the sample JSON-RPC request and response generated.</summary>
 
 **JSON-RPC Request**:
 
 ```json
 {
-    "id": 4,
-    "jsonrpc": "2.0",
-    "method": "state_get_item",
-    "params": {
-        "key": "account-hash-b0049301811f23aab30260da66927f96bfae7b99a66eb2727da23bf1427a38f5",
-        "path": [],
-        "state_root_hash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
-    }
+  "jsonrpc": "2.0",
+  "method": "query_global_state",
+  "params": {
+    "state_identifier": {
+      "StateRootHash": "a306a9cf869e52fe9eacdc28aade94215112cc04b6737b3669c35568a47a7dc2"
+    },
+    "key": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
+    "path": []
+  },
+  "id": 4
 }
 ```
 
@@ -109,42 +121,88 @@ casper-client query-global-state \
 
 ```json
 {
-    "id": 4,
-    "jsonrpc": "2.0",
-    "result": {
-        "api_version": "1.0.0",
-        "merkle_proof": "2228 chars",
-        "stored_value": {
-            "Account": {
-                "account_hash": "account-hash-b0049301811f23aab30260da66927f96bfae7b99a66eb2727da23bf1427a38f5",
-                "action_thresholds": {
-                    "deployment": 1,
-                    "key_management": 1
-                },
-                "associated_keys": [
-                    {
-                        "account_hash": "account-hash-b0049301811f23aab30260da66927f96bfae7b99a66eb2727da23bf1427a38f5",
-                        "weight": 1
-                    }
-                ],
-                "main_purse": "uref-9e90f4bbd8f581816e305eb7ea2250ca84c96e43e8735e6aca133e7563c6f527-007",
-                "named_keys": []
-            }
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "api_version": "1.5.2",
+    "block_header": null,
+    "stored_value": {
+      "Account": {
+        "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
+        "named_keys": [
+          {
+            "name": "counter",
+            "key": "hash-4bf23564c8849a0a3193781f0a9df7d27c4bce2cc585d6e9bb161a7a1ce5cd7e"
+          },
+          {
+            "name": "counter_access_uref",
+            "key": "uref-76b6c7e7a87b752d34a8c3ccdc070dbfd1940960016c537525b2ab9076b61a3e-007"
+          },
+          {
+            "name": "counter_package_name",
+            "key": "hash-e4b2060f098fa763f9a68c5c98a2d98a4fa80815ec0fd6b93ac9efbb0c18f19b"
+          },
+          {
+            "name": "my-key-name",
+            "key": "uref-09376d4202d32457ceefa4d9cdf1db6ab2324981ade06ba6f495cdf14124c3b9-007"
+          },
+          {
+            "name": "version",
+            "key": "uref-244a270207dd13ef5ff190f75d84efe4ab54bd5787be0bbb175c3fb154b7f5ed-007"
+          }
+        ],
+        "main_purse": "uref-8294864177c2c1ec887a11dae095e487b5256ce6bd2a1f2740d0e4f28bd3251c-007",
+        "associated_keys": [
+          {
+            "account_hash": "account-hash-0ea7998b2822afe5b62b08a21d54c941ad791279b089f3f7ede0d72b477eca34",
+            "weight": 1
+          },
+          {
+            "account_hash": "account-hash-1ed5a1c39bea93c105f2d22c965a84b205b36734a377d05dbb103b6bfaa595a7",
+            "weight": 3
+          },
+          {
+            "account_hash": "account-hash-77ea2e433c94c9cb8303942335da458672249d38c1fa5d1d7a7500b862ff52a4",
+            "weight": 1
+          },
+          {
+            "account_hash": "account-hash-d65d053f5017af101b752a9a12ba4c41fe3054b8632998a69193b891eab4caf5",
+            "weight": 1
+          },
+          {
+            "account_hash": "account-hash-e70dbca48c2d31bc2d754e51860ceaa8a1a49dc627b20320b0ecee1b6d9ce655",
+            "weight": 1
+          },
+          {
+            "account_hash": "account-hash-f1802d2dbd83e41f638eb9b046f762e481d56b27d4aa00817fec77fbb21f944a",
+            "weight": 1
+          }
+        ],
+        "action_thresholds": {
+          "deployment": 2,
+          "key_management": 3
         }
-    }
+      }
+    },
+    "merkle_proof": "[32054 hex chars]"
+  }
 }
 ```
 
 </details>
 
-You can use the URef of the `main_purse` to query the account balance. The balance returned is in motes (the unit that makes up the Casper token).
+To query the account balance, use the `query-balance` command and the purse identifier, which can be a public key or account hash, implying the main purse of the given account should be used. Alternatively, the purse's URef can be used. The balance returned is in motes (the unit that makes up the Casper token). For full details, run the following help command:
 
 ```bash
-casper-client get-balance \
-      --id 6 \
-      --node-address http://<node-ip-address>:7777 \
-      --state-root-hash <state-root-hash> \
-      --purse-uref <source-account-purse-uref>
+casper-client query-balance --help
+```
+
+```bash
+casper-client query-balance \
+--id 6 \
+--node-address http://<node-ip-address>:7777 \
+--state-root-hash <state-root-hash> \
+--purse-identifier <account>
 ```
 
 **Request fields:**
@@ -152,7 +210,19 @@ casper-client get-balance \
 -   `id` - Optional JSON-RPC identifier applied to the request and returned in the response. If not provided, a random integer will be assigned
 -   `node-address` - An IP address of a node on the network
 -   `state-root-hash` - Hex-encoded hash of the state root
--   `purse-uref` - The URef under which the purse is stored. This must be a properly formatted URef "uref-\-"
+-   `purse-identifier` - A public key or account hash, implying the main purse of the given account should be used. Alternatively, the purse's URef.
+
+The `-v` option generates verbose output, printing the RPC request and response generated. Let's explore an example below.
+
+**Example Balance Query with Verbose Output:**
+
+```bash
+casper-client query-balance -v \
+  --id 6 \
+  --node-address https://rpc.testnet.casperlabs.io/ \
+  --state-root-hash a306a9cf869e52fe9eacdc28aade94215112cc04b6737b3669c35568a47a7dc2 \
+  --purse-identifier 01360af61b50cdcb7b92cffe2c99315d413d34ef77fadee0c105cc4f1d4120f986
+```
 
 <details>
 <summary>Explore the JSON-RPC request and response generated.</summary>
@@ -161,13 +231,17 @@ casper-client get-balance \
 
 ```json
 {
-    "id": 6,
-    "jsonrpc": "2.0",
-    "method": "state_get_balance",
-    "params": {
-        "purse_uref": "uref-6f4026262a505d5e1b0e03b1e3b7ab74a927f8f2868120cf1463813c19acb71e-007",
-        "state_root_hash": "cfdbf775b6671de3787cfb1f62f0c5319605a7c1711d6ece4660b37e57e81aa3"
+  "jsonrpc": "2.0",
+  "method": "query_balance",
+  "params": {
+    "state_identifier": {
+      "StateRootHash": "a306a9cf869e52fe9eacdc28aade94215112cc04b6737b3669c35568a47a7dc2"
+    },
+    "purse_identifier": {
+      "main_purse_under_public_key": "01360af61b50cdcb7b92cffe2c99315d413d34ef77fadee0c105cc4f1d4120f986"
     }
+  },
+  "id": 6
 }
 ```
 
@@ -175,13 +249,12 @@ casper-client get-balance \
 
 ```json
 {
-    "id": 6,
-    "jsonrpc": "2.0",
-    "result": {
-        "api_version": "1.0.0",
-        "balance_value": "5000000000",
-        "merkle_proof": "2502 chars"
-    }
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.5.2",
+    "balance": "164000000000"
+  },
+  "id": 6
 }
 ```
 


### PR DESCRIPTION
### What does this PR fix/introduce?
Removing the "state_get_balance" documentation and examples, since it has been deprecated in favor of "query_balance".

- The examples in `querying-network.md` are the actual commands and responses.
- The examples in `verify-transfer.md` are taken from `querying-network.md`, but have been modified to fit the tutorial (using the same account hashes and state root hash, to match the transfer flow). Eventually, we need to refresh the entire tutorial with fresh examples.
- In `minimal-compliance.md`, I found the following explanation confusing, so I'd like to simplify it by removing the crossed-out section. If it adds value to this point, please let me know.
[`chain_get_state_root_hash`](./json-rpc-informational.md#chain-get-state-root-hash) - The state root hash is one of the several [global state identifiers](./types_chain.md#globalstateidentifier) used to query the network state after deployments, ~and the only way to do so in the context of `state_get_balance` and `state_get_dictionary_item`. A minimal SDK requires both dependent methods.~

Closes #1253 

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ACStoneCL 