### PR TITLE
Restore font styles for headings and menu items

### DIFF
--- a/src/assets/scss/_global.scss
+++ b/src/assets/scss/_global.scss
@@ -236,3 +236,51 @@ html {
         font-size: 26px;
     }
 }
+
+// Fix for low readability.
+// See: https://github.com/casper-network/docs/issues/1287.
+//
+.main-wrapper {
+    font: var(--ifm-font-size-base)/var(--ifm-line-height-base) var(--ifm-font-family-base);
+
+    h1, h2, h3, h4, h5, h6 {
+        font-family: var(--ifm-heading-font-family);
+        font-weight: var(--ifm-heading-font-weight);
+        line-height: var(--ifm-heading-line-height);
+    }
+
+    h1 {
+        font-size: var(--ifm-h1-font-size)
+    }
+
+    h2 {
+        font-size: var(--ifm-h2-font-size)
+    }
+
+    h3 {
+        font-size: var(--ifm-h3-font-size)
+    }
+
+    h4 {
+        font-size: var(--ifm-h4-font-size)
+    }
+
+    h5 {
+        font-size: var(--ifm-h5-font-size)
+    }
+
+    h6 {
+        font-size: var(--ifm-h6-font-size)
+    }
+
+    .menu__list {
+        .menu__link {
+            font-size: inherit !important;
+        }
+
+        .menu__link--sublist {
+            letter-spacing: inherit !important;
+            font-size: inherit !important;
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR fix/introduce?

Workaround to restore default's Docusaurus font styles, for better readability:

![xxx](https://github.com/casper-network/docs/assets/121791569/59c1c881-b071-4dd0-bb0d-dc96c3fa7b4a)


Closes #1287.
