### PR TITLE
Limit CI/CD push trigger to `dev` branch only.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,8 @@ env:
 
 on:
   push:
-    branches: "*"
+    branches:
+      - dev
   pull_request:
     types: [ opened, reopened, synchronize ]
 


### PR DESCRIPTION
### What does this PR address?

- Reduces duplicated CI/CD checks.
- Prevents pipelines from running on arbitrary branches.

Closes #1290.
