### PR TITLE
specify number of real cores and threads per core

### DIFF
--- a/source/docs/casper/operators/aws-nodes/3-instances.md
+++ b/source/docs/casper/operators/aws-nodes/3-instances.md
@@ -11,7 +11,9 @@ The following requirements describe the optimal EC2 Instance for running a Caspe
 | O.S.         | Ubuntu 20.04 LTS     |
 | RAM          | 32 GB                |
 | Disk Space   | 2 TB                 |
-| CPU Cores    | 8                    |
+| vCPU Cores   | 8                    |
+| CPU Cores    | 4                    |
+| Threads per Core | 2                |
 | AMI          | ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211129 |
 | AMI_Type     | t3.2xlarge           |
 


### PR DESCRIPTION
### What does this PR fix/introduce?
Taking into account that on AWS one must consider not only the instance's CPUs but also their equivalence to the vCPUs (virtual CPUs) offered by Amazon instances, the table specifies the equivalent for the recommended instance (t3.2xlarge).

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@bradjohnl @ipopescu 
