### PR TITLE
1315 Adding Casper Token Standard Docs to Main Site

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -322,6 +322,7 @@ module.exports = {
                         "resources/tokens/cep78/modalities",
                         "resources/tokens/cep78/using-casper-client",
                         "resources/tokens/cep78/reverse-lookup",
+                        "resources/tokens/cep78/js-tutorial",
                     ],
                 },
             ],

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -281,6 +281,51 @@ module.exports = {
         "resources/index",
         "resources/build-on-casper",
         "resources/moving-to-casper",
+        {
+            type: "category",
+            label: "Casper Token Standards",
+            collapsible: true,
+            collapsed: true,
+            link: {
+                type: "doc",
+                id: "resources/tokens/index",
+            },
+            items: [
+                {
+                    type: "category",
+                    label: "CEP-18 Fungible Token",
+                    collapsible: true,
+                    collapsed: true,
+                    className: "text_transform_reset",
+                    link: {
+                        type: "doc",
+                        id: "resources/tokens/cep18/full-tutorial",
+                    },
+                    items: ["resources/tokens/cep18/full-tutorial",
+                            "resources/tokens/cep18/quickstart-guide",
+                            "resources/tokens/cep18/query",
+                            "resources/tokens/cep18/transfer",
+                            "resources/tokens/cep18/tests",
+                    ],
+                },
+                {
+                    type: "category",
+                    label: "CEP-78 Enhanced NFT Standard",
+                    collapsible: true,
+                    collapsed: true,
+                    link: {
+                        type: "doc",
+                        id: "resources/tokens/cep78/introduction",
+                    },
+                    items: [
+                        "resources/tokens/cep78/introduction",
+                        "resources/tokens/cep78/modalities",
+                        "resources/tokens/cep78/using-casper-client",
+                        "resources/tokens/cep78/reverse-lookup",
+                    ],
+                },
+            ],
+        },
         "resources/casper-open-source-software",
         "resources/quick-start",
         //"resources/sample-projects", // NEW CONTENT WILL BE HERE

--- a/source/docs/casper/resources/tokens/cep18/full-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep18/full-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: Casper Fungible Token Tutorial
+title: Fungible Token Workflow
 slug: /resources/tokens/cep18/full-tutorial
 ---
 
@@ -15,42 +15,7 @@ The following functions implement the rules defined by Casper Fungible Tokens: `
 
 The [Writing Rust Contracts on Casper](/developers/writing-onchain-code/simple-contract/) document outlines many aspects of this tutorial and should be read first.
 
-# Table of Contents
-
-1. [Preparation](#preparation)
-
-2. [Contract Implementation](#contract-implementation)
-
-   a. [Installing the Required Crates](#installing-required-crates-installing-crates)
-
-   b. [Initializing the Contract](#initializing-the-contract-initializing-the-contract)
-
-   c. [Contract Methods](#contract-methods-contract-methods)
-
-3. [Installing the Contract](#installing-the-contract)
-
-   a. [Deploy Prerequisites](#deploy-prerequisites-deploy-prerequisites)
-
-   b. [Basic Flow](#basic-flow-basic-flow)
-
-   c. [Cloning the Token Contract](#cloning-the-token-contract-cloning-the-token-contract)
-
-   d. [Getting an IP Address from a Testnet Peer](#getting-an-ip-address-from-a-testnet-peer)
-
-   e. [Viewing the Network Status](#viewing-the-network-status)
-
-   f. [Installing the Contract](#installing-the-contract-deploying-the-contract)
-
-   g. [Querying the Network Status](#querying-the-network-status-querying-the-network-status)
-
-   h. [Verifying the Deploy](#verifying-the-deploy-verifying-the-deploy)
-
-   i. [Querying with Arguments](#querying-with-arguments-querying-with-arguments)
-
-   j. [Sample Deploy on Testnet](#example-deploy-on-testnet-sample-deploy-testnet)
-
-
-# Preparation
+## Preparation
 
 First clone the contract from GitHub:
 
@@ -80,7 +45,7 @@ make build-contract
 make test
 ```
 
-# Contract Implementation
+## Contract Implementation
 
 In [GitHub](https://github.com/casper-ecosystem/cep18), you will find a library and an [example implementation](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) of the Fungible Token for Casper networks. This section explains the example contract in more detail.
 
@@ -91,7 +56,7 @@ There are four steps to follow when you intend to create your own implementation
 3.  Compile the customized code to Wasm.
 4.  Send the customized Wasm as a deploy to a Casper network.
 
-## Installing Required Crates {#installing-crates}
+### Installing Required Crates {#installing-crates}
 
 This tutorial applies to the Rust implementation of the Casper Fungible Token standard, and requires the following Casper crates:
 
@@ -111,7 +76,7 @@ use casper_types::{CLValue, U256};
 
 **Note**: In Rust, the keyword `use` is like an include statement in C/C++.
 
-## Initializing the Contract {#initializing-the-contract}
+### Initializing the Contract {#initializing-the-contract}
 
 Initializing the contract happens through the `call()` function inside the [contract file](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs). When you deploy the contract, you need to initialize it with a `call()` function and define `name`, `symbol`, `decimals`, and `total_supply`.
 
@@ -131,7 +96,7 @@ fn call() {
 
 ```
 
-## Contract Methods {#contract-methods}
+### Contract Methods {#contract-methods}
 
 This section briefly explains the contract methods used in the Casper Fungible Token contract.
 
@@ -156,18 +121,18 @@ Contract methods are:
 - [**transfer**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L140) - Transfers an amount of tokens from the direct caller to a recipient
 - [**transfer_from**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L155) - Transfers an amount of tokens from the owner to a recipient, if the direct caller has been previously approved to spend the specified amount on behalf of the owner
 
-# Installing the Contract
+## Installing the Contract
 
 After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](/developers/cli/sending-deploys/) section to learn more about install contracts.
 
-## Deploy Prerequisites {#deploy-prerequisites}
+### Deploy Prerequisites {#deploy-prerequisites}
 
 - Set up your machine as per the [prerequisites](/developers/prerequisites/)
 - Ensure you have [set up an account](/concepts/accounts-and-keys/#creating-accounts-and-keys) with a public and secret key pair to initiate the deploy
 - Since we are deploying to the Casper Testnet, ensure your [Testnet faucet account](https://testnet.cspr.live/tools/faucet) contains enough CSPR tokens to perform the contract execution. Follow the guide to [fund your account](/developers/prerequisites/#fund-your-account) or to [transfer tokens](/developers/cli/transfers/) as needed
 - Install the [Casper command-line client](/developers/prerequisites/#install-casper-client) to interact with the network
 
-## Basic Flow {#basic-flow}
+### Basic Flow {#basic-flow}
 
 Here are the basic steps to install the Casper Fungible Token contract on a Casper Network.
 
@@ -177,7 +142,7 @@ Here are the basic steps to install the Casper Fungible Token contract on a Casp
 - [Install the contract via a deploy](#installing-the-contract-deploying-the-contract)
 - [View the network state](#querying-the-network-status-querying-the-network-status)
 
-## Cloning the Token Contract {#cloning-the-token-contract}
+### Cloning the Token Contract {#cloning-the-token-contract}
 
 This step includes cloning and preparing the token contract for the deployment.
 
@@ -209,11 +174,11 @@ make test
 
 ```
 
-## Getting an IP Address from a Testnet Peer {#getting-an-ip-address}
+### Getting an IP Address from a Testnet Peer {#getting-an-ip-address}
 
 We will use a Testnet [peer](https://testnet.cspr.live/tools/peers) to send the deploy. Read the guide to [acquiring a node address](/developers/prerequisites/#acquire-node-address-from-network-peers) if needed.
 
-## Viewing the Network Status {#viewing-network-status}
+### Viewing the Network Status {#viewing-network-status}
 
 This query captures any information related to the state of the blockchain at the specific time denoted by the network's state root hash. You need to have the state root hash and the account hash to run the query.
 
@@ -244,7 +209,7 @@ casper-client query-global-state \
 --key [ACCOUNT_HASH]
 ```
 
-## Installing the Contract {#deploying-the-contract}
+### Installing the Contract {#deploying-the-contract}
 
 Now you can install the contract to the network and check how it behaves.
 
@@ -281,11 +246,11 @@ casper-client put-deploy \
 --session-arg "name='Token test', symbol='TEST', decimals:u8=10, total_supply:u256=1000"
 ```
 
-## Querying the Network Status {#querying-the-network-status}
+### Querying the Network Status {#querying-the-network-status}
 
 You will need the newest state root hash to view the network status, as it changed with the deploy. The account hash remains the same since you are using the same account. Follow the [viewing the network state](#viewing-the-network-status) section to execute this step with the new state root hash.
 
-## Verifying the Deploy {#verifying-the-deploy}
+### Verifying the Deploy {#verifying-the-deploy}
 
 Now you can verify the sent deploy using the `get-deploy` command. This will output the details of the sent deploy.
 
@@ -294,7 +259,7 @@ casper-client get-deploy \
 --node-address http://<HOST:PORT> [DEPLOY_HASH]
 ```
 
-## Querying with Arguments {#querying-with-arguments}
+### Querying with Arguments {#querying-with-arguments}
 
 This step will narrow down the context and check the status of a specific entry point. You will use the details inside the [Fungible Token contract](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) to derive arguments.
 
@@ -308,11 +273,11 @@ casper-client query-global-state \
 -q "[CONTRACT_NAME/ARGUMENT]"
 ```
 
-## Example Deploy on Testnet {#sample-deploy-testnet}
+### Example Deploy on Testnet {#sample-deploy-testnet}
 
 The following steps will guide you through the process with sample values and results.
 
-### Cloning the Fungible Token Contract
+#### Cloning the Fungible Token Contract
 
 ```bash
 git clone https://github.com/casper-ecosystem/cep18.git
@@ -322,7 +287,7 @@ git clone https://github.com/casper-ecosystem/cep18.git
 
 Use [peers](https://testnet.cspr.live/tools/peers) to get the node IP address.
 
-### Viewing the Network Status
+#### Viewing the Network Status
 
 Here is the command to query the state of the network:
 
@@ -371,7 +336,7 @@ This result contains the network state before the deploy. You can see the `named
 </details>
 <br></br>
 
-### Sending the Deploy
+#### Sending the Deploy
 
 Send the Deploy containing your contract with this command:
 
@@ -400,7 +365,7 @@ This command execution will output the `deploy_hash` of the applied deploy. We c
 }
 ```
 
-### Viewing the Deploy Details
+#### Viewing the Deploy Details
 
 You can view the details of the sent deploy using the command below:
 
@@ -781,7 +746,7 @@ This contains the header, payment, and session details along with the execution 
 </details>
 <br></br>
 
-### Querying Contract Entry Points
+#### Querying Contract Entry Points
 
 We will query the argument 'name' in this example.
 

--- a/source/docs/casper/resources/tokens/cep18/full-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep18/full-tutorial.md
@@ -13,7 +13,7 @@ The Casper Fungible Token standard is the Casper Platform's ER-C20 equivalent. I
 
 The following functions implement the rules defined by Casper Fungible Tokens: `totalSupply`, `transfer`, `transferFrom`, `approve`, `balanceOf`, and `allowance`. A portion of this tutorial reviews the [contract](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) and the [casper_fungible_token](https://docs.rs/casper-erc20-crate/latest/casper_erc20_crate/) library.
 
-The [Writing Rust Contracts on Casper](../developers/writing-onchain-code/simple-contract/) document outlines many aspects of this tutorial and should be read first.
+The [Writing Rust Contracts on Casper](/developers/writing-onchain-code/simple-contract/) document outlines many aspects of this tutorial and should be read first.
 
 # Table of Contents
 
@@ -71,7 +71,7 @@ rustup target add wasm32-unknown-unknown
 info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
 ```
 
-If you do not see this message, check the [Getting Started Guide](../developers/writing-onchain-code/getting-started/).
+If you do not see this message, check the [Getting Started Guide](/developers/writing-onchain-code/getting-started/).
 
 Next, compile your contract and run the contract unit tests.
 
@@ -158,14 +158,14 @@ Contract methods are:
 
 # Installing the Contract
 
-After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](../developers/dapps/sending-deploys/) section to learn more about install contracts.
+After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](/developers/dapps/sending-deploys/) section to learn more about install contracts.
 
 ## Deploy Prerequisites {#deploy-prerequisites}
 
-- Set up your machine as per the [prerequisites](../developers/prerequisites/)
-- Ensure you have [set up an account](../concepts/accounts-and-keys/#creating-accounts-and-keys) with a public and secret key pair to initiate the deploy
-- Since we are deploying to the Casper Testnet, ensure your [Testnet faucet account](https://testnet.cspr.live/tools/faucet) contains enough CSPR tokens to perform the contract execution. Follow the guide to [fund your account](../developers/prerequisites/#fund-your-account) or to [transfer tokens](../developers/cli/transfers/) as needed
-- Install the [Casper command-line client](../developers/prerequisites/#install-casper-client) to interact with the network
+- Set up your machine as per the [prerequisites](/developers/prerequisites/)
+- Ensure you have [set up an account](/concepts/accounts-and-keys/#creating-accounts-and-keys) with a public and secret key pair to initiate the deploy
+- Since we are deploying to the Casper Testnet, ensure your [Testnet faucet account](https://testnet.cspr.live/tools/faucet) contains enough CSPR tokens to perform the contract execution. Follow the guide to [fund your account](/developers/prerequisites/#fund-your-account) or to [transfer tokens](/developers/cli/transfers/) as needed
+- Install the [Casper command-line client](/developers/prerequisites/#install-casper-client) to interact with the network
 
 ## Basic Flow {#basic-flow}
 
@@ -211,7 +211,7 @@ make test
 
 ## Getting an IP Address from a Testnet Peer {#getting-an-ip-address}
 
-We will use a Testnet [peer](https://testnet.cspr.live/tools/peers) to send the deploy. Read the guide to [acquiring a node address](../developers/prerequisites/#acquire-node-address-from-network-peers) if needed.
+We will use a Testnet [peer](https://testnet.cspr.live/tools/peers) to send the deploy. Read the guide to [acquiring a node address](/developers/prerequisites/#acquire-node-address-from-network-peers) if needed.
 
 ## Viewing the Network Status {#viewing-network-status}
 
@@ -219,7 +219,7 @@ This query captures any information related to the state of the blockchain at th
 
 **Getting the state root hash**
 
-Get the state root hash, which marks a snapshot of the network state at a moment in time. Use the [Node IP address](../developers/prerequisites/#acquire-node-address-from-network-peers) taken from a Testnet peer.
+Get the state root hash, which marks a snapshot of the network state at a moment in time. Use the [Node IP address](/developers/prerequisites/#acquire-node-address-from-network-peers) taken from a Testnet peer.
 
 ```bash
 casper-client get-state-root-hash --node-address http://<HOST:PORT>
@@ -248,9 +248,9 @@ casper-client query-global-state \
 
 Now you can install the contract to the network and check how it behaves.
 
-If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](../developers/dapps/sending-deploys/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
+If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](/developers/dapps/sending-deploys/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
 
-**The Casper platform currently does not refund any tokens as part of sending a deploy.** For example, if you spend 10 CSPR for the deployment and it only costs 1 CSPR, you will not receive the remaining 9 CSPR. Refer to the [Gas and the Casper Blockchain](../concepts/economics/gas-concepts/) documentation for further details.
+**The Casper platform currently does not refund any tokens as part of sending a deploy.** For example, if you spend 10 CSPR for the deployment and it only costs 1 CSPR, you will not receive the remaining 9 CSPR. Refer to the [Gas and the Casper Blockchain](/concepts/economics/gas-concepts/) documentation for further details.
 
 Use the following command template to deploy the contract:
 

--- a/source/docs/casper/resources/tokens/cep18/full-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep18/full-tutorial.md
@@ -158,7 +158,7 @@ Contract methods are:
 
 # Installing the Contract
 
-After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](/developers/dapps/cli/sending-deploys/) section to learn more about install contracts.
+After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](/developers/cli/sending-deploys/) section to learn more about install contracts.
 
 ## Deploy Prerequisites {#deploy-prerequisites}
 
@@ -248,7 +248,7 @@ casper-client query-global-state \
 
 Now you can install the contract to the network and check how it behaves.
 
-If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](/developers/dapps/cli/sending-deploys/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
+If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](/developers/cli/sending-deploys/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
 
 **The Casper platform currently does not refund any tokens as part of sending a deploy.** For example, if you spend 10 CSPR for the deployment and it only costs 1 CSPR, you will not receive the remaining 9 CSPR. Refer to the [Gas and the Casper Blockchain](/concepts/economics/gas-concepts/) documentation for further details.
 

--- a/source/docs/casper/resources/tokens/cep18/full-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep18/full-tutorial.md
@@ -1,0 +1,817 @@
+---
+title: Casper Fungible Token Tutorial
+slug: /resources/tokens/cep18/full-tutorial
+---
+
+# Casper Fungible Token Tutorial
+
+This tutorial introduces an implementation of the CEP-18 standard for the Casper blockchain, known as the Casper Fungible Token. The code for this tutorial is available in [GitHub](https://github.com/casper-ecosystem/cep18).
+
+The [Ethereum Request for Comment (ERC-20)](https://eips.ethereum.org/EIPS/eip-20#specification) standard is an integral part of the Ethereum ecosystem. This standard allows for building new tokens based on smart contracts. These ERC-20 tokens are blockchain-based assets that have value and can be transferred or recorded.
+
+The Casper Fungible Token standard is the Casper Platform's ER-C20 equivalent. It defines a set of rules that dictate the total supply of tokens, how the tokens are transferred, how transactions are approved, and how token data is accessed.
+
+The following functions implement the rules defined by Casper Fungible Tokens: `totalSupply`, `transfer`, `transferFrom`, `approve`, `balanceOf`, and `allowance`. A portion of this tutorial reviews the [contract](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) and the [casper_fungible_token](https://docs.rs/casper-erc20-crate/latest/casper_erc20_crate/) library.
+
+The [Writing Rust Contracts on Casper](../developers/writing-onchain-code/simple-contract/) document outlines many aspects of this tutorial and should be read first.
+
+# Table of Contents
+
+1. [Preparation](#preparation)
+
+2. [Contract Implementation](#contract-implementation)
+
+   a. [Installing the Required Crates](#installing-required-crates-installing-crates)
+
+   b. [Initializing the Contract](#initializing-the-contract-initializing-the-contract)
+
+   c. [Contract Methods](#contract-methods-contract-methods)
+
+3. [Installing the Contract](#installing-the-contract)
+
+   a. [Deploy Prerequisites](#deploy-prerequisites-deploy-prerequisites)
+
+   b. [Basic Flow](#basic-flow-basic-flow)
+
+   c. [Cloning the Token Contract](#cloning-the-token-contract-cloning-the-token-contract)
+
+   d. [Getting an IP Address from a Testnet Peer](#getting-an-ip-address-from-a-testnet-peer)
+
+   e. [Viewing the Network Status](#viewing-the-network-status)
+
+   f. [Installing the Contract](#installing-the-contract-deploying-the-contract)
+
+   g. [Querying the Network Status](#querying-the-network-status-querying-the-network-status)
+
+   h. [Verifying the Deploy](#verifying-the-deploy-verifying-the-deploy)
+
+   i. [Querying with Arguments](#querying-with-arguments-querying-with-arguments)
+
+   j. [Sample Deploy on Testnet](#example-deploy-on-testnet-sample-deploy-testnet)
+
+
+# Preparation
+
+First clone the contract from GitHub:
+
+```bash
+git clone https://github.com/casper-ecosystem/cep18 && cd cep18
+```
+
+Prepare your environment with the following command:
+
+```bash
+make prepare
+```
+
+If your environment is set up correctly, you will see this output:
+
+```bash
+rustup target add wasm32-unknown-unknown
+info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
+```
+
+If you do not see this message, check the [Getting Started Guide](../developers/writing-onchain-code/getting-started/).
+
+Next, compile your contract and run the contract unit tests.
+
+```bash
+make build-contract
+make test
+```
+
+# Contract Implementation
+
+In [GitHub](https://github.com/casper-ecosystem/cep18), you will find a library and an [example implementation](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) of the Fungible Token for Casper networks. This section explains the example contract in more detail.
+
+There are four steps to follow when you intend to create your own implementation of the Fungible Token contract, as follows:
+
+1.  Fork the code from the example repository listed above.
+2.  Perform any customization changes necessary on your personal fork of the example contract.
+3.  Compile the customized code to Wasm.
+4.  Send the customized Wasm as a deploy to a Casper network.
+
+## Installing Required Crates {#installing-crates}
+
+This tutorial applies to the Rust implementation of the Casper Fungible Token standard, and requires the following Casper crates:
+
+- [casper_contract](https://docs.rs/casper-contract/latest/casper_contract/index.html) - A Rust library for writing smart contracts on Casper networks
+- [casper_types](https://docs.rs/casper-types/latest/casper_types/) - Types used to allow creation of Wasm contracts and tests for use on Casper networks
+- [casper_erc20](https://docs.rs/casper-erc20-crate/latest/casper_erc20_crate/) - A library for developing Fungible Tokens for Casper networks
+
+Here is the code snippet which imports those crates:
+
+```rust
+
+use casper_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
+
+use casper_types::{CLValue, U256};
+
+```
+
+**Note**: In Rust, the keyword `use` is like an include statement in C/C++.
+
+## Initializing the Contract {#initializing-the-contract}
+
+Initializing the contract happens through the `call()` function inside the [contract file](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs). When you deploy the contract, you need to initialize it with a `call()` function and define `name`, `symbol`, `decimals`, and `total_supply`.
+
+The code snippet for initializing the contract should look like this:
+
+```rust
+
+#[no_mangle]
+fn call() {
+  let name: String = runtime::get_named_arg(NAME_RUNTIME_ARG_NAME);
+  let symbol: String = runtime::get_named_arg(SYMBOL_RUNTIME_ARG_NAME);
+  let decimals = runtime::get_named_arg(DECIMALS_RUNTIME_ARG_NAME);
+  let total_supply = runtime::get_named_arg(TOTAL_SUPPLY_RUNTIME_ARG_NAME);
+
+  let _token = CEP18::install(name, symbol, decimals, total_supply).unwrap_or_revert();
+}
+
+```
+
+## Contract Methods {#contract-methods}
+
+This section briefly explains the contract methods used in the Casper Fungible Token contract.
+
+To see the full implementation of the below contract methods, refer to the [contract file](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) in Github. If you have any questions, review the [casper_erc20](https://docs.rs/casper-erc20-crate/latest/casper_erc20_crate/) library and the [EIP-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md#) standard.
+
+Also, for further unresolved issues please contact the Casper support team via the [Discord channel](https://discord.com/invite/Q38s3Vh).
+
+Contract methods are:
+
+- [**allowance**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L83) - Returns the amount of owner’s tokens allowed to be spent by the spender
+- [**approve**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L92) - Allows a spender to transfer up to an amount of the direct caller’s tokens
+- [**balance_of**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L75) - Returns the token balance of the owner
+- [**burn**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L220) - Burns tokens, reducing the total supply.
+- [**change_security**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L331) - An administrator-level entry point to manipulate security access granted to users
+- [**decimals**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L65) - Returns the decimals of the token
+- [**decrease_allowance**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L106) - Decrease the allotted allowance for an account approved to spend from an owner's token balance
+- [**increase_allowance**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L123) - Increases the allotted allowance for an account approved to spend from an owner's token balance
+- [**mint**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L182) - Mints additional tokens, increasing the total supply
+- [**name**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L55)- Returns the name of the token
+- [**symbol**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L60) - Returns the symbol of the token
+- [**total_supply**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L70) - Returns the total supply of the token
+- [**transfer**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L140) - Transfers an amount of tokens from the direct caller to a recipient
+- [**transfer_from**](https://github.com/casper-ecosystem/cep18/blob/370952ddbd2b3bc08cd0394babc6fbaf291c52aa/cep18/src/main.rs#L155) - Transfers an amount of tokens from the owner to a recipient, if the direct caller has been previously approved to spend the specified amount on behalf of the owner
+
+# Installing the Contract
+
+After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](../developers/dapps/sending-deploys/) section to learn more about install contracts.
+
+## Deploy Prerequisites {#deploy-prerequisites}
+
+- Set up your machine as per the [prerequisites](../developers/prerequisites/)
+- Ensure you have [set up an account](../concepts/accounts-and-keys/#creating-accounts-and-keys) with a public and secret key pair to initiate the deploy
+- Since we are deploying to the Casper Testnet, ensure your [Testnet faucet account](https://testnet.cspr.live/tools/faucet) contains enough CSPR tokens to perform the contract execution. Follow the guide to [fund your account](../developers/prerequisites/#fund-your-account) or to [transfer tokens](../developers/cli/transfers/) as needed
+- Install the [Casper command-line client](../developers/prerequisites/#install-casper-client) to interact with the network
+
+## Basic Flow {#basic-flow}
+
+Here are the basic steps to install the Casper Fungible Token contract on a Casper Network.
+
+- [Clone the contract](#cloning-the-token-contract-cloning-the-token-contract)
+- [Get the IP address of a node](#getting-an-ip-address-from-a-testnet-peer-getting-an-ip-address)
+- [View the network state](#viewing-the-network-status-viewing-network-status)
+- [Install the contract via a deploy](#installing-the-contract-deploying-the-contract)
+- [View the network state](#querying-the-network-status-querying-the-network-status)
+
+## Cloning the Token Contract {#cloning-the-token-contract}
+
+This step includes cloning and preparing the token contract for the deployment.
+
+1. Clone the Fungible Token contract from the repository.
+
+```bash
+
+git clone https://github.com/casper-ecosystem/cep18.git
+
+```
+
+2. Make any necessary changes to the code for your customization requirements.
+
+3. Compile the contract to create the target .wasm file and build the Wasm.
+
+```bash
+
+cd cep18
+make prepare
+make build-contracts
+
+```
+
+4. Build and verify the compiled contract.
+
+```bash
+
+make test
+
+```
+
+## Getting an IP Address from a Testnet Peer {#getting-an-ip-address}
+
+We will use a Testnet [peer](https://testnet.cspr.live/tools/peers) to send the deploy. Read the guide to [acquiring a node address](../developers/prerequisites/#acquire-node-address-from-network-peers) if needed.
+
+## Viewing the Network Status {#viewing-network-status}
+
+This query captures any information related to the state of the blockchain at the specific time denoted by the network's state root hash. You need to have the state root hash and the account hash to run the query.
+
+**Getting the state root hash**
+
+Get the state root hash, which marks a snapshot of the network state at a moment in time. Use the [Node IP address](../developers/prerequisites/#acquire-node-address-from-network-peers) taken from a Testnet peer.
+
+```bash
+casper-client get-state-root-hash --node-address http://<HOST:PORT>
+```
+
+**Getting the account hash**
+
+Run the following command and supply the path to your public key in hexadecimal format to get the account hash.
+
+```bash
+casper-client account-address --public-key "[PATH_TO_YOUR_KEY]/public_key_hex"
+```
+
+**Querying global state**
+
+Use the command template below to query the network status with regard to your account.
+
+```bash
+casper-client query-global-state \
+--node-address http://<HOST:PORT> \
+--state-root-hash [STATE_ROOT_HASH] \
+--key [ACCOUNT_HASH]
+```
+
+## Installing the Contract {#deploying-the-contract}
+
+Now you can install the contract to the network and check how it behaves.
+
+If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](../developers/dapps/sending-deploys/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
+
+**The Casper platform currently does not refund any tokens as part of sending a deploy.** For example, if you spend 10 CSPR for the deployment and it only costs 1 CSPR, you will not receive the remaining 9 CSPR. Refer to the [Gas and the Casper Blockchain](../concepts/economics/gas-concepts/) documentation for further details.
+
+Use the following command template to deploy the contract:
+
+```bash
+casper-client put-deploy \
+    --node-address http://<HOST:PORT> \
+    --chain-name [NETWORK_NAME]] \
+    --secret-key [PATH_TO_YOUR_KEY]/secret_key.pem \
+    --payment-amount [AMOUNT] \
+    --session-path [WASM_FILE_PATH]/[File_Name].wasm
+    --session-arg <"NAME:TYPE='VALUE'" OR "NAME:TYPE=null">
+```
+
+- `NETWORK_NAME`: Use the relevant network name. Here we use '_casper-test_'
+- `PATH_TO_YOUR_KEY`: Replace this with the actual path of your secret key
+- `PAYMENT_AMOUNT`: Gas amount in tokens needed for contract execution. If there are no adequate tokens, the deploy will not execute and will return an error
+- `WASM FILE PATH`: The session-path argument should point to the location of your compiled Fungible Token Wasm file
+
+Here is a sample _put-deploy_ command:
+
+```bash
+casper-client put-deploy \
+--node-address http://95.216.24.237:7777 \
+--chain-name casper-test \
+--secret-key "/home/ubuntu/secret_key.pem" \
+--payment-amount 1000000 \
+--session-path "<machine-path>/cep18/target/wasm32-unknown-unknown/release/cep18.wasm"
+--session-arg "name='Token test', symbol='TEST', decimals:u8=10, total_supply:u256=1000"
+```
+
+## Querying the Network Status {#querying-the-network-status}
+
+You will need the newest state root hash to view the network status, as it changed with the deploy. The account hash remains the same since you are using the same account. Follow the [viewing the network state](#viewing-the-network-status) section to execute this step with the new state root hash.
+
+## Verifying the Deploy {#verifying-the-deploy}
+
+Now you can verify the sent deploy using the `get-deploy` command. This will output the details of the sent deploy.
+
+```bash
+casper-client get-deploy \
+--node-address http://<HOST:PORT> [DEPLOY_HASH]
+```
+
+## Querying with Arguments {#querying-with-arguments}
+
+This step will narrow down the context and check the status of a specific entry point. You will use the details inside the [Fungible Token contract](https://github.com/casper-ecosystem/cep18/blob/master/cep18/src/main.rs) to derive arguments.
+
+Use the command template below to query the network state with arguments:
+
+```bash
+casper-client query-global-state \
+--node-address http://<HOST:PORT> \
+--state-root-hash [STATE_ROOT_HASH] \
+--key [ACCOUNT_HASH] \
+-q "[CONTRACT_NAME/ARGUMENT]"
+```
+
+## Example Deploy on Testnet {#sample-deploy-testnet}
+
+The following steps will guide you through the process with sample values and results.
+
+### Cloning the Fungible Token Contract
+
+```bash
+git clone https://github.com/casper-ecosystem/cep18.git
+```
+
+### Getting an IP Address from a Testnet Peer
+
+Use [peers](https://testnet.cspr.live/tools/peers) to get the node IP address.
+
+### Viewing the Network Status
+
+Here is the command to query the state of the network:
+
+```bash
+casper-client query-global-state \
+--key account-hash-<account-address> \
+--node-address http://<HOST:PORT> \
+--state-root-hash E5B679BD1562fE6257257F5f969A79482E8DCEBBD501501BfA6d5844b61cBE3f
+```
+
+**Result**:
+
+This result contains the network state before the deploy. You can see the `named-key` field is empty since we haven't sent the deploy to the network yet.
+
+<details>
+<summary>Result from querying the network status</summary>
+
+```bash
+{
+  "id": 401803927542812599,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.4.3",
+    "merkle_proof": "[25564 hex chars]",
+    "stored_value": {
+      "Account": {
+        "account_hash": "account-hash-<account-address> ",
+        "action_thresholds": {
+          "deployment": 1,
+          "key_management": 1
+        },
+        "associated_keys": [
+          {
+            "account_hash": "account-hash-<account-address> ",
+            "weight": 1
+          }
+        ],
+        "main_purse": "uref-<hash>",
+        "named_keys": []
+      }
+    }
+  }
+}
+```
+
+</details>
+<br></br>
+
+### Sending the Deploy
+
+Send the Deploy containing your contract with this command:
+
+```bash
+casper-client put-deploy \
+--node-address http://<HOST:PORT>  \
+--chain-name casper-test \
+--secret-key "/home/ubuntu/secret_key.pem" \
+--payment-amount 1000000 \
+--session-path "<machine-path>/cep18/target/wasm32-unknown-unknown/release/cep18.wasm"
+--session-arg "name='Token test', symbol='TEST', decimals:u8=10, total_supply:u256=1000"
+```
+
+**Result**:
+
+This command execution will output the `deploy_hash` of the applied deploy. We can use the deploy_hash to get the details of the deploy.
+
+```bash
+{
+  "id": 931694842944790108,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.4.3",
+    "deploy_hash": "b00E59f8aBA5c7aB9...."
+  }
+}
+```
+
+### Viewing the Deploy Details
+
+You can view the details of the sent deploy using the command below:
+
+```bash
+casper-client get-deploy \
+--node-address http://<HOST:PORT> \
+b00E59f8aBA5c7aB9.....
+```
+
+**Result**:
+
+This contains the header, payment, and session details along with the execution results.
+
+- If the execution result field appears as `"execution_results":[]`, it means that the deploy hasn't been executed yet. The time to load the execution result may vary depending on the network.
+
+<details>
+<summary>Result from querying the deploy</summary>
+
+```bash
+{
+  {
+  "id": -870982079597140956,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.4.3",
+    "deploy": {
+      "approvals": [
+        {
+          "signature": "[130 hex chars]",
+          "signer": "017B8CE645c728......................."
+        }
+      ],
+      "hash": "F9D4C649Fa78Da07E.......................",
+      "header": {
+        "account": "017B8CE645c7285.......................",
+        "body_hash": "8eAEd6B7bCBB493d75d.......................",
+        "chain_name": "casper-test",
+        "dependencies": [],
+        "gas_price": 1,
+        "timestamp": "2022-01-04T15:14:29.203Z",
+        "ttl": "30m"
+      },
+      "payment": {
+        "ModuleBytes": {
+          "args": [
+            [
+              "amount",
+              {
+                "bytes": "0500e8764817",
+                "cl_type": "U512",
+                "parsed": "100000000000"
+              }
+            ]
+          ],
+          "module_bytes": ""
+        }
+      },
+      "session": {
+        "ModuleBytes": {
+          "args": [],
+          "module_bytes": "[417800 hex chars]"
+        }
+      }
+    },
+    "execution_results": [
+      {
+        "block_hash": "d3644f0306F20fa6.......................",
+        "result": {
+          "Success": {
+            "cost": "45040980830",
+            "effect": {
+              "operations": [],
+              "transforms": [
+                {
+                  "key": "hash-8cf5E4aCF51f54Eb5.......................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "hash-624dBE2395b9D9503FB.......................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "hash-010c3Fe81B7b862E50C77.......................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "hash-9824d60dC3A5c44A20b.......................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "balance-C051e7EC16e08De.......................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "balance-98d945f5324F865243.......................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "balance-C051e7EC16e08Def8b556",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "06E07f3abEa001",
+                      "cl_type": "U512",
+                      "parsed": "1789897900000"
+                    }
+                  }
+                },
+                {
+                  "key": "balance-98d945f5324F865243B7c02C0417AB6eaC361c5c56602FD42ced834a1Ba201B6",
+                  "transform": {
+                    "AddUInt512": "100000000000"
+                  }
+                },
+                {
+                  "key": "uref-d29a34C29769D4BaC250CF9efD3c6372d8e6a89B62fAD122b3BF009990Ae61CD-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "",
+                      "cl_type": "Unit",
+                      "parsed": null
+                    }
+                  }
+                },
+                {
+                  "key": "account-hash-7f4bf39A3...................................................",
+                  "transform": {
+                    "AddKeys": [
+                      {
+                        "key": "uref-d29a34C29769D4BaC250CF9efD3c6372d8e6a89B62fAD122b3BF009990Ae61CD-007",
+                        "name": "balances"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": "uref-075874B98e3CF57Ea6326746336A0Aa908e770D3ADe0cf953f7E146f8B64F837-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "",
+                      "cl_type": "Unit",
+                      "parsed": null
+                    }
+                  }
+                },
+                {
+                  "key": "account-hash-7f4bf39A311...................................................",
+                  "transform": {
+                    "AddKeys": [
+                      {
+                        "key": "uref-075874B98e3CF57Ea6326746336A0Aa908e770D3ADe0cf953f7E146f8B64F837-007",
+                        "name": "allowances"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": "uref-66Bf928E1F6A28b174A48Fca4c002Bc8b77Dd851d7EFFb9Dc1A450cB211E484a-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "0400ca9A3B",
+                      "cl_type": "U256",
+                      "parsed": "1000000000"
+                    }
+                  }
+                },
+                {
+                  "key": "uref-4EB0a2A42afBb1d3D5ae9BD4781dc96E528C7AD3f0eEC240Cf1DbDaDF4f3D486-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "0A00000043617370657254657374",
+                      "cl_type": "String",
+                      "parsed": "CasperTest"
+                    }
+                  }
+                },
+                {
+                  "key": "uref-6e87fd661D5a65aF95f02baDfEb64f8E0F44C006661d4903A68E9dF8dEAa413d-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "050000004353505254",
+                      "cl_type": "String",
+                      "parsed": "CSPRT"
+                    }
+                  }
+                },
+                {
+                  "key": "uref-aCA2425C80584391fB883603460578B1472d13a429Ebbd1a18a55cE19cE8F3C6-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "08",
+                      "cl_type": "U8",
+                      "parsed": 8
+                    }
+                  }
+                },
+                {
+                  "key": "dictionary-baA61231F04B1c2Ee97025f425eaD2F70CAd9c1E8c24355246d159038AdCb2e9",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "[188 hex chars]",
+                      "cl_type": "Any",
+                      "parsed": null
+                    }
+                  }
+                },
+                {
+                  "key": "account-hash-7f4bf39A311a7538d8C...................................................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "account-hash-7f4bf39A311a75...................................................",
+                  "transform": {
+                    "WriteAccount": "account-hash-7f4bf39A311a7538d8C91BB86C71DF774023e16bc4a70ab7e4e8AE77DbF2Ef53"
+                  }
+                },
+                {
+                  "key": "account-hash-7f4bf39A311a7538...................................................",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "account-hash-7f4bf39A311a7538d8C...................................................",
+                  "transform": {
+                    "WriteAccount": "account-hash-7f4bf39A311a75..................................................."
+                  }
+                },
+                {
+                  "key": "uref-868c0e0BEB2EB3C10e893be96E6D6bE7FC6375f3f038e46c3262509245c117a0-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "",
+                      "cl_type": "Unit",
+                      "parsed": null
+                    }
+                  }
+                },
+                {
+                  "key": "hash-28f982A396052b5068383E725ab48965AB941167f53DB36a0911ba0C98bc39F0",
+                  "transform": "WriteContractPackage"
+                },
+                {
+                  "key": "hash-28f982A396052b5068383E725ab48965AB941167f53DB36a0911ba0C98bc39F0",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "hash-AdF81845d77907054ACb250c196392c7DAEE5481d4EabEB76c318A307c11E5cB",
+                  "transform": "WriteContractWasm"
+                },
+                {
+                  "key": "hash-Faa81ED758ecE1B99E2Ce48073D13D7f6185d9dc5233E39DE5c192Bebb9483D6",
+                  "transform": "WriteContract"
+                },
+                {
+                  "key": "hash-28f982A396052b5068383E725ab48965AB941167f53DB36a0911ba0C98bc39F0",
+                  "transform": "WriteContractPackage"
+                },
+                {
+                  "key": "account-hash-7f4bf39A311a7538d8...................................................",
+                  "transform": {
+                    "AddKeys": [
+                      {
+                        "key": "hash-Faa81ED758ecE1B99E2Ce48073D13D7f6185d9dc5233E39DE5c192Bebb9483D6",
+                        "name": "test_contract"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": "uref-66Bf928E1F6A28b174A48Fca4c002Bc8b77Dd851d7EFFb9Dc1A450cB211E484a-000",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "dictionary-04932d42aff9367579770E219ce1C4Da83D1Fd42Fa0FaA4Ae98AE07914c4c1E4",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "[186 hex chars]",
+                      "cl_type": "Any",
+                      "parsed": null
+                    }
+                  }
+                },
+                {
+                  "key": "uref-66Bf928E1F6A28b174A48Fca4c002Bc8b77Dd851d7EFFb9Dc1A450cB211E484a-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "04400cAa3b",
+                      "cl_type": "U256",
+                      "parsed": "1001000000"
+                    }
+                  }
+                },
+                {
+                  "key": "uref-66Bf928E1F6A28b174A48Fca4c002Bc8b77Dd851d7EFFb9Dc1A450cB211E484a-000",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "dictionary-Ec3f20485A29255dd2c2D7b8c008207A0d139dFDCE89224DA8b63F21c157A97F",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "[186 hex chars]",
+                      "cl_type": "Any",
+                      "parsed": null
+                    }
+                  }
+                },
+                {
+                  "key": "uref-66Bf928E1F6A28b174A48Fca4c002Bc8b77Dd851d7EFFb9Dc1A450cB211E484a-000",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "04C090c83b",
+                      "cl_type": "U256",
+                      "parsed": "1003000000"
+                    }
+                  }
+                },
+                {
+                  "key": "deploy-F9D4C649Fa78Da...................................................",
+                  "transform": {
+                    "WriteDeployInfo": {
+                      "deploy_hash": "F9D4C649Fa78Da07Ec6EFcFC615ff1Bd3B68347750FA0C81B6a74C3f9582d7E4",
+                      "from": "account-hash-7f4bf39A311a...................................................",
+                      "gas": "45040980830",
+                      "source": "uref-C051e7EC16e08Def8b556F9...................................................",
+                      "transfers": []
+                    }
+                  }
+                },
+                {
+                  "key": "balance-98d945f5324F865243B7c02C0417AB6eaC361c5c56602FD42ced834a1Ba201B6",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "hash-8cf5E4aCF51f54Eb59291599187838Dc3BC234089c46fc6cA8AD17e762aE4401",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "hash-010c3Fe81B7b862E50C77EF9A958a05BfA98444F26f96f23d37A13c96244cFB7",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "hash-9824d60dC3A5c44A20b9FD260a412437933835B52Fc683d8AE36e4ec2114843e",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "balance-98d945f5324F865243B7c02C0417AB6eaC361c5c56602FD42ced834a1Ba201B6",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "balance-c69d353A5a3b6433368A8FC2F6b308ce4Ec10291782f61BA15C96F260f91FFC0",
+                  "transform": "Identity"
+                },
+                {
+                  "key": "balance-98d945f5324F865243B7c02C0417AB6eaC361c5c56602FD42ced834a1Ba201B6",
+                  "transform": {
+                    "WriteCLValue": {
+                      "bytes": "00",
+                      "cl_type": "U512",
+                      "parsed": "0"
+                    }
+                  }
+                },
+                {
+                  "key": "balance-c69d353A5a3b6433368A8FC2F6b308ce4Ec10291782f61BA15C96F260f91FFC0",
+                  "transform": {
+                    "AddUInt512": "100000000000"
+                  }
+                }
+              ]
+            },
+            "transfers": []
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+</details>
+<br></br>
+
+### Querying Contract Entry Points
+
+We will query the argument 'name' in this example.
+
+```bash
+casper-client query-global-state --node-address http://95.216.24.237:7777 \
+--state-root-hash D00dF8c35B0E9995c2911803F37A212d82c960D9bC5bA3C4F99a661e18D09411 \
+--key account-hash-7f4bf39A311a7538d8C91BB86C71DF774023e16bc4a70ab7e4e8AE77DbF2Ef53 \
+-q "test_contract/name"
+```
+
+**Result**:
+
+You can see that the name is `CasperTest` in this example.
+
+```bash
+{
+ "id": -3650676146668320186,
+ "jsonrpc": "2.0",
+ "result": {
+  "api_version": "1.4.3",
+  "block_header": null,
+  "merkle_proof": "[80252 hex chars]",
+  "stored_value": {
+   "CLValue": {
+    "bytes": "0A00000043617370657254657374",
+    "cl_type": "String",
+    "parsed": "CasperTest"
+   }
+  }
+ }
+}
+
+```

--- a/source/docs/casper/resources/tokens/cep18/full-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep18/full-tutorial.md
@@ -158,7 +158,7 @@ Contract methods are:
 
 # Installing the Contract
 
-After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](/developers/dapps/sending-deploys/) section to learn more about install contracts.
+After customizing your instance of the CEP-18 token contract, it's time to install it in global state. Installing the Fungible Token contract is similar to installing other smart contracts, while only the Wasm files and parameters will differ. Refer to the [Sending Deploys to a Casper network using the Rust Client](/developers/dapps/cli/sending-deploys/) section to learn more about install contracts.
 
 ## Deploy Prerequisites {#deploy-prerequisites}
 
@@ -248,7 +248,7 @@ casper-client query-global-state \
 
 Now you can install the contract to the network and check how it behaves.
 
-If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](/developers/dapps/sending-deploys/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
+If you are sending the deploy on Mainnet, try several put deploys on the Testnet to understand the exact gas amount required for that deploy. Refer to the [note about gas price](/developers/dapps/cli/sending-deploys/#a-note-about-gas-price) to understand more about payment amounts and gas price adjustments.
 
 **The Casper platform currently does not refund any tokens as part of sending a deploy.** For example, if you spend 10 CSPR for the deployment and it only costs 1 CSPR, you will not receive the remaining 9 CSPR. Refer to the [Gas and the Casper Blockchain](/concepts/economics/gas-concepts/) documentation for further details.
 

--- a/source/docs/casper/resources/tokens/cep18/query.md
+++ b/source/docs/casper/resources/tokens/cep18/query.md
@@ -1,5 +1,5 @@
 ---
-title: Exploring the CEP-18 Contracts
+title: CEP-18 Contract Details
 slug: /resources/tokens/cep18/query
 ---
 
@@ -15,7 +15,7 @@ This document covers the necessary information that you will need to interact wi
 
 We will need the contract package's `contract_hash` to interact with the recently installed instance of CEP-18. You can find the contract package hash within the installing account's `NamedKeys`, under the name given during the installation process.
 
-```bash
+```json
 casper-client query-global-state -n http://<HOST IP>:<PORT> \
 // This is the contract package hash, which can be found within the `NamedKeys` of the account that sent the installing deploy.
 --key hash-82bd86d2675b2dc44c19027fb7717a99db6fda5e0cad8d597f2495a9dbc9df7f \
@@ -70,7 +70,7 @@ In addition, there is a utility contract that invokes the various balance and al
 
 First, you will need to query the `cep18_test_contract` hash found within the installing account's `NamedKeys`:
 
-```bash
+```json
 casper-client query-global-state -n http://<HOST IP>:<PORT> \
 // This is the contract hash for the `cep18_test_contract` as found from the installing account's `NamedKeys`
 --key hash-015b99020edb40e7e1e2b31a8e104bc226242f960a2d10dc1d91ae3eb6fa41b6 \
@@ -80,7 +80,7 @@ casper-client query-global-state -n http://<HOST IP>:<PORT> \
 <details>
 <summary><b>Casper client command without comments</b></summary>
 
-```bash
+```json
 casper-client query-global-state -n http://<HOST IP>:<PORT> \
 --key hash-015b99020edb40e7e1e2b31a8e104bc226242f960a2d10dc1d91ae3eb6fa41b6 \
 --state-root-hash f9f73c3a4da5893b67c4cac94a5695d76cfefff61b050c98a7b19e2b8efd3933

--- a/source/docs/casper/resources/tokens/cep18/query.md
+++ b/source/docs/casper/resources/tokens/cep18/query.md
@@ -1,0 +1,158 @@
+---
+title: Exploring the CEP-18 Contracts
+slug: /resources/tokens/cep18/query
+---
+
+# Exploring the CEP-18 Contracts
+
+This document covers the necessary information that you will need to interact with your CEP-18 contract instance. Your setup should include the following two contracts:
+
+- The Casper fungible token contract
+
+- The CEP-18 utility contract, which should appear in the `NamedKeys` of the account that sent the Deploy as `cep18_test_contract`
+
+## Querying the Contract Package
+
+We will need the contract package's `contract_hash` to interact with the recently installed instance of CEP-18. You can find the contract package hash within the installing account's `NamedKeys`, under the name given during the installation process.
+
+```bash
+casper-client query-global-state -n http://<HOST IP>:<PORT> \
+// This is the contract package hash, which can be found within the `NamedKeys` of the account that sent the installing deploy.
+--key hash-82bd86d2675b2dc44c19027fb7717a99db6fda5e0cad8d597f2495a9dbc9df7f \
+// This is the most up to date state root hash, which can found by using the `get-state-root-hash` command in the Casper client.
+--state-root-hash f9f73c3a4da5893b67c4cac94a5695d76cfefff61b050c98a7b19e2b8efd3933
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client query-global-state -n http://<HOST IP>:<PORT> \
+--key hash-82bd86d2675b2dc44c19027fb7717a99db6fda5e0cad8d597f2495a9dbc9df7f \
+--state-root-hash f9f73c3a4da5893b67c4cac94a5695d76cfefff61b050c98a7b19e2b8efd3933
+```
+
+</details>
+
+This will return the `Contract Package` object:
+
+```bash
+{
+  "id": -1489823435760214673,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.0.0",
+    "block_header": null,
+    "merkle_proof": "[2048 hex chars]",
+    "stored_value": {
+      "ContractPackage": {
+        "access_key": "uref-8dac847ce0ae20f0156cf37dd233cc1d166fde8269fc9a393b0ea04174be1167-007",
+        "disabled_versions": [],
+        "groups": [],
+        "versions": [
+          {
+            "contract_hash": "contract-05d893e76c731729fc26339e5a970bd79fbf4a6adf743c8385431fb494bff45e",
+            "contract_version": 1,
+            "protocol_version_major": 1
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+* Note - In the `contract_hash` field, the hash value represents the stored contract which we will invoke later.
+
+## Querying the Utility Contract
+
+In addition, there is a utility contract that invokes the various balance and allowance entry points of the main fungible token contract. Upon receiving the returned value, the utility contract will write the value to a URef called `result`. You can find this URef in the `NamedKeys` of the utility contract.
+
+First, you will need to query the `cep18_test_contract` hash found within the installing account's `NamedKeys`:
+
+```bash
+casper-client query-global-state -n http://<HOST IP>:<PORT> \
+// This is the contract hash for the `cep18_test_contract` as found from the installing account's `NamedKeys`
+--key hash-015b99020edb40e7e1e2b31a8e104bc226242f960a2d10dc1d91ae3eb6fa41b6 \
+--state-root-hash f9f73c3a4da5893b67c4cac94a5695d76cfefff61b050c98a7b19e2b8efd3933
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client query-global-state -n http://<HOST IP>:<PORT> \
+--key hash-015b99020edb40e7e1e2b31a8e104bc226242f960a2d10dc1d91ae3eb6fa41b6 \
+--state-root-hash f9f73c3a4da5893b67c4cac94a5695d76cfefff61b050c98a7b19e2b8efd3933
+```
+</details>
+
+Which should return information similar to the following:
+
+```bash
+
+{
+  "id": 5359405942597097786,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.0.0",
+    "block_header": null,
+    "merkle_proof": "[2048 hex chars]",
+    "stored_value": {
+      "ContractPackage": {
+        "access_key": "uref-1b867a3751f505762c69c8d92ba7462818cd0c2a705bb5d4270bce479410ee55-007",
+        "disabled_versions": [],
+        "groups": [],
+        "versions": [
+          {
+            "contract_hash": "contract-a8fe057675930f0951d45816c55615228ac8af2b7b231788278dffcf1dd8c0ca",
+            "contract_version": 1,
+            "protocol_version_major": 1
+          }
+        ]
+      }
+    }
+  }
+}
+
+```
+
+You will need to take the `contract_hash` value and replace `contract` with `hash` to run another `query-global-state:
+
+```bash
+casper-client query-global-state -n http://<HOST IP>:<PORT> \
+--key hash-a8fe057675930f0951d45816c55615228ac8af2b7b231788278dffcf1dd8c0ca \
+--state-root-hash f9f73c3a4da5893b67c4cac94a5695d76cfefff61b050c98a7b19e2b8efd3933
+```
+
+Which will return the full `cep18_test_contract` information. The following snippet is condensed to show only the `NamedKeys`, but you should also see the `entry_points` when you run the command. You should see the URef `result`, which will be used to view the results of any checks run through the utility contract.
+
+```bash
+{
+  "id": -1426549275795832481,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.0.0",
+    "block_header": null,
+    "merkle_proof": "[3370 hex chars]",
+    "stored_value": {
+      "Contract": {
+        "contract_package_hash": "contract-package-015b99020edb40e7e1e2b31a8e104bc226242f960a2d10dc1d91ae3eb6fa41b6",
+        "contract_wasm_hash": "contract-wasm-7959083a4df983ddcd3a9ae46af092dbf126031181ab2619ddc64db09bde8c27",
+        "named_keys": [
+          {
+            "key": "uref-a46ad389b53715d9991a513c8ca48e1502facc4c563c0700a31e830c4cb8a7d4-007",
+            "name": "result"
+          }
+        ],
+        "protocol_version": "1.0.0"
+      }
+    }
+  }
+}
+
+```
+
+## Next Steps
+
+- [CEP-18 Token Transfers and Allowances](./transfer.md)

--- a/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
+++ b/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
@@ -1,0 +1,107 @@
+---
+title: Casper Fungible Token Quick Start Guide
+slug: /resources/tokens/cep18/quickstart-guide
+---
+
+# Casper Fungible Token Quick Start Guide
+
+This quick start guide introduces you to the Casper client commands and Wasm files necessary to deploy a CEP-18 Casper Fungible Token contract to a [Casper network](https://cspr.live).
+
+The [Ethereum Request for Comment (ERC-20)](https://eips.ethereum.org/EIPS/eip-20#specification) standard defines a set of rules that dictate the total supply of tokens, how the tokens are transferred, how transactions are approved, and how token data is accessed. These fungible tokens are blockchain-based assets that have value and can be transferred or recorded.
+
+To execute transactions on a Casper network (involving fungible tokens), you will need some CSPR tokens to pay for the transactions.
+
+For greater detail into the creation and mechanics of the Casper fungible token contract, see the full [Casper Fungible Token Tutorial](./full-tutorial.md).
+
+## Prerequisites
+
+Before using this guide, ensure you meet the following requirements:
+
+-   Set up your machine as per the [prerequisites](../developers/prerequisites/)
+-   Use the [Casper command-line client]
+-   Get a valid [`node-address`](https://cspr.live/tools/peers)
+-   Know how to deploy a [smart contract](../developers/dapps/sending-deploys/) to a Casper network
+-   Hold enough CSPR tokens to pay for transactions
+
+# Setup
+
+Clone the [fungible token (CEP-18) contract repository](https://github.com/casper-ecosystem/cep18) and run the `make build-contract` command. This will create the `cep18.wasm` and the `cep18_test_contract.wasm`. The token Wasm is the main contract. We will use the `cep18_test_contract` Wasm to query the balances and allowances of the fungible token balances throughout this workflow.
+
+## Install the Main Fungible Token Contract
+
+The following command will create a deploy containing the CEP-18 contract instance using your supplied arguments as follows:
+
+- **Name** - The name of your CEP-18 token
+- **Symbol** - The symbol used to refer to your CEP-18 token
+- **Total_supply** - The total supply of the CEP-18 token to be minted
+- **Decimals** - The number of spaces after the decimal. (As an example, a total supply of 1000000 with a `decimals` setting of 3 would be 1,000.000 tokens)
+
+```bash
+casper-client put-deploy -n http://<NODE IP>:<PORT> \
+--chain-name <CHAIN NAME> \
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-path ~/casper/demo/cep18.wasm \
+--session-arg "name:string='CEP18'" \
+--session-arg "symbol:string='gris'" \
+--session-arg "total_supply:u256='100'" \
+--session-arg "decimals:u8='1'" \
+--payment-amount 150000000000
+```
+
+## Install the `cep18_test_contract` Contract Package
+
+The following command will install the CEP-18 helper contract that allows you to check balances and access approval features.
+
+```bash
+casper-client put-deploy -n http://<NODE IP>:<PORT> \
+--chain-name <CHAIN NAME> \
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-path ~/casper/demo/cep18_test_contract.wasm \
+--payment-amount 50000000000
+```
+
+At this point, the account that installed both the main contract and the helper contract will look like this.
+
+```bash
+{
+	"src": {
+	"Account": {
+	"_accountHash": "account-hash-303c0f8208220fe9a4de40e1ada1d35fdd6c678877908f01fddb2a56502d67fd",
+	"namedKeys": [
+		{
+		"name": "cep18_test_contract",
+		"key": "hash-999326ca8408dfd37da023eb6fd82f174151be64f83f9fb837632a0d69fd4c7e"
+		},
+		{
+		"name": "cep18_token_contract",
+		"key": "hash-b568f50a64acc8bbe43462ffe243849a88111060b228dacb8f08d42e26985180"
+		},
+	],
+	"mainPurse": "uref-6c062525debdee18d5cad083ca530fcb65ef8741574fba4c97673f4ed00093f7-007",
+	"associatedKeys": [
+		{
+		"accountHash": "account-hash-303c0f8208220fe9a4de40e1ada1d35fdd6c678877908f01fddb2a56502d67fd",
+		"weight": 1
+		}
+	],
+	"actionThresholds": {
+		"deployment": 1,
+		"keyManagement": 1
+		}
+		}
+	}
+}
+```
+
+**_Note:_**
+
+> 1. `cep18_token_contract` is the main contract, and is a stored contract, record its hash
+> 2. `cep18_test_call` is a contract package which contains the utility contract required to read the balances and allowances of users within the fungible token state.
+
+### Next Steps
+
+In the following sections, the sample guide explains the querying of the contract package, token transfers, and approvals.
+
+- [Exploring the CEP18 Contracts](./query.md)
+- [CEP-18 Token Transfers and Allowances](./transfer.md)
+- [Testing Framework for CEP-18](./tests.md)

--- a/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
+++ b/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
@@ -20,7 +20,7 @@ Before using this guide, ensure you meet the following requirements:
 -   Set up your machine as per the [prerequisites](/developers/prerequisites/)
 -   Use the [Casper command-line client]
 -   Get a valid [`node-address`](https://cspr.live/tools/peers)
--   Know how to deploy a [smart contract](/developers/dapps/cli/sending-deploys/) to a Casper network
+-   Know how to deploy a [smart contract](/developers/cli/sending-deploys/) to a Casper network
 -   Hold enough CSPR tokens to pay for transactions
 
 # Setup

--- a/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
+++ b/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
@@ -1,9 +1,9 @@
 ---
-title: Casper Fungible Token Quick Start Guide
+title: On-chain Installation
 slug: /resources/tokens/cep18/quickstart-guide
 ---
 
-# Casper Fungible Token Quick Start Guide
+# Installing and Interacting with a CEP-18 Contract
 
 This quick start guide introduces you to the Casper client commands and Wasm files necessary to deploy a CEP-18 Casper Fungible Token contract to a [Casper network](https://cspr.live).
 

--- a/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
+++ b/source/docs/casper/resources/tokens/cep18/quickstart-guide.md
@@ -17,10 +17,10 @@ For greater detail into the creation and mechanics of the Casper fungible token 
 
 Before using this guide, ensure you meet the following requirements:
 
--   Set up your machine as per the [prerequisites](../developers/prerequisites/)
+-   Set up your machine as per the [prerequisites](/developers/prerequisites/)
 -   Use the [Casper command-line client]
 -   Get a valid [`node-address`](https://cspr.live/tools/peers)
--   Know how to deploy a [smart contract](../developers/dapps/sending-deploys/) to a Casper network
+-   Know how to deploy a [smart contract](/developers/dapps/cli/sending-deploys/) to a Casper network
 -   Hold enough CSPR tokens to pay for transactions
 
 # Setup

--- a/source/docs/casper/resources/tokens/cep18/tests.md
+++ b/source/docs/casper/resources/tokens/cep18/tests.md
@@ -7,7 +7,7 @@ slug: /resources/tokens/cep18/tests
 
 The testing framework in this tutorial uses the [Casper engine test support](https://crates.io/crates/casper-engine-test-support) crate for testing the contract implementation against the Casper execution environment.
 
-The following section reviews the [GitHub testing folder](https://github.com/casper-ecosystem/cep18/tree/master/tests), which creates a testing framework for the Casper [Fungible Token](https://github.com/casper-ecosystem/cep18) project. You can find more details about testing Casper contracts [here](../developers/writing-onchain-code/testing-contracts/).
+The following section reviews the [GitHub testing folder](https://github.com/casper-ecosystem/cep18/tree/master/tests), which creates a testing framework for the Casper [Fungible Token](https://github.com/casper-ecosystem/cep18) project. You can find more details about testing Casper contracts [here](/developers/writing-onchain-code/testing-contracts/).
 
 The following is an example of a complete test expecting a failed transfer:
 
@@ -69,7 +69,7 @@ The [TestFixture](https://github.com/casper-ecosystem/cep18/blob/master/example/
 
 ### Setting up the Testing Context
 
-The code in the [utility directory](https://github.com/casper-ecosystem/cep18/tree/dev/tests/src/utility) initializes the blockchain's [global state](../concepts/glossary/G/#global-state) with all the data and entrypoints the smart contract needs.
+The code in the [utility directory](https://github.com/casper-ecosystem/cep18/tree/dev/tests/src/utility) initializes the blockchain's [global state](/concepts/glossary/G/#global-state) with all the data and entrypoints the smart contract needs.
 
 Expand the example below to see a subset of the required constants for this project. The testing framework defines constants via the [`constants.rs`](https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/utility/constants.rs) file within the `utility` directory. For the most up-to-date version of the code, visit [GitHub](https://github.com/casper-ecosystem/cep18).
 

--- a/source/docs/casper/resources/tokens/cep18/tests.md
+++ b/source/docs/casper/resources/tokens/cep18/tests.md
@@ -1,0 +1,387 @@
+---
+title: Testing Framework for CEP-18
+slug: /resources/tokens/cep18/tests
+---
+
+# Testing Framework for CEP-18
+
+The testing framework in this tutorial uses the [Casper engine test support](https://crates.io/crates/casper-engine-test-support) crate for testing the contract implementation against the Casper execution environment.
+
+The following section reviews the [GitHub testing folder](https://github.com/casper-ecosystem/cep18/tree/master/tests), which creates a testing framework for the Casper [Fungible Token](https://github.com/casper-ecosystem/cep18) project. You can find more details about testing Casper contracts [here](../developers/writing-onchain-code/testing-contracts/).
+
+The following is an example of a complete test expecting a failed transfer:
+
+```rust
+#[should_panic(expected = "ApiError::User(65534) [131070]")]
+#[test]
+fn should_not_transfer_with_insufficient_balance() {
+    let mut fixture = TestFixture::install_contract();
+
+    let initial_ali_balance = fixture.balance_of(Key::from(fixture.ali)).unwrap();
+    assert_eq!(fixture.balance_of(Key::from(fixture.bob)), None);
+
+    fixture.transfer(
+        Key::from(fixture.bob),
+        initial_ali_balance + U256::one(),
+        fixture.ali,
+    );
+}
+```
+
+To build and run the tests, issue the following command in the project folder, [cep18](https://github.com/casper-ecosystem/cep18):
+
+```bash
+make test
+```
+
+The project contains a [Makefile](https://github.com/casper-ecosystem/cep18/blob/dev/Makefile), which is a custom build script that compiles the contract before running tests in _release_ mode. Then, the script copies the `contract.wasm` file to the [tests/wasm](https://github.com/casper-ecosystem/cep18/tree/master/tests/wasm) directory. In practice, you only need to run the `make test` command during development.
+
+## Configuring the Test Package
+
+In this project, we define a `tests` package using the [tests/Cargo.toml](https://github.com/casper-ecosystem/cep18/blob/dev/tests/Cargo.toml) file.
+
+```bash
+[package]
+name = "tests"
+version = "1.0.0"
+...
+
+[dependencies]
+casper-types = "2.0.0"
+casper-engine-test-support = "4.0.0"
+casper-execution-engine = "4.0.0"
+once_cell = "1.16.0"
+
+[lib]
+name = "tests"
+...
+```
+
+## Testing Logic
+
+In Github, you will find an [example](https://github.com/casper-ecosystem/cep18/tree/dev/cep18) containing a Casper Fungible Token [contract](https://github.com/casper-ecosystem/cep18/blob/dev/cep18/src/main.rs) implementation with the corresponding [tests](https://github.com/casper-ecosystem/cep18/tree/dev/tests/src). The tests follow this sequence:
+
+- [Step 1](#setting-up-the-testing-context) - Specify the starting state of the blockchain.
+- [Step 2](#deploying-the-contract) - Deploy the compiled contract to the blockchain and query it.
+- [Step 3](#invoking-contract-entrypoints) - Create additional deploys for calling each of the entrypoints in the contract.
+
+The [TestFixture](https://github.com/casper-ecosystem/cep18/blob/master/example/cep18-tests/src/test_fixture/test_fixture.rs) accomplishes these steps by simulating a real-world deploy that stores the contract on the blockchain and then invoking the contract's entrypoints.
+
+### Setting up the Testing Context
+
+The code in the [utility directory](https://github.com/casper-ecosystem/cep18/tree/dev/tests/src/utility) initializes the blockchain's [global state](../concepts/glossary/G/#global-state) with all the data and entrypoints the smart contract needs.
+
+Expand the example below to see a subset of the required constants for this project. The testing framework defines constants via the [`constants.rs`](https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/utility/constants.rs) file within the `utility` directory. For the most up-to-date version of the code, visit [GitHub](https://github.com/casper-ecosystem/cep18).
+
+
+<details>
+<summary>Example of required constants</summary>
+
+```rust
+// File https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/utility/installer_request_builders.rs
+
+use casper_engine_test_support::{
+    ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
+    MINIMUM_ACCOUNT_CREATION_BALANCE, PRODUCTION_RUN_GENESIS_REQUEST,
+};
+use casper_execution_engine::core::engine_state::ExecuteRequest;
+use casper_types::{
+    account::AccountHash, bytesrepr::FromBytes, runtime_args, system::mint, CLTyped, ContractHash, ContractPackageHash, Key, RuntimeArgs, U256,
+};
+
+use crate::utility::constants::{
+    ALLOWANCE_AMOUNT_1, ALLOWANCE_AMOUNT_2, TOTAL_SUPPLY_KEY, TRANSFER_AMOUNT_1, TRANSFER_AMOUNT_2,
+};
+
+use super::constants::{
+    ACCOUNT_1_ADDR, ACCOUNT_2_ADDR, ARG_ADDRESS, ARG_AMOUNT, ARG_DECIMALS, ARG_NAME, ARG_OWNER, ARG_RECIPIENT, ARG_SPENDER, ARG_SYMBOL, ARG_TOKEN_CONTRACT, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM, CEP18_TEST_CONTRACT_KEY, CEP18_TEST_CONTRACT_WASM, CEP18_TOKEN_CONTRACT_KEY, CHECK_ALLOWANCE_OF_ENTRYPOINT, CHECK_BALANCE_OF_ENTRYPOINT,CHECK_TOTAL_SUPPLY_ENTRYPOINT, METHOD_APPROVE, METHOD_APPROVE_AS_STORED_CONTRACT,METHOD_TRANSFER, METHOD_TRANSFER_AS_STORED_CONTRACT, RESULT_KEY, TOKEN_DECIMALS, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY,
+};
+```
+
+</details>
+
+
+### Installing the Contract
+
+The next step is to define a struct that has its own virtual machine (VM) instance and implements the Fungible Token entrypoints. This struct holds a `TestContext` of its own. The _contract_hash_ and the _session_code_ won’t change after the contract is deployed, so it is good to keep them handy.
+
+This code snippet builds the context and includes the compiled contract _.wasm_ binary being tested. The `TestContext` struct creates a new instance of the `cep18_token` with several test accounts.
+
+**Note**: These accounts have a positive initial balance.
+
+The full and most recent code implementation is available on [GitHub](https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/utility/installer_request_builders.rs).
+
+<details>
+<summary>Example of a CEP-18 token in a test</summary>
+
+```rust
+// File https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/utility/installer_request_builders.rs
+
+// Creating the `TestContext` struct.
+
+pub(crate) struct TestContext {
+pub(crate) cep18_token: ContractHash,
+pub(crate) cep18_test_contract_package: ContractPackageHash,
+}
+
+// Setting up the test instance of CEP-18.
+
+pub(crate) fn setup() -> (InMemoryWasmTestBuilder, TestContext) {
+    setup_with_args(runtime_args! {
+        ARG_NAME => TOKEN_NAME,
+        ARG_SYMBOL => TOKEN_SYMBOL,
+        ARG_DECIMALS => TOKEN_DECIMALS,
+        ARG_TOTAL_SUPPLY => U256::from(TOKEN_TOTAL_SUPPLY),
+    })
+}
+
+// Establishing test accounts.
+
+pub(crate) fn setup_with_args(install_args: RuntimeArgs) -> (InMemoryWasmTestBuilder, TestContext) {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder.run_genesis(&PRODUCTION_RUN_GENESIS_REQUEST);
+
+    let id: Option<u64> = None;
+    let transfer_1_args = runtime_args! {
+        mint::ARG_TARGET => *ACCOUNT_1_ADDR,
+        mint::ARG_AMOUNT => MINIMUM_ACCOUNT_CREATION_BALANCE,
+        mint::ARG_ID => id,
+    };
+    let transfer_2_args = runtime_args! {
+        mint::ARG_TARGET => *ACCOUNT_2_ADDR,
+        mint::ARG_AMOUNT => MINIMUM_ACCOUNT_CREATION_BALANCE,
+        mint::ARG_ID => id,
+    };
+
+    let transfer_request_1 =
+        ExecuteRequestBuilder::transfer(*DEFAULT_ACCOUNT_ADDR, transfer_1_args).build();
+    let transfer_request_2 =
+        ExecuteRequestBuilder::transfer(*DEFAULT_ACCOUNT_ADDR, transfer_2_args).build();
+
+    // Installing the test version of CEP-18 with the default account.
+
+    let install_request_1 =
+        ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, CEP18_CONTRACT_WASM, install_args)
+            .build();
+
+    let install_request_2 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CEP18_TEST_CONTRACT_WASM,
+        RuntimeArgs::default(),
+    )
+    .build();
+
+    builder.exec(transfer_request_1).expect_success().commit();
+    builder.exec(transfer_request_2).expect_success().commit();
+    builder.exec(install_request_1).expect_success().commit();
+    builder.exec(install_request_2).expect_success().commit();
+
+    let account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+
+    let cep18_token = account
+        .named_keys()
+        .get(CEP18_TOKEN_CONTRACT_KEY)
+        .and_then(|key| key.into_hash())
+        .map(ContractHash::new)
+        .expect("should have contract hash");
+
+    let cep18_test_contract_package = account
+        .named_keys()
+        .get(CEP18_TEST_CONTRACT_KEY)
+        .and_then(|key| key.into_hash())
+        .map(ContractPackageHash::new)
+        .expect("should have contract package hash");
+
+    let test_context = TestContext {
+        cep18_token,
+        cep18_test_contract_package,
+    };
+
+    (builder, test_context)
+}
+```
+
+</details>
+
+### Creating Helper Functions
+
+The previous step has simulated sending a real deploy on the network. The next code snippet in `installer_request_builders.rs` defines helper functions that will be used throughout the testing framework:
+
+- `cep18_check_total_supply` - A function for testing the total supply of the CEP-18 contract instance.
+- `cep18_check_balance_of` - A function for checking an account's balance of CEP-18 tokens.
+- `cep18_check_allowance_of` - A function for checking an account's spending allowance from another account's balance.
+
+These are followed by functions that check specific aspects of the CEP-18 contract. These include `test_cep18_transfer`, `make_cep18_approve_request` and `test_approve_for`.
+
+The following code snippet is an example function that tests the ability to transfer CEP-18 tokens from the default address to the two other addresses established in [contract installation](#installing-the-contract-deploying-the-contract):
+
+<details>
+<summary>Example helper function</summary>
+
+```rust
+// File https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/utility/installer_request_builders.rs
+
+pub(crate) fn test_cep18_transfer(
+    builder: &mut InMemoryWasmTestBuilder,
+    test_context: &TestContext,
+    sender1: Key,
+    recipient1: Key,
+    sender2: Key,
+    recipient2: Key) {
+    let TestContext { cep18_token, .. } = test_context;
+
+    // Defining the amount to be transferred to each account.
+
+    let transfer_amount_1 = U256::from(TRANSFER_AMOUNT_1);
+    let transfer_amount_2 = U256::from(TRANSFER_AMOUNT_2);
+
+    // Checking the pre-existing balances of the default address and the two receiving addresses.
+
+    let sender_balance_before = cep18_check_balance_of(builder, cep18_token, sender1);
+    assert_ne!(sender_balance_before, U256::zero());
+
+    let account_1_balance_before = cep18_check_balance_of(builder, cep18_token, recipient1);
+    assert_eq!(account_1_balance_before, U256::zero());
+
+    let account_2_balance_before = cep18_check_balance_of(builder, cep18_token, recipient1);
+    assert_eq!(account_2_balance_before, U256::zero());
+
+    // Creating the first transfer request.
+
+    let token_transfer_request_1 =
+        make_cep18_transfer_request(sender1, cep18_token, recipient1, transfer_amount_1);
+
+    builder
+        .exec(token_transfer_request_1)
+        .expect_success()
+        .commit();
+
+    // Checking the prior balance against the new balance to ensure the transfer occurred correctly.
+
+    let account_1_balance_after = cep18_check_balance_of(builder, cep18_token, recipient1);
+    assert_eq!(account_1_balance_after, transfer_amount_1);
+    let account_1_balance_before = account_1_balance_after;
+
+    let sender_balance_after = cep18_check_balance_of(builder, cep18_token, sender1);
+    assert_eq!(
+        sender_balance_after,
+        sender_balance_before - transfer_amount_1
+    );
+    let sender_balance_before = sender_balance_after;
+
+    // Creating the second transfer request.
+
+    let token_transfer_request_2 =
+        make_cep18_transfer_request(sender2, cep18_token, recipient2, transfer_amount_2);
+
+    builder
+        .exec(token_transfer_request_2)
+        .expect_success()
+        .commit();
+
+    // Checking prior balances against new balances.
+
+    let sender_balance_after = cep18_check_balance_of(builder, cep18_token, sender1);
+    assert_eq!(sender_balance_after, sender_balance_before);
+
+    let account_1_balance_after = cep18_check_balance_of(builder, cep18_token, recipient1);
+    assert!(account_1_balance_after < account_1_balance_before);
+    assert_eq!(
+        account_1_balance_after,
+        transfer_amount_1 - transfer_amount_2
+    );
+
+    let account_2_balance_after = cep18_check_balance_of(builder, cep18_token, recipient2);
+    assert_eq!(account_2_balance_after, transfer_amount_2);
+}
+```
+
+</details>
+
+## Creating Unit Tests
+
+Within this testing context, the [`tests` directory](https://github.com/casper-ecosystem/cep18/tree/dev/tests/src) includes a variety of unit tests, which verify the contract code by invoking the functions defined in the [installer_request_builders.rs](https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/utility/installer_request_builders.rs) file.
+
+The example below shows one of the tests. Visit [GitHub](https://github.com/casper-ecosystem/cep18/tree/dev/tests/src) to find all the available tests.
+
+<details>
+<summary>Example test querying token properties</summary>
+
+```rust
+// File https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/install.rs
+
+use casper_engine_test_support::DEFAULT_ACCOUNT_ADDR;
+use casper_types::{Key, U256};
+
+use crate::utility::{
+    constants::{
+        ALLOWANCES_KEY, BALANCES_KEY, DECIMALS_KEY, NAME_KEY, SYMBOL_KEY, TOKEN_DECIMALS,
+        TOKEN_NAME, TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, TOTAL_SUPPLY_KEY,
+    },
+    installer_request_builders::{
+        cep18_check_balance_of, invert_cep18_address, setup, TestContext,
+    },
+};
+
+#[test]
+fn should_have_queryable_properties() {
+    let (mut builder, TestContext { cep18_token, .. }) = setup();
+
+    let name: String = builder.get_value(cep18_token, NAME_KEY);
+    assert_eq!(name, TOKEN_NAME);
+
+    let symbol: String = builder.get_value(cep18_token, SYMBOL_KEY);
+    assert_eq!(symbol, TOKEN_SYMBOL);
+
+    let decimals: u8 = builder.get_value(cep18_token, DECIMALS_KEY);
+    assert_eq!(decimals, TOKEN_DECIMALS);
+
+    let total_supply: U256 = builder.get_value(cep18_token, TOTAL_SUPPLY_KEY);
+    assert_eq!(total_supply, U256::from(TOKEN_TOTAL_SUPPLY));
+
+    let owner_key = Key::Account(*DEFAULT_ACCOUNT_ADDR);
+
+    let owner_balance = cep18_check_balance_of(&mut builder, &cep18_token, owner_key);
+    assert_eq!(owner_balance, total_supply);
+
+    let contract_balance =
+        cep18_check_balance_of(&mut builder, &cep18_token, Key::Hash(cep18_token.value()));
+    assert_eq!(contract_balance, U256::zero());
+
+    // Ensures that Account and Contract ownership is respected and we're not keying ownership under
+    // the raw bytes regardless of variant.
+    let inverted_owner_key = invert_cep18_address(owner_key);
+    let inverted_owner_balance =
+        cep18_check_balance_of(&mut builder, &cep18_token, inverted_owner_key);
+    assert_eq!(inverted_owner_balance, U256::zero());
+}
+```
+
+</details>
+
+## Running the Tests
+
+The [lib.rs](https://github.com/casper-ecosystem/cep18/blob/dev/tests/src/lib.rs) file is configured to run the example integration tests via the `make test` command:
+
+```rust
+#[cfg(test)]
+mod allowance;
+#[cfg(test)]
+mod install;
+#[cfg(test)]
+mod mint_and_burn;
+#[cfg(test)]
+mod transfer;
+#[cfg(test)]
+mod utility;
+```
+
+To run the tests, navigate to the parent [cep18 directory](https://github.com/casper-ecosystem/cep18) and run the command:
+
+```bash
+make test
+```
+
+This example uses `bash`. If you are using a Rust IDE, you need to configure it to run the tests.

--- a/source/docs/casper/resources/tokens/cep18/tests.md
+++ b/source/docs/casper/resources/tokens/cep18/tests.md
@@ -1,5 +1,5 @@
 ---
-title: Testing Framework for CEP-18
+title: Testing Guide
 slug: /resources/tokens/cep18/tests
 ---
 
@@ -34,7 +34,7 @@ To build and run the tests, issue the following command in the project folder, [
 make test
 ```
 
-The project contains a [Makefile](https://github.com/casper-ecosystem/cep18/blob/dev/Makefile), which is a custom build script that compiles the contract before running tests in _release_ mode. Then, the script copies the `contract.wasm` file to the [tests/wasm](https://github.com/casper-ecosystem/cep18/tree/master/tests/wasm) directory. In practice, you only need to run the `make test` command during development.
+The project contains a [Makefile](https://github.com/casper-ecosystem/cep18/blob/dev/Makefile), which is a custom build script that compiles the contract before running tests in _release_ mode. Then, the script copies the `contract.wasm` file to the `tests/wasm` directory. In practice, you only need to run the `make test` command during development.
 
 ## Configuring the Test Package
 
@@ -65,7 +65,7 @@ In Github, you will find an [example](https://github.com/casper-ecosystem/cep18/
 - [Step 2](#deploying-the-contract) - Deploy the compiled contract to the blockchain and query it.
 - [Step 3](#invoking-contract-entrypoints) - Create additional deploys for calling each of the entrypoints in the contract.
 
-The [TestFixture](https://github.com/casper-ecosystem/cep18/blob/master/example/cep18-tests/src/test_fixture/test_fixture.rs) accomplishes these steps by simulating a real-world deploy that stores the contract on the blockchain and then invoking the contract's entrypoints.
+The test fixture accomplishes these steps by simulating a real-world deploy that stores the contract on the blockchain and then invoking the contract's entrypoints.
 
 ### Setting up the Testing Context
 

--- a/source/docs/casper/resources/tokens/cep18/transfer.md
+++ b/source/docs/casper/resources/tokens/cep18/transfer.md
@@ -1,5 +1,5 @@
 ---
-title: CEP-18 Token Transfers and Allowances
+title: CEP-18 Transfers
 slug: /resources/tokens/cep18/transfer
 ---
 
@@ -11,7 +11,7 @@ This document describes how to transfer CEP-18 tokens on a Casper network using 
 
 The following command will invoke the `transfer` entry point on your instance of CEP-18, directing it to transfer 10 of the associated CEP-18 tokens to another account.
 
-```bash
+```json
 casper-client put-deploy -n http://<node IP>:<PORT> \
 // The chain name of the Casper network on which your CEP-18 instance was installed.
 --chain-name <CHAIN NAME>\
@@ -51,7 +51,7 @@ This command will return a deploy hash that you can query using `casper-client g
 
 The following Casper client command invokes the `check_balance_of` entry point on the `cep18_test_contract`.
 
-```bash
+```json
 casper-client put-deploy -n http://<node IP>:<PORT>\
 --secret-key ~/casper/demo/user_a/secret_key.pem \
 --session-package-name "cep18_test_contract" \
@@ -84,7 +84,7 @@ After sending this command, you will need to query the `results` URef within the
 
 You can use the following command to query global state for the `results` URef.
 
-```bash
+```json
 casper-client query-global-state -n http://<NODE IP>:<PORT> \
 // This is the `results` URef location from your `cep18_test_contract` `NamedKeys`
 --key uref-a46ad389b53715d9991a513c8ca48e1502facc4c563c0700a31e830c4cb8a7d4-007 \
@@ -131,7 +131,7 @@ The Casper fungible token contract features an `allowance` entry point that allo
 
 The following command approves a third-party account to spend an `allowance` of 15 CEP-18 tokens from the balance of the account that sent the CEP-18 instance. 
 
-```bash
+```json
 casper-client put-deploy -n http://<node IP>:<PORT>\
 --chain-name <CHAIN NAME> \
 --secret-key ~/casper/demo/user_a/secret_key.pem \
@@ -165,7 +165,7 @@ casper-client put-deploy -n http://<node IP>:<PORT>\
 
 After approving an account to spend an `allowance` of tokens, we can verify the allotted allowance by using the utility contract. The following command will write the `allowance` of the spender's account to the `result` URef of in the utility contract's `NamedKeys`:
 
-```bash
+```json
 casper-client put-deploy -n http://<node IP>:<PORT>\
 --secret-key ~/casper/demo/user_a/secret_key.pem \
 --session-package-name "cep18_test_contract" \
@@ -199,7 +199,7 @@ casper-client put-deploy -n http://<node IP>:<PORT>\
 
 The following command queries global state to return the value stored under the `result` URef:
 
-```bash
+```json
 casper-client query-global-state -n http://<node IP>:<PORT> \
 // This is the previously identified `result` URef from the utility contract's `NamedKeys`
 --key uref-a46ad389b53715d9991a513c8ca48e1502facc4c563c0700a31e830c4cb8a7d4-007 \
@@ -242,7 +242,7 @@ You should get a response similar to the following:
 
 The following command allows an account to transfer CEP-18 tokens held by another account up to their approved `allowance`.
 
-```bash
+```json
 casper-client put-deploy -n http://<NODE IP>:<PORT> \
 --chain-name <CHAIN NAME> \
 // This is the secret key for the account that is spending their `allowance` from another account's balance.

--- a/source/docs/casper/resources/tokens/cep18/transfer.md
+++ b/source/docs/casper/resources/tokens/cep18/transfer.md
@@ -1,0 +1,280 @@
+---
+title: CEP-18 Token Transfers and Allowances
+slug: /resources/tokens/cep18/transfer
+---
+
+# CEP-18 Token Transfers and Allowances
+
+This document describes how to transfer CEP-18 tokens on a Casper network using the Casper client. The [Exploring the CEP18 Contracts](./query.md) documentation contains more in depth explanations on how to find the various hashes and URefs referenced throughout this document.
+
+## Transferring CEP-18 Tokens to Another Account
+
+The following command will invoke the `transfer` entry point on your instance of CEP-18, directing it to transfer 10 of the associated CEP-18 tokens to another account.
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT> \
+// The chain name of the Casper network on which your CEP-18 instance was installed.
+--chain-name <CHAIN NAME>\
+// The local path to your account's secret key.
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+// The contract hash of your CEP-18 contract instance.
+--session-hash hash-b568f50a64acc8bbe43462ffe243849a88111060b228dacb8f08d42e26985180 \
+// The name of the entry point you are invoking.
+--session-entry-point "transfer" \
+// The account hash of the account that you are sending CEP-18 tokens to.
+--session-arg "recipient:key='account-hash-9f81014b9c7406c531ebf0477132283f4eb59143d7903a2fae54358b26cea44b" \
+// The amount of CEP-18 tokens you are sending to the receiving account.
+--session-arg "amount:u256='10'" \
+// The gas payment you are allotting, in motes.
+--payment-amount "10000000000"
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT> \
+--chain-name <CHAIN NAME>\
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-hash hash-b568f50a64acc8bbe43462ffe243849a88111060b228dacb8f08d42e26985180 \
+--session-entry-point "transfer" \
+--session-arg "recipient:key='account-hash-9f81014b9c7406c531ebf0477132283f4eb59143d7903a2fae54358b26cea44b" \
+--session-arg "amount:u256='50'" \
+--payment-amount "10000000000"
+```
+
+</details>
+
+This command will return a deploy hash that you can query using `casper-client get-deploy`. Querying the Deploy allows you to verify execution success, but you will need to use the `check_balance_of` entry point on the utility contract to verify the account's balance.
+
+### Invoking the `check_balance_of` Entry Point
+
+The following Casper client command invokes the `check_balance_of` entry point on the `cep18_test_contract`.
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT>\
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-package-name "cep18_test_contract" \
+--session-entry-point "check_balance_of" \
+// This is the contract hash of your CEP-18 contract instance, passed in as an `account-hash-`.
+--session-arg "token_contract:account_hash='account-hash-b568f50a64acc8bbe43462ffe243849a88111060b228dacb8f08d42e26985180'" \
+// This is the account hash of the account you are checking the balance of.
+--session-arg "address:key='account-hash-303c0f8208220fe9a4de40e1ada1d35fdd6c678877908f01fddb2a56502d67fd'" \
+--chain-name <CHAIN NAME> \
+--payment-amount 1000000000
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT>\
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-package-name "cep18_test_contract" \
+--session-entry-point "check_balance_of" \
+--session-arg "token_contract:account_hash='account-hash-b568f50a64acc8bbe43462ffe243849a88111060b228dacb8f08d42e26985180'" \
+--session-arg "address:key='account-hash-303c0f8208220fe9a4de40e1ada1d35fdd6c678877908f01fddb2a56502d67fd'" \
+--chain-name <CHAIN NAME> \
+--payment-amount 1000000000
+```
+
+</details>
+
+After sending this command, you will need to query the `results` URef within the `NamedKeys` of your `cep18_test_contract` utility contract instance. More information on finding this URef can be found in the [Exploring the CEP18 Contracts](./query.md#querying-the-utility-contract) document.
+
+You can use the following command to query global state for the `results` URef.
+
+```bash
+casper-client query-global-state -n http://<NODE IP>:<PORT> \
+// This is the `results` URef location from your `cep18_test_contract` `NamedKeys`
+--key uref-a46ad389b53715d9991a513c8ca48e1502facc4c563c0700a31e830c4cb8a7d4-007 \
+--state-root-hash 3aecd0e4b6ec29ee7c1eed701132eabfe6e66a1e0f1595c9c65bfed447e474f7
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client query-global-state -n http://<NODE IP>:<PORT> \
+--key uref-a46ad389b53715d9991a513c8ca48e1502facc4c563c0700a31e830c4cb8a7d4-007 \
+--state-root-hash 3aecd0e4b6ec29ee7c1eed701132eabfe6e66a1e0f1595c9c65bfed447e474f7
+```
+
+</details>
+
+This command should show something similar to the following in response, with `parsed` being the amount of CEP-18 tokens that the account holds.
+
+```bash
+{
+  "id": -8841145064950441692,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.0.0",
+    "block_header": null,
+    "merkle_proof": "[3796 hex chars]",
+    "stored_value": {
+      "CLValue": {
+        "bytes": "010a",
+        "cl_type": "U256",
+        "parsed": "10"
+      }
+    }
+  }
+}
+```
+
+## Approving an Allowance for Another Account
+
+The Casper fungible token contract features an `allowance` entry point that allows an account to delegate another account to spend a preset number of CEP-18 tokens from their balance. 
+
+### Approving an Account to Spend Tokens on Another Account's Behalf
+
+The following command approves a third-party account to spend an `allowance` of 15 CEP-18 tokens from the balance of the account that sent the CEP-18 instance. 
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT>\
+--chain-name <CHAIN NAME> \
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+// This is the contract hash of the CEP-18 token contract.
+--session-hash hash-05d893e76c731729fc26339e5a970bd79fbf4a6adf743c8385431fb494bff45e \
+--session-entry-point "approve" \
+// This is the account hash of the account that will receive an allowance from the balance of the account that sent the Deploy.
+--session-arg "spender:key='account-hash-17192017d32db5dc9f598bf8ac6ac35ee4b64748669b00572d88335941479513'" \
+// This is the number of CEP-18 tokens included in the allowance.
+--session-arg "amount:u256='15'" \
+--payment-amount "10000000000"
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT>\
+--chain-name <CHAIN NAME> \
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-hash hash-05d893e76c731729fc26339e5a970bd79fbf4a6adf743c8385431fb494bff45e \
+--session-entry-point "approve" \
+--session-arg "spender:key='account-hash-17192017d32db5dc9f598bf8ac6ac35ee4b64748669b00572d88335941479513'" \
+--session-arg "amount:u256='15'" \
+--payment-amount "10000000000"
+```
+
+</details>
+
+### Verifying a Previously Issued Allowance
+
+After approving an account to spend an `allowance` of tokens, we can verify the allotted allowance by using the utility contract. The following command will write the `allowance` of the spender's account to the `result` URef of in the utility contract's `NamedKeys`:
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT>\
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-package-name "cep18_test_contract" \
+--session-entry-point "check_allowance_of" \
+// This is the contract hash for the CEP-18 token.
+--session-arg "token_contract:account_hash='account-hash-05d893e76c731729fc26339e5a970bd79fbf4a6adf743c8385431fb494bff45e'" \
+// This is the account hash for the account that owns the CEP-18 tokens.
+--session-arg "owner:key='account-hash-39f15c23df9be1244572bb499fac62cbcad3cab2dc1438609842f602f943d7d2'" \
+// This is the account hash for the account previously authorized to spend an allowance of the owning account's CEP-18 tokens.
+--session-arg "spender:key='account-hash-17192017d32db5dc9f598bf8ac6ac35ee4b64748669b00572d88335941479513'" \
+--chain-name <CHAIN NAME> \
+--payment-amount 10000000000
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://<node IP>:<PORT>\
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-package-name "cep18_test_contract" \
+--session-entry-point "check_allowance_of" \
+--session-arg "token_contract:account_hash='account-hash-05d893e76c731729fc26339e5a970bd79fbf4a6adf743c8385431fb494bff45e'" \
+--session-arg "owner:key='account-hash-39f15c23df9be1244572bb499fac62cbcad3cab2dc1438609842f602f943d7d2'" \
+--session-arg "spender:key='account-hash-17192017d32db5dc9f598bf8ac6ac35ee4b64748669b00572d88335941479513'" \
+--chain-name <CHAIN NAME> \
+--payment-amount 10000000000
+```
+
+</details>
+
+The following command queries global state to return the value stored under the `result` URef:
+
+```bash
+casper-client query-global-state -n http://<node IP>:<PORT> \
+// This is the previously identified `result` URef from the utility contract's `NamedKeys`
+--key uref-a46ad389b53715d9991a513c8ca48e1502facc4c563c0700a31e830c4cb8a7d4-007 \
+--state-root-hash e64f877f65df26db74300bb175c244d589bd88a23b91abf9ceb73ac5e65e90f1
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client query-global-state -n http://<node IP>:<PORT> \
+--key uref-a46ad389b53715d9991a513c8ca48e1502facc4c563c0700a31e830c4cb8a7d4-007 \
+--state-root-hash e64f877f65df26db74300bb175c244d589bd88a23b91abf9ceb73ac5e65e90f1
+```
+
+</details>
+
+You should get a response similar to the following:
+
+```bash
+{
+  "id": -9142472925449984061,
+  "jsonrpc": "2.0",
+  "result": {
+    "api_version": "1.0.0",
+    "block_header": null,
+    "merkle_proof": "[3796 hex chars]",
+    "stored_value": {
+      "CLValue": {
+        "bytes": "010f",
+        "cl_type": "U256",
+        "parsed": "15"
+      }
+    }
+  }
+}
+```
+
+### Transferring Tokens from an Allowance
+
+The following command allows an account to transfer CEP-18 tokens held by another account up to their approved `allowance`.
+
+```bash
+casper-client put-deploy -n http://<NODE IP>:<PORT> \
+--chain-name <CHAIN NAME> \
+// This is the secret key for the account that is spending their `allowance` from another account's balance.
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+// This is the CEP-18 token contract.
+--session-hash hash-05d893e76c731729fc26339e5a970bd79fbf4a6adf743c8385431fb494bff45e \
+--session-entry-point "transfer_from" \
+// This is the account hash of the account that holds the CEP-18 in their balance.
+--session-arg "owner:key='account-hash-39f15c23df9be1244572bb499fac62cbcad3cab2dc1438609842f602f943d7d2'" \
+// This is the account hash of the account that will receive the transferred CEP-18 tokens.
+--session-arg "recipient:key='account-hash-17192017d32db5dc9f598bf8ac6ac35ee4b64748669b00572d88335941479513'" \
+// This is the amount of tokens to be transferred. If this amount exceeds the `allowance` of the account sending the Deploy, it will fail.
+--session-arg "amount:u256='10'" \
+--payment-amount "10000000000"
+```
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://<NODE IP>:<PORT> \
+--chain-name <CHAIN NAME> \
+--secret-key ~/casper/demo/user_a/secret_key.pem \
+--session-hash hash-05d893e76c731729fc26339e5a970bd79fbf4a6adf743c8385431fb494bff45e \
+--session-entry-point "transfer_from" \
+--session-arg "owner:key='account-hash-39f15c23df9be1244572bb499fac62cbcad3cab2dc1438609842f602f943d7d2'" \
+--session-arg "recipient:key='account-hash-17192017d32db5dc9f598bf8ac6ac35ee4b64748669b00572d88335941479513'" \
+--session-arg "amount:u256='10'" \
+--payment-amount "10000000000"
+```
+</details>
+
+### Next Steps
+
+- [Testing Framework for CEP-18](./tests.md)

--- a/source/docs/casper/resources/tokens/cep78/introduction.md
+++ b/source/docs/casper/resources/tokens/cep78/introduction.md
@@ -1,24 +1,10 @@
 ---
-title: CEP-78 Enhanced NFT Standard Introduction
+title: Introduction
 slug: /resources/tokens/cep78/introduction
 ---
 
 
 # CEP-78 Enhanced NFT Standard Introduction
-
-## Table of Contents
-
-1. [Usage](#usage)
-
-   - [Installing the Contract](#building-the-contract)
-
-   - [Utility Session Code](#utility-session-code)
-
-2. [Installing and Interacting with CEP-78 Contracts using the Rust Casper Client](#installing-and-interacting-with-the-contract-using-the-rust-casper-client)
-
-3. [Test Suite and Specification](#test-suite-and-specification)
-
-4. [Error Codes](#error-codes)
 
 ## Usage
 

--- a/source/docs/casper/resources/tokens/cep78/introduction.md
+++ b/source/docs/casper/resources/tokens/cep78/introduction.md
@@ -1,0 +1,282 @@
+---
+title: CEP-78 Enhanced NFT Standard Introduction
+slug: /resources/tokens/cep78/introduction
+---
+
+
+# CEP-78 Enhanced NFT Standard Introduction
+
+## Table of Contents
+
+1. [Usage](#usage)
+
+   - [Installing the Contract](#building-the-contract)
+
+   - [Utility Session Code](#utility-session-code)
+
+2. [Installing and Interacting with CEP-78 Contracts using the Rust Casper Client](#installing-and-interacting-with-the-contract-using-the-rust-casper-client)
+
+3. [Test Suite and Specification](#test-suite-and-specification)
+
+4. [Error Codes](#error-codes)
+
+## Usage
+
+### Building the Contract
+
+The `main.rs` file within the contract provides the installer for the NFT contract. Users can compile the contract to Wasm using the `make build-contract` command from the Makefile provided.
+
+The pre-built Wasm for the contract and all other utility session code can be found as part of the most current release. Users wishing to build the Wasm themselves can pull the code and use the `make build-contract` command provided in the Makefile. Please note, however, that you must install `wasm-strip` to build the contract.
+
+The `call` method will install the contract with the necessary entrypoints and call the `init()` entrypoint, which allows the contract to self-initialize and set up the necessary state variables for operation.
+
+### Required Runtime Arguments
+
+The following are the required runtime arguments that must be passed to the installer session code to correctly install the NFT contract. For more information on the modalities that these arguments set, please refer to the [Modalities](./modalities.md) documentation.
+
+- `"collection_name":` The name of the NFT collection, passed in as a `String`. This parameter is required and cannot be changed post installation.
+- `"collection_symbol"`: The symbol representing a given NFT collection, passed in as a `String`. This parameter is required and cannot be changed post installation.
+- `"total_token_supply"`: The total number of NFTs that a specific instance of a contract will mint passed in as a `U64` value. This parameter is required.
+- `"ownership_mode"`: The [`OwnershipMode`](./modalities.md#ownership) modality that dictates the ownership behavior of the NFT contract. This argument is passed in as a `u8` value and is required at the time of installation.
+- `"nft_kind"`: The [`NFTKind`](./modalities.md#nftkind) modality that specifies the off-chain items represented by the on-chain NFT data. This argument is passed in as a `u8` value and is required at the time of installation.
+- `"json_schema"`: The JSON schema for the NFT tokens that will be minted by the NFT contract passed in as a `String`. This parameter is required if the metadata kind is set to `CustomValidated(3)` and cannot be changed post installation.
+- `"nft_metadata_kind"`: The base metadata schema for the NFTs to be minted by the NFT contract. This argument is passed in as a `u8` value and is required at the time of installation.
+- `"identifier_mode"`: The [`NFTIdentifierMode`](./modalities.md#nftidentifiermode) modality dictates the primary identifier for NFTs minted by the contract. This argument is passed in as a `u8` value and is required at the time of installation.
+- `"metadata_mutability"`: The [`MetadataMutability`](./modalities.md#metadata-mutability) modality dictates whether the metadata of minted NFTs can be updated. This argument is passed in as a `u8` value and is required at the time of installation.
+
+The following are the optional parameters that can be passed in at the time of installation.
+
+- `"minting_mode"`: The [`MintingMode`](./modalities.md#minting) modality that dictates the access to the `mint()` entry-point in the NFT contract. This is an optional parameter that will default to restricting access to the installer of the contract. This parameter cannot be changed once the contract has been installed.
+- `"allow_minting"`: The `"allow_minting"` flag allows the installer of the contract to pause the minting of new NFTs. The `allow_minting` is a boolean toggle that allows minting when `true`. If not provided at install the toggle will default to `true`. This value can be changed by the installer by calling the `set_variables()` entrypoint.
+
+- `"whitelist_mode"`: The [`WhitelistMode`](./modalities.md#whitelistmode) modality dictates whether the contract whitelist can be updated. This optional parameter will default to an unlocked whitelist that can be updated post installation. This parameter cannot be changed once the contract has been installed.
+- `"holder_mode"`: The [`NFTHolderMode`](./modalities.md#nftholdermode) modality dictates which entities can hold NFTs. This is an optional parameter and will default to a mixed mode allowing either `Accounts` or `Contracts` to hold NFTs. This parameter cannot be changed once the contract has been installed.
+- `"contract_whitelist"`: The contract whitelist is a list of contract hashes that specifies which contracts can call the `mint()` entrypoint to mint NFTs. This is an optional parameter which will default to an empty whitelist. This value can be changed via the `set_variables` post installation. If the whitelist mode is set to locked, a non-empty whitelist must be passed; else, installation of the contract will fail.
+- `"burn_mode"`: The [`BurnMode`](./modalities.md#burnmode) modality dictates whether minted NFTs can be burnt. This is an optional parameter and will allow tokens to be burnt by default. This parameter cannot be changed once the contract has been installed.
+- `"owner_reverse_lookup_mode"`: The [`OwnerReverseLookupMode`](./modalities.md#reportingmode) modality dictates whether the lookup for owners to token identifiers is available. This is an optional parameter and will not provide the lookup by default. This parameter cannot be changed once the contract has been installed.
+- `"events_mode"`: The [`EventsMode`](./modalities.md#eventsmode) modality selects the event schema used to record any changes that occur to tokens issued by the contract instance.
+- `"additional_required_metdata"`: An additional metadata schema that must be included. This argument is passed in as a `u8` value.
+- `"optional_metdata"`: An optional metadata schema that may be included. This argument is passed in as a `u8` value.
+
+#### Example deploy
+
+The following is an example of installing the NFT contract via a deploy using the Rust CLI Casper client. You can find more examples [here](./using-casper-client.md).
+
+```bash
+casper-client put-deploy -n http://65.108.0.148:7777/rpc --chain-name "casper-test" --payment-amount 500000000000 -k keys/secret_key.pem --session-path contract/target/wasm32-unknown-unknown/release/contract.wasm \
+--session-arg "collection_name:string='enhanced-nft-1'" \
+--session-arg "collection_symbol:string='ENFT-1'" \
+--session-arg "total_token_supply:u64='10'" \
+--session-arg "ownership_mode:u8='0'" \
+--session-arg "nft_kind:u8='1'" \
+--session-arg "json_schema:string='nft-schema'" \
+--session-arg "allow_minting:bool='true'" \
+--session-arg "owner_reverse_lookup_mode:u8='0'" \
+--session-arg "nft_metadata_kind:u8='2'" \
+--session-arg "identifier_mode:u8='0'" \
+--session-arg "metadata_mutability:u8='1'"
+```
+
+### Utility Session Code
+
+Specific entrypoints in use by the current implementation of the NFT contract require session code to accept return values passed by the contract over the Wasm boundary.
+In order to help with the installation and use of the NFT contract, session code for such entrypoints has been provided. It is recommended that
+users and DApp developers attempting to engage with the NFT contract do so with the help of the provided utility session code. The session code can be found in the `client`
+folder within the project folder.
+
+| Entrypoint name | Session code                  |
+| --------------- | ----------------------------- |
+| `"mint"`        | `client/mint_session`         |
+| `"balance_of"`  | `client/balance_of_session`   |
+| `"get_approved` | `client/get_approved_session` |
+| `"owner_of"`    | `client/owner_of_session`     |
+| `"transfer"`    | `client/transfer_session`     |
+
+### Checking Token Ownership
+
+[Learn to check token ownership](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/tutorials/token-ownership-tutorial.md) starting with version [v1.1.1](https://github.com/casper-ecosystem/cep-78-enhanced-nft/releases/tag/v1.1.1). The `OwnerReverseLookupMode` modality must be set to `Complete` as described [here](./reverse-lookup.md).
+
+
+### Upgrading to Version 1.1.1 
+
+Upgrade to v1.1.1 using a [Standard NamedKey Convention](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/tutorials/standard-migration-tutorial.md) or a [Custom NamedKey Convention](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/tutorials/custom-migration-tutorial.md).
+
+## Installing and Interacting with the Contract using the Rust Casper Client
+
+You can find instructions on installing an instance of the CEP-78 contract using the Rust CLI Casper client [here](./using-casper-client.md).
+
+## Test Suite and Specification
+
+The expected behavior of the NFT contract implementation is asserted by its test suite found in the `tests` folder.
+The test suite and the corresponding unit tests comprise the specification around the contract and outline the expected behaviors
+of the NFT contract across the entire range of possible configurations (i.e modalities and toggles like allow minting). The test suite
+ensures that as new modalities are added, and current modalities are extended, no regressions and conflicting behaviors are introduced.
+The test suite also asserts the correct working behavior of the utility session code provided in the client folder. The tests can be run
+by using the provided `Makefile` and running the `make test` command.
+
+## Error Codes
+
+| Code | Error                                       |
+| ---- | ------------------------------------------- |
+| 1    | InvalidAccount                              |
+| 2    | MissingInstaller                            |
+| 3    | InvalidInstaller                            |
+| 4    | UnexpectedKeyVariant                        |
+| 5    | MissingTokenOwner                           |
+| 6    | InvalidTokenOwner                           |
+| 7    | FailedToGetArgBytes                         |
+| 8    | FailedToCreateDictionary                    |
+| 9    | MissingStorageUref                          |
+| 10   | InvalidStorageUref                          |
+| 11   | MissingOwnerUref                            |
+| 12   | InvalidOwnersUref                           |
+| 13   | FailedToAccessStorageDictionary             |
+| 14   | FailedToAccessOwnershipDictionary           |
+| 15   | DuplicateMinted                             |
+| 16   | FailedToConvertCLValue                      |
+| 17   | MissingCollectionName                       |
+| 18   | InvalidCollectionName                       |
+| 19   | FailedToSerializeMetaData                   |
+| 20   | MissingAccount                              |
+| 21   | MissingMintingStatus                        |
+| 22   | InvalidMintingStatus                        |
+| 23   | MissingCollectionSymbol                     |
+| 24   | InvalidCollectionSymbol                     |
+| 25   | MissingTotalTokenSupply                     |
+| 26   | InvalidTotalTokenSupply                     |
+| 27   | MissingTokenID                              |
+| 28   | InvalidTokenIdentifier                      |
+| 29   | MissingTokenOwners                          |
+| 30   | MissingAccountHash                          |
+| 31   | InvalidAccountHash                          |
+| 32   | TokenSupplyDepleted                         |
+| 33   | MissingOwnedTokensDictionary                |
+| 34   | TokenAlreadyBelongsToMinterFatal            |
+| 35   | FatalTokenIdDuplication                     |
+| 36   | InvalidMinter                               |
+| 37   | MissingMintingMode                          |
+| 38   | InvalidMintingMode                          |
+| 39   | MissingInstallerKey                         |
+| 40   | FailedToConvertToAccountHash                |
+| 41   | InvalidBurner                               |
+| 42   | PreviouslyBurntToken                        |
+| 43   | MissingAllowMinting                         |
+| 44   | InvalidAllowMinting                         |
+| 45   | MissingNumberOfMintedTokens                 |
+| 46   | InvalidNumberOfMintedTokens                 |
+| 47   | MissingTokenMetaData                        |
+| 48   | InvalidTokenMetaData                        |
+| 49   | MissingApprovedAccountHash                  |
+| 50   | InvalidApprovedAccountHash                  |
+| 51   | MissingApprovedTokensDictionary             |
+| 52   | TokenAlreadyApproved                        |
+| 53   | MissingApproveAll                           |
+| 54   | InvalidApproveAll                           |
+| 55   | MissingOperator                             |
+| 56   | InvalidOperator                             |
+| 57   | Phantom                                     |
+| 58   | ContractAlreadyInitialized                  |
+| 59   | MintingIsPaused                             |
+| 60   | FailureToParseAccountHash                   |
+| 61   | VacantValueInDictionary                     |
+| 62   | MissingOwnershipMode                        |
+| 63   | InvalidOwnershipMode                        |
+| 64   | InvalidTokenMinter                          |
+| 65   | MissingOwnedTokens                          |
+| 66   | InvalidAccountKeyInDictionary               |
+| 67   | MissingJsonSchema                           |
+| 68   | InvalidJsonSchema                           |
+| 69   | InvalidKey                                  |
+| 70   | InvalidOwnedTokens                          |
+| 71   | MissingTokenURI                             |
+| 72   | InvalidTokenURI                             |
+| 73   | MissingNftKind                              |
+| 74   | InvalidNftKind                              |
+| 75   | MissingHolderMode                           |
+| 76   | InvalidHolderMode                           |
+| 77   | MissingWhitelistMode                        |
+| 78   | InvalidWhitelistMode                        |
+| 79   | MissingContractWhiteList                    |
+| 80   | InvalidContractWhitelist                    |
+| 81   | UnlistedContractHash                        |
+| 82   | InvalidContract                             |
+| 83   | EmptyContractWhitelist                      |
+| 84   | MissingReceiptName                          |
+| 85   | InvalidReceiptName                          |
+| 86   | InvalidJsonMetadata                         |
+| 87   | InvalidJsonFormat                           |
+| 88   | FailedToParseCep78Metadata                  |
+| 89   | FailedToParse721Metadata                    |
+| 90   | FailedToParseCustomMetadata                 |
+| 91   | InvalidCEP78Metadata                        |
+| 92   | FailedToJsonifyCEP78Metadata                |
+| 93   | InvalidNFT721Metadata                       |
+| 94   | FailedToJsonifyNFT721Metadata               |
+| 95   | InvalidCustomMetadata                       |
+| 96   | MissingNFTMetadataKind                      |
+| 97   | InvalidNFTMetadataKind                      |
+| 98   | MissingIdentifierMode                       |
+| 99   | InvalidIdentifierMode                       |
+| 100  | FailedToParseTokenId                        |
+| 101  | MissingMetadataMutability                   |
+| 102  | InvalidMetadataMutability                   |
+| 103  | FailedToJsonifyCustomMetadata               |
+| 104  | ForbiddenMetadataUpdate                     |
+| 105  | MissingBurnMode                             |
+| 106  | InvalidBurnMode                             |
+| 107  | MissingHashByIndex                          |
+| 108  | InvalidHashByIndex                          |
+| 109  | MissingIndexByHash                          |
+| 110  | InvalidIndexByHash                          |
+| 111  | MissingPageTableURef                        |
+| 112  | InvalidPageTableURef                        |
+| 113  | MissingPageLimit                            |
+| 114  | InvalidPageLimit                            |
+| 115  | InvalidPageNumber                           |
+| 116  | InvalidPageIndex                            |
+| 117  | MissingUnmatchedHashCount                   |
+| 118  | InvalidUnmatchedHashCount                   |
+| 119  | MissingPackageHashForUpgrade                |
+| 120  | MissingPageUref                             |
+| 121  | InvalidPageUref                             |
+| 122  | CannotUpgradeWithZeroSupply                 |
+| 123  | CannotInstallWithZeroSupply                 |
+| 124  | MissingMigrationFlag                        |
+| 125  | InvalidMigrationFlag                        |
+| 126  | ContractAlreadyMigrated                     |
+| 127  | UnregisteredOwnerInMint                     |
+| 128  | UnregisteredOwnerInTransfer                 |
+| 129  | MissingReportingMode                        |
+| 130  | InvalidReportingMode                        |
+| 131  | MissingPage                                 |
+| 132  | UnregisteredOwnerFromMigration              |
+| 133  | ExceededMaxTotalSupply                      |
+| 134  | MissingCep78PackageHash                     |
+| 135  | InvalidCep78InvalidHash                     |
+| 136  | InvalidPackageHashName                      |
+| 137  | InvalidAccessKeyName                        |
+| 138  | InvalidCheckForUpgrade                      |
+| 139  | InvalidNamedKeyConvention                   |
+| 140  | OwnerReverseLookupModeNotTransferable       |
+| 141  | InvalidAdditionalRequiredMetadata           |
+| 142  | InvalidOptionalMetadata                     |
+| 143  | MissingOptionalNFTMetadataKind              |
+| 144  | InvalidOptionalNFTMetadataKind              |
+| 145  | MissingAdditionalNFTMetadataKind            |
+| 146  | InvalidAdditionalNFTMetadataKind            |
+| 147  | InvalidRequirement                          |
+| 148  | MissingEventsMode                           |
+| 149  | InvalidEventsMode                           |
+| 150  | CannotUpgradeToMoreSupply                   |
+| 151  | MissingOperatorDict                         |
+| 152  | MissingApprovedDict                         |
+| 153  | MissingSpenderAccountHash                   |
+| 154  | InvalidSpenderAccountHash                   |
+| 155  | MissingOwnerTokenIdentifierKey              |
+| 156  | InvalidTransferFilterContract               |
+| 157  | MissingTransferFilterContract               |
+| 158  | TransferFilterContractNeedsTransferableMode |
+| 159  | TransferFilterContractDenied                |
+| 160  | MissingACLWhiteList                         |
+| 161  | InvalidACLWhitelist                         |
+| 162  | EmptyACLWhitelist                           |

--- a/source/docs/casper/resources/tokens/cep78/js-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep78/js-tutorial.md
@@ -1,5 +1,5 @@
 ---
-title: CEP-78 JavaScript Client Tutorial
+title: CEP-78 JavaScript Client
 slug: /resources/tokens/cep78/js-tutorial
 ---
 

--- a/source/docs/casper/resources/tokens/cep78/js-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep78/js-tutorial.md
@@ -1,3 +1,8 @@
+---
+title: CEP-78 JavaScript Client Tutorial
+slug: /resources/tokens/cep78/js-tutorial
+---
+
 # CEP-78 JavaScript Client Tutorial
 
 This tutorial outlines the usage of the JavaScript client available for the CEP-78 Enhanced NFT Standard.

--- a/source/docs/casper/resources/tokens/cep78/js-tutorial.md
+++ b/source/docs/casper/resources/tokens/cep78/js-tutorial.md
@@ -1,0 +1,238 @@
+# CEP-78 JavaScript Client Tutorial
+
+This tutorial outlines the usage of the JavaScript client available for the CEP-78 Enhanced NFT Standard.
+
+Further information on the CEP-78 Enhanced NFT Standard can be found [here](https://github.com/casper-ecosystem/cep-78-enhanced-nft).
+
+The client is available in *npm* as [casper-cep78-js-client](https://www.npmjs.com/package/casper-cep78-js-client).
+
+## Client Installation
+
+The client can be installed in a project you have built using TypeScript / Javascript.
+
+To install run:
+
+```js
+npm install casper-cep78-js-client
+```
+
+## Installing a CEP-78 Contract using the JavaScript Client
+
+The `install` method crafts a [Deploy](./deploy-and-deploy-lifecycle/) using `InstallArgs`.
+As with every deploy created by the SDK, you can send it using the `.send(rpcUrl)` method providing the RPC URL that you want to use. It will return deployHash. 
+
+```js
+
+  const cc = new CEP78Client(process.env.NODE_URL!, process.env.NETWORK_NAME!);
+
+  const installDeploy = await cc.install(
+    {
+      collectionName: "my-collection",
+      collectionSymbol: "MY-NFTS",
+      totalTokenSupply: "1000",
+      ownershipMode: NFTOwnershipMode.Transferable,
+      nftKind: NFTKind.Physical,
+      jsonSchema: {
+        properties: {
+          color: { name: "color", description: "", required: true },
+          size: { name: "size", description: "", required: true },
+          material: { name: "material", description: "", required: true },
+          condition: { name: "condition", description: "", required: false },
+        },
+      },
+      nftMetadataKind: NFTMetadataKind.CustomValidated,
+      identifierMode: NFTIdentifierMode.Ordinal,
+      metadataMutability: MetadataMutability.Immutable,
+      mintingMode: MintingMode.Installer,
+      ownerReverseLookupMode: OwnerReverseLookupMode.Complete
+    },
+    "250000000000",
+    FAUCET_KEYS.publicKey,
+    [FAUCET_KEYS]
+  );
+
+  const hash = await installDeploy.send(process.env.http://localhost:11101/rpc);
+
+```
+
+`InstallArgs` are specified as follows:
+
+* `collectionName` - The name of the NFT collection, passed in as a `String`. **This parameter is required and cannot be changed post installation**.
+
+* `collectionSymbol` - The symbol representing a given NFT collection, passed in as a `String`. **This parameter is required and cannot be changed post installation**.
+
+* `totalTokenSupply` - The total number of NFTs that a specific contract instance will mint passed in as a `U64` value. **This parameter is required and cannot be changed post installation**.
+
+* `ownershipMode` - The `OwnershipMode` modality that dictates the ownership behavior of the NFT contract. This argument is passed in as a `u8` value and is required at the time of installation.
+
+* `nftKind` - The `NFTKind` modality that specifies the off-chain items represented by the on-chain NFT data. This argument is passed in as a `u8` value and is required at the time of installation.
+
+* `jsonSchema` - The JSON schema for the NFT tokens that will be minted by the NFT contract passed in as a `String`. More information on `NFTMetadataKind` can be found [here](./modalities.md#nftmetadatakind). This parameter may be left empty if metadata kind is set to `Raw(3)`. If the metadata kind is set to `CustomValidated(4)`, it will require a specifically formatted custom schema. This parameter **cannot be changed post installation**.
+
+* `nftMetadataKind` - The metadata schema for the NFTs to be minted by the NFT contract. This argument is passed in as a `u8` value and is required at the time of installation.
+
+* `identifierMode` - The `NFTIdentifierMode` modality dictates the primary identifier for NFTs minted by the contract. This argument is passed in as a `u8` value and is required at the time of installation.
+
+* `metadataMutability` - The `MetadataMutability` modality dictates whether the metadata of minted NFTs can be updated. This argument is passed in as a `u8` value and is required at the time of installation.
+
+* `mintingmode` - The `MintingMode` modality dictates the access to the `mint()` entry point in the NFT contract. This optional parameter will default to restricting access to the installer of the contract. **This parameter cannot be changed once the contract has been installed**.
+
+* `holdermode` - The `NFTHolderMode` modality dictates which entities can hold NFTs. This optional parameter will default to a mixed mode, allowing either `Accounts` or `Contracts` to hold NFTs. **This parameter cannot be changed once the contract has been installed**.
+
+* `burnMode` - The `BurnMode` modality dictates whether minted NFTs can be burned. This optional parameter will allow tokens to be burnt by default. **This parameter cannot be changed once the contract has been installed**.
+
+* `ownerReverseLookupMode` - The `OwnerReverseLookupMode` dictates whether the contract will index ownership of tokens as outlined [here](./reverse-lookup.md#the-cep-78-page-system) to allow lookup of owned tokens by account. **This parameter cannot be changed once the contract has been installed**.
+
+Further information on CEP-78 modality options can be found [here](./modalities.md).
+
+## Minting a Token
+
+The CEP-78 JS Client includes code to construct a deploy that will `Mint` a token, as follows:
+
+```js
+
+  const mintDeploy = cc.mint(
+    {
+      owner: FAUCET_KEYS.publicKey,
+      meta: {
+        color: "Blue",
+        size: "Medium",
+        material: "Aluminum",
+        condition: "Used",
+      },
+    },
+    { useSessionCode: true },
+    "2000000000",
+    FAUCET_KEYS.publicKey,
+    [FAUCET_KEYS]
+  );
+
+  const mintDeployHash = await mintDeploy.send("http://localhost:11101/rpc");
+
+```
+The arguments adhere to those provided in the original installation, with the `.send()` pointing to a valid RPC URL on your target Casper network. In this instance, we are using an NCTL RPC URL.
+
+In this example, the [`useSessionCode`](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/client-js/examples/usage.ts#L86-L88) variable decides if the user will call `mint` using session code, or not. It will be set to `true` if the `OwnerReverseLookupMode` is set to `Complete`. [It then registers the recipient with the contract](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/client-js/examples/usage.ts#L116-L130) and mints the token.
+
+If `OwnerReverseLookupMode` is set to `NoLookup`, `useSessionCode` will be set to `false` and it will simply mint the token as it does not need to register the recipient.
+
+## Register Recipient 
+
+As we used `ownerReverseLookupMode: OwnerReverseLookupMode.Complete` in this contract installation, we must register the recipient. To do this, we construct a `register` deploy:
+
+```js
+
+    const registerDeploy = cc.register(
+      {
+        tokenOwner: USER1_KEYS.publicKey,
+      },
+      "1000000000",
+      USER1_KEYS.publicKey,
+      [USER1_KEYS]
+    );
+
+    const registerDeployHash = await registerDeploy.send("http://localhost:11101/rpc");
+    
+```
+    
+## Transferring a Token
+
+After minting one or more tokens, you can then use the following code to transfer the tokens between accounts:
+
+```js
+
+  const transferDeploy = cc.transfer(
+    {
+      tokenId: "0",
+      source: FAUCET_KEYS.publicKey,
+      target: USER1_KEYS.publicKey,
+    },
+    { useSessionCode: true },
+    "13000000000",
+    FAUCET_KEYS.publicKey,
+    [FAUCET_KEYS]
+  );
+
+  const transferDeployHash = await transferDeploy.send("http://localhost:11101/rpc");
+
+```
+
+Transferring accepts the following arguments:
+
+* `tokenId` - The sequential ID assigned to a token in mint order.
+
+* `source` - The account sending the token in question.
+
+* `target` - The account receiving the transferred token.
+
+As above, the `useSessionCode` variable determines if the user will call `transfer` using session code based on the setting of `OwnerReverseLookupMode`.
+
+## Burning a Token
+
+The following code shows how to burn a minted NFT that you hold and have access rights to, requiring only the `tokenId` argument:
+
+```js
+
+  const burnDeploy = await contractClient.burn(
+    { tokenId: "0" },
+    "13000000000",
+    USER1_KEYS.publicKey,
+    [USER1_KEYS]
+  );
+
+  const burnDeployHash = await burnDeploy.send("http://localhost:11101/rpc");
+
+```
+
+## Example Usages
+
+### Running an Install Example
+
+This repository includes an example script for installing a CEP-78 contract instance.
+
+You will need to define the following variables in the `.env` file:
+
+* `NODE_URL` - The address of a node. If you are testing using [NCTL](./developers/dapps/setup-nctl), this will be `http://localhost:11101/rpc`.
+
+* `NETWORK_NAME` - The name of the Casper network you are operating on, `casper-net-1` when testing using a local network with NCTL.
+
+* `MASTER_KEY_PAIR_PATH` - The path to the key pair of the minting account.
+
+* `USER1_KEY_PAIR_PATH` - The path to an additional account's key pair for use in testing transfer features.
+
+You may also need to install associated dependencies using:
+
+```js
+npm i
+```
+
+This example can be run using the following command:
+
+```js
+npm run example:install
+```
+
+The example will then return the installation's `deployHash`, and inform you when the installation is successful.
+
+The example will then provide the installing account's information, which will include the CEP-78 NFT contract's hash and package hash.
+
+
+### Running a Usage Example
+
+A usage example uses the same variables as the Install example above, but tests the basic functionality of the contract after installation.
+
+The usage example can be run using the following command:
+
+```js
+npm run example:usage
+```
+
+This example will acquire the contract's hash and package hash, prior to sending three separate deploys to perform several function tests as follows:
+
+* `Mint` - The example will attempt to mint an NFT using the installation account.
+
+* `Transfer` - The example will transfer the previously minted NFT to a second account (USER1 as defined in the variables.)
+
+* `Burn` - The example will burn the minted NFT.
+
+The associated code for these deploys may be found in the `client-js/examples` directory.

--- a/source/docs/casper/resources/tokens/cep78/modalities.md
+++ b/source/docs/casper/resources/tokens/cep78/modalities.md
@@ -1,0 +1,367 @@
+---
+title: CEP-78 Modalities
+slug: /resources/tokens/cep78/modalities
+---
+
+
+# CEP-78 Modalities
+
+The enhanced NFT implementation supports various 'modalities' that dictate the behavior of a specific contract instance. Modalities represent the common expectations around contract usage and behavior.
+
+The following section discusses the currently implemented modalities and illustrates the significance of each.
+
+<b>Modalities</b>
+
+
+- [Ownership](#ownership)
+- [NFTKind](#nftkind)
+- [NFTHolderMode](#nftholdermode)
+- [WhitelistMode](#whitelistmode)
+- [Minting](#minting)
+- [NFTMetadataKind](#nftmetadatakind)
+- [NFTIdentifierMode](#nftidentifiermode)
+- [Metadata Mutability](#metadata-mutability)
+- [BurnMode](#burnmode)
+- [OwnerReverseLookupMode](#ownerreverselookupmode)
+- [NamedKeyConventionMode](#namedkeyconventionmode)
+- [EventsMode](#eventsmode)
+
+<b>Further Information</b>
+
+- [Modality Conflicts](#modality-conflicts)
+
+## Ownership
+
+This modality specifies the behavior regarding ownership of NFTs and whether the owner of the NFT can change over the contract's lifetime. There are three modes:
+
+1. `Minter`: `Minter` mode is where the ownership of the newly minted NFT is attributed to the minter of the NFT and cannot be specified by the minter. In the `Minter` mode the owner of the NFT will not change and thus cannot be transferred to another entity.
+2. `Assigned`: `Assigned` mode is where the owner of the newly minted NFT must be specified by the minter of the NFT. In this mode, the assigned entity can be either minter themselves or a separate entity. However, similar to the `Minter` mode, the ownership in this mode cannot be changed, and NFTs minted in this mode cannot be transferred from one entity to another.
+3. `Transferable`: In the `Transferable` mode the owner of the newly minted NFT must be specified by the minter. However, in the `Transferable` mode, NFTs can be transferred from the owner to another entity.
+
+In all the three mentioned modes, the owner entity is currently restricted to `Accounts` on the Casper network.
+
+**Note**: In the `Transferable` mode, it is possible to transfer the NFT to an `Account` that does not exist.
+
+This `Ownership` mode is a required installation parameter and cannot be changed once the contract has been installed.
+The mode is passed in as `u8` value to the `"ownership_mode"` runtime argument.
+
+| Ownership    | u8  |
+| ------------ | --- |
+| Minter       | 0   |
+| Assigned     | 1   |
+| Transferable | 2   |
+
+The ownership mode of a contract can be determined by querying the `ownership_mode` entry within the contract's `NamedKeys`.
+
+## NFTKind
+
+The `NFTKind` modality specifies the commodity that NFTs minted by a particular contract will represent. Currently, the `NFTKind` modality does not alter or govern the behavior of the contract itself
+and only exists to specify the correlation between on-chain data and off-chain items. There are three different variations of the `NFTKind` mode.
+
+1. `Physical`: The NFT represents a real-world physical item e.g., a house.
+2. `Digital`: The NFT represents a digital item, e.g., a unique JPEG or digital art.
+3. `Virtual`: The NFT is the virtual representation of a physical notion, e.g., a patent or copyright.
+
+The `NFTKind` mode is a required installation parameter and cannot be changed once the contract has been installed.
+The mode is passed in as a `u8` value to `nft_kind` runtime argument.
+
+| NFTKind  | u8  |
+| -------- | --- |
+| Physical | 0   |
+| Digital  | 1   |
+| Virtual  | 2   |
+
+## NFTHolderMode
+
+The `NFTHolderMode` dictates which entities on a Casper network can own and mint NFTs. There are three different options currently available:
+
+1. `Accounts`: In this mode, only `Accounts` can own and mint NFTs.
+2. `Contracts`: In this mode, only `Contracts` can own and mint NFTs.
+3. `Mixed`: In this mode both `Accounts` and `Contracts` can own and mint NFTs.
+
+If the `NFTHolderMode` is set to `Contracts` a `ContractHash` whitelist must be provided. This whitelist dictates which
+`Contracts` are allowed to mint NFTs in the restricted `Installer` minting mode.
+
+| NFTHolderMode | u8  |
+| ------------- | --- |
+| Accounts      | 0   |
+| Contracts     | 1   |
+| Mixed         | 2   |
+
+This modality is an optional installation parameter and will default to the `Mixed` mode if not provided. However, this
+mode cannot be changed once the contract has been installed.
+The mode is passed in as a `u8` value to `nft_holder_mode` runtime argument.
+
+## WhitelistMode
+
+The `WhitelistMode` dictates if the ACL whitelist restricting access to the mint entry point can be updated. There are currently two options:
+
+1. `Unlocked`: The ACL whitelist is unlocked and can be updated via the set variables endpoint.
+2. `Locked`: The ACL whitelist is locked and cannot be updated further.
+
+If the `WhitelistMode` is set to `Locked` an ACL whitelist of entity keys must be provided on installation. This whitelist dictates which entities can mint NFTs in the restricted `ACL` minting mode. These entities include `Accounts` and/or `Contracts`.
+
+This `WhitelistMode` is an optional installation parameter and will be set to unlocked if not passed. However, the whitelist mode itself cannot be changed once the contract has been installed. The mode is passed in as a `u8` value to `whitelist_mode` runtime argument.
+
+| WhitelistMode | u8  |
+| ------------- | --- |
+| Unlocked      | 0   |
+| Locked        | 1   |
+
+## Minting
+
+The minting mode governs the behavior of contract when minting new tokens. The minting modality provides two options:
+
+1. `Installer`: This mode restricts the ability to mint new NFT tokens only to the installing account of the NFT contract.
+2. `Public`: This mode allows any account to mint NFT tokens.
+3. `ACL`: This mode allows whitelisted accounts or contracts to mint NFT tokens.
+
+This modality is an optional installation parameter and will default to the `Installer` mode if not provided. However, this
+mode cannot be changed once the contract has been installed. The mode is set by passing a `u8` value to the `minting_mode` runtime argument.
+
+| MintingMode | u8  |
+| ----------- | --- |
+| Installer   | 0   |
+| Public      | 1   |
+| ACL         | 2   |
+
+## NFTMetadataKind
+
+This modality dictates the schema for the metadata for NFTs minted by a given instance of an NFT contract. There are four supported modalities:
+
+1. `CEP78`: This mode specifies that NFTs minted must have valid metadata conforming to the CEP-78 schema.
+2. `NFT721`: This mode specifies that NFTs minted must have valid metadata conforming to the NFT-721 metadata schema.
+3. `Raw`: This mode specifies that metadata validation will not occur and raw strings can be passed to `token_metadata` runtime argument as part of the call to `mint` entrypoint.
+4. `CustomValidated`: This mode specifies that a custom schema provided at the time of install will be used when validating the metadata as part of the call to `mint` entrypoint.
+
+During installation, one `NFTMetadataKind` must be chosen as the base metadata kind for the contract instance. Additional kinds may be included using either the `additional_required_metadata` or `optional_metadata` arguments.
+
+### CEP-78 metadata example
+
+```json
+{
+  "name": "John Doe",
+  "token_uri": "https://www.barfoo.com",
+  "checksum": "940bffb3f2bba35f84313aa26da09ece3ad47045c6a1292c2bbd2df4ab1a55fb"
+}
+```
+
+### NFT-721 metadata example
+
+```json
+{
+  "name": "John Doe",
+  "symbol": "abc",
+  "token_uri": "https://www.barfoo.com"
+}
+```
+
+### Custom Validated
+
+The CEP-78 implementation allows installers of the contract to provide their custom schema at the time of installation.
+The schema is passed as a String value to `json_schema` runtime argument at the time of installation. Once provided, the schema
+for a given instance of the contract cannot be changed.
+
+The custom JSON schema must contain a top-level `properties` field. An example of a [`valid JSON schema`](#example-custom-validated-schema) is provided. In this example, each property has a name, the description of the property itself, and whether the property is required to be present in the metadata.
+If the metadata kind is not set to custom validated, then the value passed to the `json_schema` runtime argument will be ignored.
+
+#### Example Custom Validated schema
+
+```json
+{
+  "properties": {
+    "deity_name": {
+      "name": "deity_name",
+      "description": "The name of deity from a particular pantheon.",
+      "required": true
+    },
+    "mythology": {
+      "name": "mythology",
+      "description": "The mythology the deity belongs to.",
+      "required": true
+    }
+  }
+}
+```
+
+#### Example Custom Metadata
+
+```json
+{
+  "deity_name": "Baldur",
+  "mythology": "Nordic"
+}
+```
+
+| NFTMetadataKind | u8  |
+| --------------- | --- |
+| CEP78           | 0   |
+| NFT721          | 1   |
+| Raw             | 2   |
+| CustomValidated | 3   |
+
+## NFTIdentifierMode
+
+The identifier mode governs the primary identifier for NFTs minted for a given instance on an installed contract. This modality provides two options:
+
+1. `Ordinal`: NFTs minted in this modality are identified by a `u64` value. This value is determined by the number of NFTs minted by the contract at the time the NFT is minted.
+2. `Hash`: NFTs minted in this modality are identified by a base16 encoded representation of the blake2b hash of the metadata provided at the time of mint.
+
+Since the primary identifier in the `Hash` mode is derived by hashing over the metadata, making it a content-addressed identifier, the metadata for the minted NFT cannot be updated after the mint.
+
+Attempting to install the contract with the `MetadataMutability` modality set to `Mutable` in the `Hash` identifier mode will raise an error.
+
+This modality is a required installation parameter and cannot be changed once the contract has been installed.
+
+It is passed in as a `u8` value to the `identifier_mode` runtime argument.
+
+| NFTIdentifierMode | u8  |
+| ----------------- | --- |
+| Ordinal           | 0   |
+| Hash              | 1   |
+
+## Metadata Mutability
+
+The metadata mutability mode governs the behavior around updates to a given NFTs metadata. This modality provides two options:
+
+1. `Immutable`: Metadata for NFTs minted in this mode cannot be updated once the NFT has been minted.
+2. `Mutable`: Metadata for NFTs minted in this mode can update the metadata via the `set_token_metadata` entrypoint.
+
+The `Mutable` option cannot be used in conjunction with the `Hash` modality for the NFT identifier; attempting to install the contract with this configuration raises `InvalidMetadataMutability` error.
+This modality is a required installation parameter and cannot be changed once the contract has been installed.
+It is passed in as a `u8` value to the `metadata_mutability` runtime argument.
+
+| MetadataMutability | u8  |
+| ------------------ | --- |
+| Immutable          | 0   |
+| Mutable            | 1   |
+
+## BurnMode
+
+The `BurnMode` modality dictates whether tokens minted by a given instance of an NFT contract can be burnt. This modality
+provides two options:
+
+1. `Burnable`: Minted tokens can be burnt.
+2. `NonBurnable`: Minted tokens cannot be burnt.
+
+| BurnMode    | u8  |
+| ----------- | --- |
+| Burnable    | 0   |
+| NonBurnable | 1   |
+
+This modality is an optional installation parameter and will default to the `Burnable` mode if not provided. However, this
+mode cannot be changed once the contract has been installed. The mode is set by passing a `u8` value to the `burn_mode` runtime argument.
+
+## OwnerReverseLookupMode
+
+The `OwnerReverseLookupMode` modality is set at install and determines if a given contract instance writes necessary data to allow reverse lookup by owner in addition to by ID.
+
+This modality provides the following options:
+
+1. `NoLookup`: The reporting and receipt functionality is not supported. In this option, the contract instance does not maintain a reverse lookup database of ownership and therefore has more predictable gas costs and greater scaling.
+2. `Complete`: The reporting and receipt functionality is supported. Token ownership will be tracked by the contract instance using the system described [here](./reverse-lookup.md).
+3. `TransfersOnly`: The reporting and receipt functionality is supported like `Complete`. However, it does not begin tracking until the first transfer. This modality is for use cases where the majority of NFTs are owned by a private minter and only NFT's that have been transferred benefit from reverse lookup tracking. Token ownership will also be tracked by the contract instance using the system described [here](./reverse-lookup.md).
+
+Additionally, when set to `Complete`, causes a receipt to be returned by the `mint` or `transfer` entrypoints, which the caller can store in their account or contract context for later reference.
+
+Further, two special entrypoints are enabled in `Complete` mode. First, `register_owner` which when called will allocate the necessary tracking record for the imputed entity. This allows isolation of the one time gas cost to do this per owner, which is convenient for accounting purposes. Second, `updated_receipts`, which allows an owner of one or more NFTs held by the contract instance to attain up to date receipt information for the NFTs they currently own.
+
+| OwnerReverseLookupMode | u8  |
+| ---------------------- | --- |
+| NoLookup               | 0   |
+| Complete               | 1   |
+| TransfersOnly          | 2   |
+
+This modality is an optional installation parameter and will default to the `NoLookup` mode if not provided. The mode is set by passing a `u8` value to the `owner_reverse_lookup_mode` runtime argument. This mode cannot be changed once the contract has been installed.
+
+**Note** : if `ownership_mode` is set to `Minter` and the `minting_mode` is set to `Installer` only, `OwnerReverseLookupMode` will be set to `NoLookup`. This is because the minter, by definition, owns all of the tokens forever. Therefore, there is no reason to do a reverse lookup for that owner. This rule applies only to newly installed contract instances.
+
+**Note** : if `OwnerReverseLookupMode` is set to `TransfersOnly` then `ownership_mode` has to be set to `Transferable` only. This is because other ownership modes do not allow transfer.
+
+If you are upgrading a contract from CEP-78 version 1.0 to 1.1, `OwnerReverseLookupMode` will be set to `Complete`, as this was the standard behavior of CEP-78 1.0. In addition to being set to `Complete`, existing records will be migrated into the CEP-78 1.1 format, which will impose a one-time gas cost to cover the migration.
+
+If you have an existing CEP-78 version 1.0 contract instance, and would prefer the newer functionality with no lookup, the only option is to install a separate, new contract instance and mint all of the NFTs anew in that instance and then burn the corresponding NFTs from the old instance. If you do not own all the NFTs held by the old contract instance, you do not have this option.
+
+## NamedKeyConventionMode
+
+The `NamedKeyConvention` modality dictates whether the Wasm passed will attempt to install a version 1.1.1 instance of CEP-78 or attempt to migrate a version 1.0 CEP-78 instance to version 1.1.1.
+
+This modality provides three options:
+
+1. `DerivedFromCollectionName`: This modality will signal the contract to attempt to install a new version 1.1.1 instance of the CEP-78 contract. The contract package hash and the access URef will be saved in the installing account's `NamedKeys` as `cep78_contract_package_<collection_name>` and `cep78_contract_package_access_<collection_name>`.
+2. `V_1_0_standard`: This modality will signal the contract to attempt to upgrade from version 1.0 to version 1.1.1. In this scenario, the contract will retrieve the package hash and the access URef from the `NamedKey` entries originally created during the 1.0 installation.
+3. `V_1_0_custom`: This modality will signal the contract to attempt to upgrade from version 1.0 to version 1.1.1. In this scenario, the calling account must provide the `NamedKey` entries under which the package hash and the access URef are saved. Additionally, this requires the passing of the runtime arguments `access_key_name` and `hash_key_name` for the access URef and package hash, respectively. In this modality, these arguments are required and must be passed in.
+
+| NamedKeyConvention        | u8  |
+| ------------------------- | --- |
+| DerivedFromCollectionName | 0   |
+| V_1_0_standard            | 1   |
+| V_1_0_custom              | 2   |
+
+## EventsMode
+
+The `EventsMode` modality determines how the installed instance of CEP-78 will handle the recording of events that occur from interacting with the contract.
+
+The modality provides three options:
+
+1. `NoEvents`: This modality will signal the contract to not record events at all. This is the default mode.
+2. `CEP47`: This modality will signal the contract to record events using the CEP47 event schema. Further information can be found [below](#cep47-mode).
+3. `CES`: This modality will signal the contract to record events using the [Casper Event Standard](#casper-event-standard).
+
+| EventsMode | u8  |
+| ---------- | --- |
+| NoEvents   | 0   |
+| CEP47      | 1   |
+| CES        | 2   |
+
+### Transfer Filter Hook
+
+The transfer filter modality, if enabled, specifies a contract package hash pointing to a contract that will be called when the `transfer` method is invoked on the contract. CEP-78 will call the `can_transfer`
+method on the specified callback contract, which is expected to return a value of `TransferFilterContractResult`, represented as a u8.
+
+- `TransferFilterContractResult::DenyTransfer` will block the transfer regardless of the outcome of other checks
+- `TransferFilterContractResult::ProceedTransfer` will allow the transfer to proceed if other checks also pass
+
+The transfer filter can be enabled by passing a `ARG_TRANSFER_FILTER_CONTRACT` argument to the install method, with a value of type `Option<Key>`
+
+### CEP47 Mode
+
+The CEP47 `EventsMode` modality mimics the event schema previously used in the CEP47 NFT standard. Events are stored as a `BTreeMap` within a dictionary (`EVENTS`) in the contract's context. Entries consist of the `PREFIX_HASH_KEY_NAME`, followed by the `EVENT_TYPE` and then variable data as listed in the table below. The events can be retrieved directly via their dictionary entry using the JSON-RPC, with more information on this process available [here](./concepts/dictionaries).
+
+| Event name      | Included values and type                                                        |
+| --------------- | ------------------------------------------------------------------------------- |
+| Mint            | `recipient (Key)`, `token_id (String)`                                          |
+| Transfer        | `owner (Key)`, `operator (Option<Key>)`, `recipient (Key)`, `token_id (String)` |
+| Burn            | `owner (Key)`, `token_id (String)`                                              |
+| ApprovalGranted | `owner (Key)`, `spender (Key)`, `token_id (String)`                             |
+| ApprovalRevoked | `owner (Key)`, `token_id (String)`                                              |
+| ApprovalForAll  | `owner (Key)`, `operator (Key)`                                                 |
+| RevokedForAll   | `owner (Key)`, `operator (Key)`                                                 |
+| MetadataUpdate  | `token_id (String)`                                                             |
+| Migration       | -                                                                               |
+| VariablesSet    | -                                                                               |
+
+### Casper Event Standard
+
+`CES` is an option within the `EventsMode` modality that determines how changes to tokens issued by the contract instance will be recorded. Any changes are recorded in the `__events` dictionary and can be observed via a node's Server Side Events stream. They may also be viewed by querying the dictionary at any time using the JSON-RPC interface.
+
+The emitted events are encoded according to the [Casper Event Standard](https://github.com/make-software/casper-event-standard), and the schema is visible to an observer reading the `__events_schema` contract named key.
+
+For this CEP-78 reference implementation, the events schema is as follows:
+
+| Event name      | Included values and type                                                        |
+| --------------- | ------------------------------------------------------------------------------- |
+| Mint            | `recipient (Key)`, `token_id (String)`, `data (String)`                         |
+| Transfer        | `owner (Key)`, `operator (Option<Key>)`, `recipient (Key)`, `token_id (String)` |
+| Burn            | `owner (Key)`, `token_id (String)`                                              |
+| Approval        | `owner (Key)`, `spender (Key)`, `token_id (String)`                             |
+| ApprovalRevoked | `owner (Key)`, `token_id (String)`                                              |
+| ApprovalForAll  | `owner (Key)`, `operator (Key)`                                                 |
+| RevokedForAll   | `owner (Key)`, `operator (Key)`                                                 |
+| MetadataUpdated | `token_id (String)`, `data (String)`                                            |
+| Migration       | -                                                                               |
+| VariablesSet    | -                                                                               |
+
+## Modality Conflicts
+
+The `MetadataMutability` option set to `Mutable` cannot be used in conjunction with the `NFTIdentifierMode` modality set to `Hash`.

--- a/source/docs/casper/resources/tokens/cep78/modalities.md
+++ b/source/docs/casper/resources/tokens/cep78/modalities.md
@@ -8,28 +8,6 @@ slug: /resources/tokens/cep78/modalities
 
 The enhanced NFT implementation supports various 'modalities' that dictate the behavior of a specific contract instance. Modalities represent the common expectations around contract usage and behavior.
 
-The following section discusses the currently implemented modalities and illustrates the significance of each.
-
-<b>Modalities</b>
-
-
-- [Ownership](#ownership)
-- [NFTKind](#nftkind)
-- [NFTHolderMode](#nftholdermode)
-- [WhitelistMode](#whitelistmode)
-- [Minting](#minting)
-- [NFTMetadataKind](#nftmetadatakind)
-- [NFTIdentifierMode](#nftidentifiermode)
-- [Metadata Mutability](#metadata-mutability)
-- [BurnMode](#burnmode)
-- [OwnerReverseLookupMode](#ownerreverselookupmode)
-- [NamedKeyConventionMode](#namedkeyconventionmode)
-- [EventsMode](#eventsmode)
-
-<b>Further Information</b>
-
-- [Modality Conflicts](#modality-conflicts)
-
 ## Ownership
 
 This modality specifies the behavior regarding ownership of NFTs and whether the owner of the NFT can change over the contract's lifetime. There are three modes:

--- a/source/docs/casper/resources/tokens/cep78/reverse-lookup.md
+++ b/source/docs/casper/resources/tokens/cep78/reverse-lookup.md
@@ -1,5 +1,5 @@
 ---
-title: Owner Reverse Lookup Functionality
+title: Ownership Lookup
 slug: /resources/tokens/cep78/reverse-lookup
 ---
 

--- a/source/docs/casper/resources/tokens/cep78/reverse-lookup.md
+++ b/source/docs/casper/resources/tokens/cep78/reverse-lookup.md
@@ -1,0 +1,53 @@
+---
+title: Owner Reverse Lookup Functionality
+slug: /resources/tokens/cep78/reverse-lookup
+---
+
+
+# Owner Reverse Lookup Functionality
+
+In version 1.0 of the CEP-78 Enhanced NFT Standard contract, tracking minted tokens consisted of a single, unbounded list that would grow in size with each additional token. As a result, gas costs would increase over time as the list must be overwritten with each new minting. The related tutorial can be found [here](https://github.com/casper-ecosystem/cep-78-enhanced-nft/blob/dev/tutorials/token-ownership-tutorial.md).
+
+In an effort to stabilize the gas costs of larger NFT collections, version 1.1 of CEP-78 includes the use of a pre-allocated page system to track ownership of NFTs within the contract.
+
+This system stabilizes the cost for interacting with the contract, but not the mint price itself. The size of metadata for a collection, and any differences in that metadata, will still result in some fluctuation in the price for the NFT itself. However, the cost of engaging the system itself will remain stable. Users can expect to pay a higher upfront price for page allocation, but will not need to pay this cost again for any NFTs minted within that given page.
+
+## The CEP-78 Page System
+
+Ownership of NFTs within a CEP-78 contract is now tracked with a series of `pages`, with each page tracking a range of 1,000 tokens each. When installing an instance of the CEP-78 contract, the user determines the total token supply. This, in turn, determines the maximum number of pages, i.e., for a 10,000 token collection, each account could have up to 10 pages numbering from 0-9 tracking ownership of NFTs.
+
+A `page_table` tracks which pages within a range have been allocated and set for a certain user. The size of the page table directly correlates to the total token supply, i.e. for a CEP-78 instance tracking 10,000 tokens, the page table would be 10 bits wide. For a total of 20,000 it would be 20 bits wide. The cost of the initial page table allocation depends on the overall total size of a collection, with larger collections possessing correspondingly greater gas costs. To make initial minting costs more stable across contracts, the process of allocating a page table has been shifted to the `register_owner` entrypoint.
+
+After registering as an owner, the contract creates an entry within the `page_table` dictionary for the minting account or contract. This dictionary entry consists of a series of `boolean` values amounting to the total number of pages in the collection. In our 10,000 token example, this would be 10 bits set to false.
+
+Upon minting the token, the user will pay for a page allocation. This adds them to the `page` dictionary, in which each entry corresponds to a specific account or contract that owns tokens within that page. That account or contract's entry in the `page` dictionary will consist of 1,000 `page_address` bits set to `False` upon allocation, and the minting of any given token in that page will set the `page_address` bit to `True`.
+
+In addition, that account or contract's `page_table` will be updated by marking the corresponding page number's bit as `True`.
+
+As an example, consider a new user minting their first NFT with a given CEP-78 contract set to a maximum number of 10,000 tokens. They are minting the 2,350th token within that collection. The following sequence of events would occur:
+
+1. The contract registers their account as an owner.
+
+2. The contract creates a `page_table` dictionary for that account, with 10 boolean values. As the numbering system begins with `0`, the third boolean value corresponding with page `2` is set to `True`.
+
+3. The account pays for allocation of page 2, creating an entry in the `Page 2` dictionary for that account. Within that entry, there are 1,000 boolean values set to false. Minting the 2,350th token in the collection sets the corresponding `page_address` boolean for 350 as `True`.
+
+4. Any further tokens minted by this account prior to the 3,000th token being minted will not have to pay for additional page allocations. If the account mints a token at or beyond 3,000, they must pay for the corresponding page allocation. For example, if they decided to mint the 5,125th token in the collection, they would need to pay for `page 5` to be allocated to them. They would then be added to the `page 5` dictionary with the `page_address` boolean for 125 set as `True`.
+
+This system binds the data writing costs to a maximum size of any given page dictionary.
+
+## Updated Receipts
+
+If the contract enables `OwnerReverseLookupMode`, calling the `updated_receipts` entrypoint will return a list of receipt names alongside the dictionary for the relevant pages.
+
+Updated receipts come in the format of `"{<collection name>}\_m{modulo}\_p{<page number>}"`. Once again using the 2,350th token as an example, the receipt would read:
+
+```
+cep78_collection_m_350_p_2
+```
+
+You can determine the token number by multiplying the `page_number` by the `page_size`(1,000) and adding the `modulo`.
+
+If the `NFTIdentifierMode` is set to `Ordinal`, this number corresponds directly to the token ID.
+
+If it is set to `Hash`, you will need to reference the `HASH_BY_INDEX` dictionary to determine the mapping of token numbers to token hashes.

--- a/source/docs/casper/resources/tokens/cep78/using-casper-client.md
+++ b/source/docs/casper/resources/tokens/cep78/using-casper-client.md
@@ -24,7 +24,7 @@ Information on the modalities used throughout this installation process can be f
 
 ## Installing the Contract
 
-Installing the enhanced NFT contract to global state requires the use of a [Deploy](/developers/dapps/cli/sending-deploys/). In this case, the session code can be compiled to Wasm by running the `make build-contract` command provided in the Makefile at the top level. The Wasm will be found in the `contract/target/wasm32-unknown-unknown/release` directory as `contract.wasm`.
+Installing the enhanced NFT contract to global state requires the use of a [Deploy](/developers/cli/sending-deploys/). In this case, the session code can be compiled to Wasm by running the `make build-contract` command provided in the Makefile at the top level. The Wasm will be found in the `contract/target/wasm32-unknown-unknown/release` directory as `contract.wasm`.
 
 Below is an example of a `casper-client` command that provides all required session arguments to install a valid instance of the CEP-78 contract on global state.
 

--- a/source/docs/casper/resources/tokens/cep78/using-casper-client.md
+++ b/source/docs/casper/resources/tokens/cep78/using-casper-client.md
@@ -1,5 +1,5 @@
 ---
-title: Installing and Interacting with a CEP-78 Contract using the Rust Casper Client
+title: On-chain Installation
 slug: /resources/tokens/using-casper-client
 ---
 
@@ -9,18 +9,6 @@ slug: /resources/tokens/using-casper-client
 This documentation will guide you through the process of installing and interacting with an instance of the CEP-78 enhanced NFT standard contract through Casper's Rust CLI client. The contract code installs an instance of CEP-78 as per session arguments provided at the time of installation. It requires a minimum Rust version of `1.63.0`.
 
 Information on the modalities used throughout this installation process can be found in the [modalities documentation](modalities.md).
-
-## Table of Contents
-
-1. [Installing the Contract](#installing-the-contract)
-
-2. [Directly Invoking Entrypoints](#directly-invoking-entrypoints)
-
-3. [Minting an NFT](#minting-an-nft)
-
-4. [Transferring NFTs Between Users](#transferring-nfts-between-users)
-
-5. [Burning an NFT](#burning-an-nft)
 
 ## Installing the Contract
 

--- a/source/docs/casper/resources/tokens/cep78/using-casper-client.md
+++ b/source/docs/casper/resources/tokens/cep78/using-casper-client.md
@@ -1,0 +1,243 @@
+---
+title: Installing and Interacting with a CEP-78 Contract using the Rust Casper Client
+slug: /resources/tokens/using-casper-client
+---
+
+
+# Installing and Interacting with a CEP-78 Contract using the Rust Casper Client
+
+This documentation will guide you through the process of installing and interacting with an instance of the CEP-78 enhanced NFT standard contract through Casper's Rust CLI client. The contract code installs an instance of CEP-78 as per session arguments provided at the time of installation. It requires a minimum Rust version of `1.63.0`.
+
+Information on the modalities used throughout this installation process can be found in the [modalities documentation](modalities.md).
+
+## Table of Contents
+
+1. [Installing the Contract](#installing-the-contract)
+
+2. [Directly Invoking Entrypoints](#directly-invoking-entrypoints)
+
+3. [Minting an NFT](#minting-an-nft)
+
+4. [Transferring NFTs Between Users](#transferring-nfts-between-users)
+
+5. [Burning an NFT](#burning-an-nft)
+
+## Installing the Contract
+
+Installing the enhanced NFT contract to global state requires the use of a [Deploy](../developers/dapps/sending-deploys/). In this case, the session code can be compiled to Wasm by running the `make build-contract` command provided in the Makefile at the top level. The Wasm will be found in the `contract/target/wasm32-unknown-unknown/release` directory as `contract.wasm`.
+
+Below is an example of a `casper-client` command that provides all required session arguments to install a valid instance of the CEP-78 contract on global state.
+
+- `casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/contract/target/wasm32-unknown-unknown/release/contract.wasm`
+
+1. `--session-arg "collection_name:string='CEP-78-collection'"`
+
+   The name of the NFT collection as a string. In this instance, "CEP-78-collection".
+
+2. `--session-arg "collection_symbol:string='CEP78'"`
+
+   The symbol representing the NFT collection as a string. In this instance, "CEP78".
+
+3. `--session-arg "total_token_supply:u64='100'"`
+
+   The total supply of tokens to be minted. In this instance, 100. If the contract owner is unsure of the total number of NFTs they will require, they should err on the side of caution.
+
+4. `--session-arg "ownership_mode:u8='2'"`
+
+   The ownership mode for this contract. In this instance the 2 represents "Transferable" mode. Under these conditions, users can freely transfer their NFTs between one another.
+
+5. `--session-arg "nft_kind:u8='1'"`
+
+   The type of commodity represented by these NFTs. In this instance, the 1 represents a digital collection.
+
+6. `--session-arg "nft_metadata_kind:u8='0'"`
+
+   The type of metadata used by this contract. In this instance, the 0 represents CEP-78 standard for metadata.
+
+7. `--session-arg "json_schema:string=''"`
+
+   An empty JSON string, as the contract has awareness of the CEP-78 JSON schema. Using the custom validated modality would require passing through a valid JSON schema for your custom metadata.
+
+8. `--session-arg "identifier_mode:u8='0'"`
+
+   The mode used to identify individual NFTs. For 0, this means an ordinal identification sequence rather than by hash.
+
+9. `--session-arg "metadata_mutability:u8='0'"`
+
+   A setting allowing for mutability of metadata. This is only available when using the ordinal identification mode, as the hash mode depends on immutability for identification. In this instance, despite ordinal identification, the 0 represents immutable metadata.
+
+The session arguments match the available modalities as listed [here](./modalities.md).
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 500000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/contract/target/wasm32-unknown-unknown/release/contract.wasm \
+--session-arg "collection_name:string='CEP-78-collection'" \
+--session-arg "collection_symbol:string='CEP78'" \
+--session-arg "total_token_supply:u64='100'" \
+--session-arg "ownership_mode:u8='2'" \
+--session-arg "nft_kind:u8='1'" \
+--session-arg "nft_metadata_kind:u8='0'" \
+--session-arg "json_schema:string=''" \
+--session-arg "identifier_mode:u8='0'" \
+--session-arg "metadata_mutability:u8='0'"
+```
+
+</details>
+
+## Directly Invoking Entrypoints
+
+With the release of CEP-78 version 1.1, users that are interacting with a CEP-78 contract that does not use `ReverseLookupMode` should opt out of using the client Wasms provided as part of the release. Opting out in this situation is recommended, as directly invoking the entrypoints incurs a lower gas cost compared against using the provided client Wasm to invoke the entrypoint.
+
+You may invoke the `mint`, `transfer` or `burn` entrypoints directly through either the contract package hash or the contract hash directly.
+
+Specifically in the case of `mint`, there are fewer runtime arguments that must be provided, thereby reducing the total gas cost of minting an NFT.
+
+<details>
+<summary><b>Example Mint using StoredVersionByHash</b></summary>
+
+```bash
+
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" \ --payment-amount 7500000000 \ -k ~/secret_key.pem \
+--session-package-hash hash-b3b7a74ae9ef2ea8afc06d6a0830961259605e417e95a53c0cb1ca9737bb0ec7 \
+--session-entry-point "mint" \
+--session-arg "token_owner:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'" \
+--session-arg "token_meta_data:string='{\"name\": \"John Doe\",\"token_uri\": \"https:\/\/www.barfoo.com\",\"checksum\": \"940bffb3f2bba35f84313aa26da09ece3ad47045c6a1292c2bbd2df4ab1a55fb\"}'"
+
+```
+
+</details>
+
+<details>
+<summary><b>Example Transfer using StoredContractByHash</b></summary>
+
+Based on the identifier mode for the given contract instance, either the `token_id` runtime argument must be passed in or in the case of the hash identifier mode, the `token_hash` runtime argument.
+
+```bash
+
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" \ --payment-amount 7500000000 \ -k ~/secret_key.pem \
+--session-hash hash-b3b7a74ae9ef2ea8afc06d6a0830961259605e417e95a53c0cb1ca9737bb0ec7 \
+--session-entry-point "transfer" \
+--session-arg "source_key:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'" \
+--session-arg "target_key:key='account-hash-b4782e7c47e4deca5bd90b7adb2d6e884f2d331825d5419d6cbfb59e17642aab'" \
+--session-arg "token_id:u64='0'"
+
+```
+
+</details>
+
+## Minting an NFT
+
+Below is an example of a `casper-client` command that uses the `mint` function of the contract to mint an NFT for the user associated with `node-1` in an [NCTL environment](../developers/dapps/nctl-test/).
+
+- `casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 5000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/client/mint_session/target/wasm32-unknown-unknown/release/mint_call.wasm`
+
+1. `--session-arg "nft_contract_hash:key='hash-206339c3deb8e6146974125bb271eb510795be6f250c21b1bd4b698956669f95'"`
+
+   The contract hash of the previously installed CEP-78 NFT contract from which we will be minting.
+
+2. `--session-arg "collection_name:string='cep78_<collection_name>'"`
+
+   The collection name of the previously installed CEP-78 NFT contract from which we will be minting.
+
+3. `--session-arg "token_owner:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'"`
+
+   The collection name of the NFT to be minted.
+
+4. `--session-arg "token_meta_data:string='{\"name\": \"John Doe\",\"token_uri\": \"https:\/\/www.barfoo.com\",\"checksum\": \"940bffb3f2bba35f84313aa26da09ece3ad47045c6a1292c2bbd2df4ab1a55fb\"}'"`
+
+   Metadata describing the NFT to be minted, passed in as a `string`.
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" \
+--payment-amount 5000000000 \
+-k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem \
+--session-path ~/casper/enhanced-nft/client/mint_session/target/wasm32-unknown-unknown/release/mint_call.wasm \
+--session-arg "nft_contract_hash:key='hash-206339c3deb8e6146974125bb271eb510795be6f250c21b1bd4b698956669f95'" \
+--session-arg "collection_name:string='cep78_<collection_name>'"` \
+--session-arg "token_owner:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'"  \
+--session-arg "token_meta_data:string='{\"name\": \"John Doe\",\"token_uri\": \"https:\/\/www.barfoo.com\",\"checksum\": \"940bffb3f2bba35f84313aa26da09ece3ad47045c6a1292c2bbd2df4ab1a55fb\"}'"
+
+```
+
+</details>
+
+## Transferring NFTs Between Users
+
+Below is an example of a `casper-client` command that uses the `transfer` function to transfer ownership of an NFT from one user to another. In this case, we are transferring the previously minted NFT from the user associated with `node-2` to the user associated with `node-3`.
+
+- `casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 5000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-2/keys/secret_key.pem --session-path ~/casper/enhanced-nft/client/transfer_session/target/wasm32-unknown-unknown/release/transfer_call.wasm`
+
+1. `--session-arg "nft_contract_hash:key='hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5'"`
+
+   The contract hash of the CEP-78 NFT Contract associated with the NFT to be transferred.
+
+2. `--session-arg "source_key:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'"`
+
+   The account hash of the user that currently owns the NFT and wishes to transfer it.
+
+3. `--session-arg "target_key:key='account-hash-b4772e7c47e4deca5bd90b7adb2d6e884f2d331825d5419d6cbfb59e17642aab'"`
+
+   The account hash of the user that will receive the NFT.
+
+4. `--session-arg "is_hash_identifier_mode:bool='false'"`
+
+   Argument that the hash identifier mode is ordinal, thereby requiring a `token_id` rather than a `token_hash`.
+
+5. `--session-arg "token_id:u64='0'"`
+
+   The `token_id` of the NFT to be transferred.
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" \
+--payment-amount 5000000000 \
+-k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-2/keys/secret_key.pem \
+--session-path ~/casper/enhanced-nft/client/transfer_session/target/wasm32-unknown-unknown/release/transfer_call.wasm \
+--session-arg "nft_contract_hash:key='hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5'" \
+--session-arg "source_key:key='account-hash-e9ff87766a1d2bab2565bfd5799054946200b51b20c3ca7e54a9269e00fe7cfb'" \
+--session-arg "target_key:key='account-hash-b4772e7c47e4deca5bd90b7adb2d6e884f2d331825d5419d6cbfb59e17642aab'" \
+--session-arg "is_hash_identifier_mode:bool='false'" \
+--session-arg "token_id:u64='0'"
+```
+
+</details>
+
+## Burning an NFT
+
+Below is an example of a `casper-client` command that uses the `burn` function to burn an NFT within a CEP-78 collection. If this command is used, the NFT in question will no longer be accessible by anyone.
+
+- `casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 5000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem`
+
+1. `--session-hash hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5`
+
+   The session hash corresponding to the NFT's contract hash.
+
+2. `--session-entry-point "burn"`
+
+   The entrypoint corresponding to the `burn` function.
+
+3. `--session-arg "token_id:u64='1'"`
+
+   The token ID for the NFT to be burned. If the `identifier_mode` is not set to `Ordinal`, you must provide the `token_hash` instead.
+
+<details>
+<summary><b>Casper client command without comments</b></summary>
+
+```bash
+casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" \
+--payment-amount 5000000000 \
+-k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem \
+--session-hash hash-52e78ae3f6c485d036a74f65ebbb8c75fcc7c33fb42eb667fb32aeba72c63fb5 \
+--session-entry-point "burn" \
+--session-arg "token_id:u64='1'"
+```
+
+</details>

--- a/source/docs/casper/resources/tokens/cep78/using-casper-client.md
+++ b/source/docs/casper/resources/tokens/cep78/using-casper-client.md
@@ -24,7 +24,7 @@ Information on the modalities used throughout this installation process can be f
 
 ## Installing the Contract
 
-Installing the enhanced NFT contract to global state requires the use of a [Deploy](../developers/dapps/sending-deploys/). In this case, the session code can be compiled to Wasm by running the `make build-contract` command provided in the Makefile at the top level. The Wasm will be found in the `contract/target/wasm32-unknown-unknown/release` directory as `contract.wasm`.
+Installing the enhanced NFT contract to global state requires the use of a [Deploy](/developers/dapps/cli/sending-deploys/). In this case, the session code can be compiled to Wasm by running the `make build-contract` command provided in the Makefile at the top level. The Wasm will be found in the `contract/target/wasm32-unknown-unknown/release` directory as `contract.wasm`.
 
 Below is an example of a `casper-client` command that provides all required session arguments to install a valid instance of the CEP-78 contract on global state.
 
@@ -129,7 +129,7 @@ casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-
 
 ## Minting an NFT
 
-Below is an example of a `casper-client` command that uses the `mint` function of the contract to mint an NFT for the user associated with `node-1` in an [NCTL environment](../developers/dapps/nctl-test/).
+Below is an example of a `casper-client` command that uses the `mint` function of the contract to mint an NFT for the user associated with `node-1` in an [NCTL environment](/developers/dapps/nctl-test/).
 
 - `casper-client put-deploy -n http://localhost:11101/rpc --chain-name "casper-net-1" --payment-amount 5000000000 -k ~/casper/casper-node/utils/nctl/assets/net-1/nodes/node-1/keys/secret_key.pem --session-path ~/casper/enhanced-nft/client/mint_session/target/wasm32-unknown-unknown/release/mint_call.wasm`
 

--- a/source/docs/casper/resources/tokens/index.md
+++ b/source/docs/casper/resources/tokens/index.md
@@ -8,17 +8,18 @@ slug: /resources/tokens/
 
 | Title                                                                  | Description                                                                     |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Casper Fungible Token Tutorial](./cep18/full-tutorial.md)              | A full tutorial for use of the CEP-18 Casper Fungible Token Standard.           |
-| [Casper Fungible Token Quickstart Guide](./cep18/quickstart-guide.md)   | A quickstart guide for installing a CEP-18 contract with the Rust Casper Client.|
+| [A Casper Fungible Token Tutorial](./cep18/full-tutorial.md)              | A full tutorial for use of the CEP-18 Casper Fungible Token Standard.           |
+| [Installing and Interacting with a CEP-18 Contract](./cep18/quickstart-guide.md)   | A quickstart guide for installing a CEP-18 contract with the Rust Casper Client.|
 | [Exploring the CEP-18 Contracts](./cep18/query.md)                      | A guide to interacting with installed CEP-18 contracts.                         |
 | [CEP-18 Token Transfers and Allowances](./cep18/transfer.md)            | A guide for transferring Casper Fungible Tokens.                                |
 | [Testing Framework for CEP-18](./cep18/tests.md)                        | A CEP-18 testing framework using the Casper engine test support crate.          |
 
 ## CEP-78 Enhanced NFT Standard
 
-| Title                                                                                                          | Description                                                                      |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [CEP-78 Enhanced NFT Standard Introduction](./cep78/introduction.md)                                            | An introduction to the CEP-78 Enhanced NFT Standard.                             |
-| [CEP-78 Modalities](./cep78/introduction.md)                                                                    | Information on the features available when installing a CEP-78 contract instance.|
-| [Installing and Interacting with a CEP-78 Contract using the Rust Casper Client](./cep78/using-casper-client.md)| An introduction to features present in the CEP-78 Enhanced NFT Standard.         |
-| [Owner Reverse Lookup Functionality](./cep78/reverse-lookup.md)                                                 | Information on the Onwer Reverse Lookup feature of CEP-78 contracts.             |
+| Title                                                                          | Description                                                      |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
+| [CEP-78 Enhanced NFT Standard Introduction](./cep78/introduction.md)           | An introduction to the CEP-78 Enhanced NFT Standard.             |
+| [CEP-78 Modalities](./cep78/introduction.md)                                   | Information on the features available when installing a CEP-78 contract instance.|
+| [Installing and Interacting with a CEP-78 Contract](./cep78/using-casper-client.md)| An introduction to features present in the CEP-78 Enhanced NFT Standard.|
+| [Owner Reverse Lookup Functionality](./cep78/reverse-lookup.md)                | Information on the Onwer Reverse Lookup feature of CEP-78 contracts.|
+| [A CEP-78 JavaScript Client Tutorial](./cep78/js-tutorial.md)                  | A tutorial for using the JavaScript CEP-78 client.                  |

--- a/source/docs/casper/resources/tokens/index.md
+++ b/source/docs/casper/resources/tokens/index.md
@@ -1,0 +1,24 @@
+---
+slug: /resources/tokens/
+---
+
+# Casper Token Standards
+
+## CEP-18 Casper Fungible Token Standard
+
+| Title                                                                  | Description                                                                     |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Casper Fungible Token Tutorial](./cep18/full-tutorial.md)              | A full tutorial for use of the CEP-18 Casper Fungible Token Standard.           |
+| [Casper Fungible Token Quickstart Guide](./cep18/quickstart-guide.md)   | A quickstart guide for installing a CEP-18 contract with the Rust Casper Client.|
+| [Exploring the CEP-18 Contracts](./cep18/query.md)                      | A guide to interacting with installed CEP-18 contracts.                         |
+| [CEP-18 Token Transfers and Allowances](./cep18/transfer.md)            | A guide for transferring Casper Fungible Tokens.                                |
+| [Testing Framework for CEP-18](./cep18/tests.md)                        | A CEP-18 testing framework using the Casper engine test support crate.          |
+
+## CEP-78 Enhanced NFT Standard
+
+| Title                                                                                                          | Description                                                                      |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [CEP-78 Enhanced NFT Standard Introduction](./cep78/introduction.md)                                            | An introduction to the CEP-78 Enhanced NFT Standard.                             |
+| [CEP-78 Modalities](./cep78/introduction.md)                                                                    | Information on the features available when installing a CEP-78 contract instance.|
+| [Installing and Interacting with a CEP-78 Contract using the Rust Casper Client](./cep78/using-casper-client.md)| An introduction to features present in the CEP-78 Enhanced NFT Standard.         |
+| [Owner Reverse Lookup Functionality](./cep78/reverse-lookup.md)                                                 | Information on the Onwer Reverse Lookup feature of CEP-78 contracts.             |


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR introduces documentation held in the [CEP-18](https://github.com/casper-ecosystem/cep18) and [CEP-78](https://github.com/casper-ecosystem/cep-78-enhanced-nft) repositories into the main documentation site.

A new index has been added and documents edited as necessary, but this is mostly replication of previously reviewed content.

Closes #1315

### Additional context
[Add 'Casper Token Standards' to 'Resources' tab #1315](https://github.com/casper-network/docs/issues/1315)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
@ipopescu 