### PR TITLE
Redelegation Clarification

### DIFF
--- a/source/docs/casper/developers/cli/redelegate.md
+++ b/source/docs/casper/developers/cli/redelegate.md
@@ -48,7 +48,7 @@ The command will return a deploy hash, which is needed to verify the deploy's pr
 
 :::note
 
-Calling the `delegate` entry point on the auction contract has a fixed cost of 2.5 CSPR and there is a minimum delegation amount of 500 CSPR that also applies to redelegations.
+Calling the `redelegate` entry point on the auction contract has a fixed cost of 2.5 CSPR and there is a minimum delegation amount of 500 CSPR that also applies to redelegations.
 
 :::
 

--- a/source/docs/casper/developers/cli/redelegate.md
+++ b/source/docs/casper/developers/cli/redelegate.md
@@ -48,7 +48,7 @@ The command will return a deploy hash, which is needed to verify the deploy's pr
 
 :::note
 
-Calling the `delegate` entry point on the auction contract has a fixed cost of 2.5 CSPR.
+Calling the `delegate` entry point on the auction contract has a fixed cost of 2.5 CSPR and there is a minimum delegation amount of 500 that also applies to redelegations.
 
 :::
 

--- a/source/docs/casper/developers/cli/redelegate.md
+++ b/source/docs/casper/developers/cli/redelegate.md
@@ -48,7 +48,7 @@ The command will return a deploy hash, which is needed to verify the deploy's pr
 
 :::note
 
-Calling the `delegate` entry point on the auction contract has a fixed cost of 2.5 CSPR and there is a minimum delegation amount of 500 that also applies to redelegations.
+Calling the `delegate` entry point on the auction contract has a fixed cost of 2.5 CSPR and there is a minimum delegation amount of 500 CSPR that also applies to redelegations.
 
 :::
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR clarifies that redelegations share the 500 CSPR minimum threshold amount.

### Additional context
[Slack Conversation](https://casper-labs-team.slack.com/archives/C0135SDEGUC/p1699550381376029)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ipopescu 
