### PR TITLE
1325 Adding information about enabling contracts.

### DIFF
--- a/source/docs/casper/developers/writing-onchain-code/upgrading-contracts.md
+++ b/source/docs/casper/developers/writing-onchain-code/upgrading-contracts.md
@@ -11,7 +11,7 @@ Our smart contract packaging tools enable you to:
 
 ## The Contract Package
 
-When you upgrade a contract, you add a new contract version in a contract package. The versioning process is additive rather than an in-place replacement of an existing contract. The original version of the contract is still there, and you can enable certain versions for specific clients. You can also disable a contract version if needed.
+When you upgrade a contract, you add a new contract version in a contract package. The versioning process is additive rather than an in-place replacement of an existing contract. The original version of the contract is still there, and you can enable certain versions for specific clients. You can also disable a contract version if needed. If you find that you need to use a disabled contract version, you may also re-enable it.
 
 <p align="center"><img src={useBaseUrl("/image/package-representation.png")} alt="package-representation" width="400"/></p>
 

--- a/source/docs/casper/resources/beginner/upgrade-contract.md
+++ b/source/docs/casper/resources/beginner/upgrade-contract.md
@@ -338,9 +338,20 @@ There are two ways to call versioned contracts:
 After calling the entry point, the count value should be decremented. You can verify it by querying the network again using the new state root hash.
 
 
-## Disabling a Contract Version
+## Disabling and Enabling Contract Versions
 
-You can disable the indicated contract version of the indicated contract package by using the [disable_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.disable_contract_version.html) function. Disabled contract versions can no longer be executed.
+You can disable a contract version within a contract package by using the [disable_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.disable_contract_version.html) function.
+
+Disabled contract versions can no longer be executed. As such, if there is only a single contract version within the package, you will no longer be able to use the contract.
+
+<!--TODO This link is only a guess until 1.5.4 releases and the auto-docs populate.-->
+[Enable_contract_version](https://docs.rs/casper-contract/latest/casper_contract/contract_api/storage/fn.enable_contract_version.html) allows you to re-enable a previously disabled contract version.
+
+::note
+
+Be aware that calling a contract package will use the most recent contract version. It is not necessary to disable a previous contract version, unless you have a specific need to do so.
+
+:::
 
 ## Creating a Locked Contract Package {#locked-contract-package}
 


### PR DESCRIPTION
### What does this PR fix/introduce?
Adding information about the `enable_contract_version` function in 1.5.4.

Closes #1325

### Additional context
[Document the Ability to Re-enable a Disabled Contract Version #1325](https://github.com/casper-network/docs/issues/1325)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [ ] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ipopescu 
