### PR TITLE
Add info on Rust crates and documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: gh-pages
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: gh-pages-backup
           path: .
@@ -96,7 +96,7 @@ jobs:
         run: |
           echo "$prod_pages_fqdn" > ./docs/CNAME
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: gh-pages-depl-payload
           path: ./docs

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -91,6 +91,7 @@ module.exports = {
     developers: [
         "developers/index",
         "developers/prerequisites",
+        "developers/essential-crates",
         {
             type: "category",
             label: "Writing On-Chain Code",
@@ -302,11 +303,12 @@ module.exports = {
                         type: "doc",
                         id: "resources/tokens/cep18/full-tutorial",
                     },
-                    items: ["resources/tokens/cep18/full-tutorial",
-                            "resources/tokens/cep18/quickstart-guide",
-                            "resources/tokens/cep18/query",
-                            "resources/tokens/cep18/transfer",
-                            "resources/tokens/cep18/tests",
+                    items: [
+                        "resources/tokens/cep18/full-tutorial",
+                        "resources/tokens/cep18/quickstart-guide",
+                        "resources/tokens/cep18/query",
+                        "resources/tokens/cep18/transfer",
+                        "resources/tokens/cep18/tests",
                     ],
                 },
                 {

--- a/source/docs/casper/developers/essential-crates.md
+++ b/source/docs/casper/developers/essential-crates.md
@@ -1,0 +1,61 @@
+# Essential Rust Crates
+
+Several Rust crates are available on [crates.io](https://crates.io/) to support smart contract development with Rust. A crate is a compilation unit that can be compiled into a binary or a library. The corresponding documentation is published on [docs.rs](https://docs.rs). The most important crates are listed below.
+
+## `casper-types`
+
+Types shared by many Casper crates:
+- https://crates.io/crates/casper-types
+- https://docs.rs/casper-types/latest
+
+## `casper-contract`
+
+A library for developing Casper smart contracts:
+- https://crates.io/crates/casper-contract
+- https://docs.rs/casper-contract/latest
+
+## `casper-engine-test-support`
+
+The Casper test support library:
+- https://crates.io/crates/casper-engine-test-support
+- https://docs.rs/casper-engine-test-support/
+
+## `casper-node`
+
+The component for running a node on a Casper network:
+- https://crates.io/crates/casper-node
+- https://docs.rs/casper-node/latest
+
+## `casper-client`
+A client library for interacting with a Casper network:
+- https://crates.io/crates/casper-client
+- https://docs.rs/casper-client/latest
+
+## `casper-event-standard`
+
+A Rust library that provides a simple and standardized way for Casper contracts to emit events:
+- https://crates.io/crates/casper-event-standard
+- https://docs.rs/casper-event-standard/latest
+
+## `casper-hashing`
+
+A library providing hashing functionality including Merkle Proof utilities:
+- https://crates.io/crates/casper-hashing
+- https://docs.rs/casper-hashing/latest/
+
+## `casper-wasm-utils`
+
+Command-line utilities and corresponding Rust API for producing pwasm-compatible executables:
+- https://crates.io/crates/casper-wasm-utils
+- https://docs.rs/casper-wasm-utils/latest
+
+## `cargo-casper`
+
+A command line tool for creating a Wasm smart contract and tests:
+- https://crates.io/crates/cargo-casper
+- https://docs.rs/crate/cargo-casper/latest
+
+## Other Libraries
+
+The [Open-Source Software](../resources/casper-open-source-software.md) page provides other community-curated tools and libraries.
+

--- a/source/docs/casper/developers/index.md
+++ b/source/docs/casper/developers/index.md
@@ -10,6 +10,7 @@ This section supports developers getting started with the Casper blockchain by w
 | Topic                    | Description                         |
 | ------------------------ | ----------------------------------- |
 | [Development Prerequisites](./prerequisites.md) | Setup needed for various workflows |
+| [Essential Casper Crates](./essential-crates.md) | Available Casper crates and the corresponding documentation |
 | [Writing On-Chain Code](./writing-onchain-code/index.md) | Writing contracts in Rust and Wasm for a Casper network |
 | [Casper JSON-RPC API](./json-rpc/index.md) | Endpoints for developers wishing to interact directly with a Casper node's JSON-RPC API |
 | [Building dApps](./dapps/index.md) | Useful information for dApp developers |

--- a/source/docs/casper/developers/prerequisites.md
+++ b/source/docs/casper/developers/prerequisites.md
@@ -100,7 +100,7 @@ Note: You can also use `brew` on MacOS or `apt` on Linux to install Rust.
 
 ## Installing the Casper Crates {#installing-the-casper-crates}
 
-The best and fastest way to set up a Casper Rust project is to use `cargo casper`. Using this will create a simple contract, a runtime environment, and a testing framework with a simple test. _Cargo_ is a build system and package manager for Rust (much like _pip_ if you are familiar with Python, or _npm_ and _yarn_ for those familiar with Javascript). It is also possible to use this configuration in your CI/CD pipeline.
+The best and fastest way to set up a Casper Rust project is to use [cargo casper](https://crates.io/crates/cargo-casper), which is the command line tool for creating a Wasm smart contract and tests for use on a Casper network. This tool will create a simple contract, a runtime environment, and a testing framework with a simple test. _Cargo_ is a build system and package manager for Rust (much like _pip_ if you are familiar with Python, or _npm_ and _yarn_ for those familiar with Javascript). It is also possible to use this configuration in your CI/CD pipeline.
 
 ```bash
 cargo install cargo-casper
@@ -117,6 +117,12 @@ Verify the installation:
 ```bash
 cargo-casper --version
 ```
+
+:::note
+
+Familiarize yourself with the essential Casper crates described [here](./essential-crates.md).
+
+:::
 
 ## Installing the Casper Client {#install-casper-client}
 

--- a/source/docs/casper/developers/writing-onchain-code/getting-started.md
+++ b/source/docs/casper/developers/writing-onchain-code/getting-started.md
@@ -40,13 +40,19 @@ rustup toolchain install nightly
 
 ### Available Casper Rust crates
 
-To support smart contract development with Rust, the following crates are published: 
+To support smart contract development with Rust, the following crates are published:
 
-- [Casper Contract](https://crates.io/crates/casper-contract) - a library supporting communication with the blockchain. This is the main library you will need to write smart contracts.
-- [Casper Test Support](https://crates.io/crates/casper-engine-test-support) - a virtual machine against which you can test your smart contracts.
-- [Casper Types](https://crates.io/crates/casper-types) - a library with types we use across the Rust ecosystem.
+- [casper-contract](https://crates.io/crates/casper-contract) - a library supporting communication with the blockchain. This is the main library you will need to write smart contracts.
+- [casper-engine-test-support](https://crates.io/crates/casper-engine-test-support) - a virtual machine against which you can test your smart contracts.
+- [casper-types](https://crates.io/crates/casper-types) - a library with types we use across the Rust ecosystem.
 
-A crate is a compilation unit that can be compiled into a binary or a library.
+A crate is a compilation unit that can be compiled into a binary or a library. 
+
+:::note
+
+For a comprehensive list of crates, visit the [Essential Casper Crates](../essential-crates.md) page.
+
+:::
 
 ### Available API documentation
 


### PR DESCRIPTION
### What does this PR fix/introduce?

This PR adds a list of important crates for development. The ”Getting Started” and “Prerequisites” page link to the list. The rest of the pages in writing & testing contracts already have links.

Closes #1238

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ACStoneCL 

<img width="1374" alt="Screenshot 2023-12-16 at 18 15 27" src="https://github.com/casper-network/docs/assets/4185994/2ae33fea-ebca-42c3-83a6-a3406b2bce8b">

