### PR TITLE
1344 Navigation Fix

### DIFF
--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -303,7 +303,6 @@ module.exports = {
                         id: "resources/tokens/cep18/full-tutorial",
                     },
                     items: [
-                        "resources/tokens/cep18/full-tutorial",
                         "resources/tokens/cep18/quickstart-guide",
                         "resources/tokens/cep18/query",
                         "resources/tokens/cep18/transfer",
@@ -320,7 +319,6 @@ module.exports = {
                         id: "resources/tokens/cep78/introduction",
                     },
                     items: [
-                        "resources/tokens/cep78/introduction",
                         "resources/tokens/cep78/modalities",
                         "resources/tokens/cep78/using-casper-client",
                         "resources/tokens/cep78/reverse-lookup",

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -302,11 +302,12 @@ module.exports = {
                         type: "doc",
                         id: "resources/tokens/cep18/full-tutorial",
                     },
-                    items: ["resources/tokens/cep18/full-tutorial",
-                            "resources/tokens/cep18/quickstart-guide",
-                            "resources/tokens/cep18/query",
-                            "resources/tokens/cep18/transfer",
-                            "resources/tokens/cep18/tests",
+                    items: [
+                        "resources/tokens/cep18/full-tutorial",
+                        "resources/tokens/cep18/quickstart-guide",
+                        "resources/tokens/cep18/query",
+                        "resources/tokens/cep18/transfer",
+                        "resources/tokens/cep18/tests",
                     ],
                 },
                 {
@@ -373,7 +374,6 @@ module.exports = {
                 "resources/beginner/upgrade-contract",
                 "resources/beginner/cep18",
                 "resources/beginner/aws-node",
-                // TODO link external tutorials if possible, to show them in sidebar navigation
                 //"resources/beginner/use-javascript-sdk" TODO remove or replace
             ],
         },


### PR DESCRIPTION
### What does this PR fix/introduce?

This PR fixes the navigation loop in the Casper Token Standards section. The fix is to remove the duplicate links. Tested locally. Closes #1344

#### Before and after screenshots

<img width="1154" alt="Screenshot_2023-12-19_at_13_53_51" src="https://github.com/casper-network/docs/assets/4185994/fac4a6f9-6f1c-41f6-8be1-8db41bb37472">

<img width="1305" alt="Screenshot_2023-12-19_at_13_52_23" src="https://github.com/casper-network/docs/assets/4185994/73d53ef0-7562-485d-8fd1-ddd2edf1895d">

#### Additional context

I tested these sections as well, and they were fine:

https://docs.casper.network/concepts/economics/concepts/
https://docs.casper.network/counter/
https://docs.casper.network/counter-testnet/
https://docs.casper.network/sdk/
https://docs.casper.network/developers/cli/transfers/

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.

### Reviewers
@ACStoneCL 

