### PR TITLE
927 - Highlight ways to contribute to the docs

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,6 +1,6 @@
 # Casper Documentation Developer Guide
 
-If you want to add new content or make structural updates to the documentation, follow this guide.
+If you want to add new content or make structural updates to the documentation, follow this guide. Also, read the [Writing Style Guide](./writing-style-guide.md).
 
 ## Technology Stack
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Welcome to the documentation website for the [Casper Network](https://casper.network/). The documentation lives at this address: https://docs.casper.network/.
 
-Information on writing style guidelines for documentation can be found in [CONTRIBUTE.md](./CONTRIBUTE.md).
+Read this page to learn how to contribute new content and run the documentation website locally.
 
 ## Setup
 
@@ -17,7 +17,7 @@ Follow these steps to run the documentation website locally, displayed in your l
 -   Install `yarn` via `npm` using this command:
 
     ```
-        npm install --global yarn
+    npm install --global yarn
     ```
 
 ### Running the website locally
@@ -48,12 +48,12 @@ The following section details how to [update the content](#updating-existing-con
 ### Updating existing content
 
 1. Navigate to the `source/docs/casper` folder.
-2. Find the content you want to update and modify the markdown file(s). If you want to add new content, read the [Developer Guide](#developer-guide).
+2. Find the content you want to update and modify the markdown file(s). If you want to add new content, read the [Developer Guide](./DEVELOPERS.md) and the [Writing Style Guide](./writing-style-guide.md).
 3. [Run the website locally](#running-the-website-locally) to test your changes.
 4. Submit changes to the [documentation](https://github.com/casper-network/docs) using a pull request from your forked repository.
 
-**Note**: The website refreshes as you make changes to the markdown files. However, if you change the structure or configuration of the website, you need to re-start the application.
+**Note**: The website refreshes as you change the markdown files. However, if you change the structure or configuration of the website, you need to restart the application.
 
 ### Adding new content
 
-Adding new content requires structural changes, so read the [Developer Guide](./DEVELOPERS.md).
+Adding new content may require structural changes. Read the [Developer Guide](./DEVELOPERS.md) and the [Writing Style Guide](./writing-style-guide.md).

--- a/config/navbar.config.js
+++ b/config/navbar.config.js
@@ -107,7 +107,7 @@ module.exports = {
         //     ],
         // },
         {
-            href: "https://github.com/casper-network/docs",
+            href: "https://github.com/casper-network/docs/blob/dev/README.md",
             label: "GitHub",
             position: "right",
         },

--- a/writing-style-guide.md
+++ b/writing-style-guide.md
@@ -1,4 +1,4 @@
-# Contributing Documentation
+# Writing Style Guide
 
 This is the Writing Style Guide used by Casper's documentation team.
 


### PR DESCRIPTION
### What does this PR fix/introduce?

This PR highlights ways to contribute to the documentation. On docs.casper.network, the GitHub link could open the documentation README.md directly to make the contribution options even clearer. Closes #927 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.

### Reviewers
@ACStoneCL 
