### PR TITLE
JSON-RPC API Updates for 2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ref: gh-pages
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: gh-pages-backup
           path: .
@@ -96,7 +96,7 @@ jobs:
         run: |
           echo "$prod_pages_fqdn" > ./docs/CNAME
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: gh-pages-depl-payload
           path: ./docs

--- a/source/docs/casper/concepts/hash-types.md
+++ b/source/docs/casper/concepts/hash-types.md
@@ -26,10 +26,14 @@ For the sake of user convenience and compatibility, we expect the delivery of ha
 |Key::Dictionary | dictionary- | dictionary-0101010101010101010101010101010101010101010101010101010101010101|
 |Key::SystemContractRegistry | system-contract-registry- |system-contract-registry-00000000000000000000000000000000|
 |Key::EraSummary | era-summary- |era-summary-00000000000000000000000000000000|
-
-<!-- TODO Add Unbond and ChainspecRegistry after it is added to the live node branch
 |Key::Unbond | unbond- | unbond-ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70|
-|Key::ChainspecRegistry | chainspec-registry- | chainspec-registry-11111111111111111111111111111111|
+|Key::ChainspecRegistry | chainspec-registry- | chainspec-registry-11111111111111111111111111111111 |
+|Key::ChecksumRegistry | checksum-registry- | checksum-registry-00000000000000000000000000000000 |
+|Key::BidAddr | bid-addr- | `Unified` bid-addr-00ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70, `Validator` bid-addr-01ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70, `Delegator` bid-addr-02ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70 |
+<!-- TODO When examples available.
+|Key::Package | package- | |
+|Key::AddressableEntity | addressable-entity- | |
+|Key::ByteCode | byte-code- | |
 -->
 
 ## Hash and Key Explanations {#hash-and-key-explanations}
@@ -55,8 +59,11 @@ For the sake of user convenience and compatibility, we expect the delivery of ha
 - `Key::Dictionary` is the hash derived from a URef and a piece of arbitrary data and leads to a dictionary.
 - `Key::SystemContractRegistry` is a unique `Key` under which a mapping of the names and ContractHashes for system contracts, including `Mint`, `Auction`, `HandlePayment` and `StandardPayment`, is stored.
 - `Key::EraSummary` is a `Key` under which we store current era info.
-
-<!-- TODO Add Unbond and ChainspecRegistry after it is added to the live node branch
 - `Key::Unbond` is a variant of the key type that tracks unbonding purses.
 - `Key::ChainspecRegistry` is a unique `Key` which contains a mapping of file names to the hash of the file itself. These files include *Chainspec.toml* and may also include *Accounts.toml* and *GlobalState.toml*.
--->
+- `Key::ChecksumRegistry` is a unique `key` variant under which we write a registry of checksums for a given block.  There are two checksums in the registry, one for the execution results and the other for the approvals of all deploys in the block.
+- `Key::BidAddr` manages data associated with bids for the `Auction` contract. It may be any one of three variants: `unified`, `validator`, or `delegator`.
+- `Key::Package` is a `Key` under which package information is stored.
+- `Key::AddressableEntity` is a `Key` under which an [addressable entity]() is stored.
+- `Key::ByteCode` is a `Key` under which a byte code record is stored.
+- `Key::Message` is a `Key` under which a message is stored.

--- a/source/docs/casper/concepts/hash-types.md
+++ b/source/docs/casper/concepts/hash-types.md
@@ -30,11 +30,6 @@ For the sake of user convenience and compatibility, we expect the delivery of ha
 |Key::ChainspecRegistry | chainspec-registry- | chainspec-registry-11111111111111111111111111111111 |
 |Key::ChecksumRegistry | checksum-registry- | checksum-registry-00000000000000000000000000000000 |
 |Key::BidAddr | bid-addr- | `Unified` bid-addr-00ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70, `Validator` bid-addr-01ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70, `Delegator` bid-addr-02ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70ef4687f74d465826239bab05c4e1bdd2223dd8c201b96f361f775125e624ef70 |
-<!-- TODO When examples available.
-|Key::Package | package- | |
-|Key::AddressableEntity | addressable-entity- | |
-|Key::ByteCode | byte-code- | |
--->
 
 ## Hash and Key Explanations {#hash-and-key-explanations}
 
@@ -64,6 +59,6 @@ For the sake of user convenience and compatibility, we expect the delivery of ha
 - `Key::ChecksumRegistry` is a unique `key` variant under which we write a registry of checksums for a given block.  There are two checksums in the registry, one for the execution results and the other for the approvals of all deploys in the block.
 - `Key::BidAddr` manages data associated with bids for the `Auction` contract. It may be any one of three variants: `unified`, `validator`, or `delegator`.
 - `Key::Package` is a `Key` under which package information is stored.
-- `Key::AddressableEntity` is a `Key` under which an [addressable entity]() is stored.
+- `Key::AddressableEntity` is a `Key` under which an [`AddressableEntity`](/developers/json-rpc/types_chain.md/#addressableentity) is stored.
 - `Key::ByteCode` is a `Key` under which a byte code record is stored.
 - `Key::Message` is a `Key` under which a message is stored.

--- a/source/docs/casper/concepts/serialization-standard.md
+++ b/source/docs/casper/concepts/serialization-standard.md
@@ -26,9 +26,11 @@ A `blake2b` hash of the public key, representing the address of a user's account
 
 ## Action Thresholds {#action-thresholds}
 
-The minimum weight thresholds that have to be met when executing an action of a certain type. It serializes as two consecutive [`u8` values](#clvalue-numeric) as follows.
+The minimum weight thresholds that have to be met when executing an action of a certain type. It serializes as three consecutive [`u8` values](#clvalue-numeric) as follows.
 
 -   `deployment` The minimum weight threshold required to perform deployment actions as a `u8` value.
+
+-   `upgrade_management` The minimum weight threshold required to perform upgrade management actions as a `u8` value.
 
 -   `key_management` The minimum weight threshold required to perform key management actions as a `u8` value.
 
@@ -442,8 +444,15 @@ Given the different variants for the over-arching `Key` data-type, each of the d
 | `Withdraw`   |  8               |
 | `Dictionary` |  9               |
 | `SystemContractRegistry`| 10    |
-| `Unbond`     |  11              |
-| `ChainspecRegistry` | 12        |
+| `EraSummary` | 11               |
+| `Unbond`     | 12               |
+| `ChainspecRegistry` | 13        |
+| `ChecksumRegistry` | 14         |
+| `BidAddr`    | 15               |
+| `Package`    | 16               |
+| `AddressableEntity` | 17        |
+| `ByteCode`   | 18               |
+| `Message`    | 19               |
 
 -   `Account` serializes as a 32 byte long buffer containing the byte representation of the underlying `AccountHash`
 -   `Hash` serializes as a 32 byte long buffer containing the byte representation of the underlying `Hash` itself.
@@ -453,10 +462,22 @@ Given the different variants for the over-arching `Key` data-type, each of the d
 -   `EraInfo` serializes a `u64` primitive type containing the little-endian byte representation of `u64`.
 -   `Balance` serializes as 32 byte long buffer containing the byte representation of the URef address.
 -   `Bid` and `Withdraw` both contain the `AccountHash` as their identifier; therefore, they serialize in the same manner as the `Account` variant.
--   `Dictionary` as the 32 byte long buffer containing the byte representation of the seed URef hashed with the identifying name of the dictionary item.
--   `SystemContractRegistry` as a 32 byte long buffer of zeros.
+-   `Dictionary` serializes as the 32 byte long buffer containing the byte representation of the seed URef hashed with the identifying name of the dictionary item.
+-   `SystemContractRegistry` serializes as a 32 byte long buffer of zeros.
+-   `EraSummary` serializes as a 32 byte long buffer of zeros.
 -   `Unbond` contains the `AccountHash` as its identifier; therefore, it serialize in the same manner as the `Account` variant.
--   `ChainspecRegistry` as a 32 byte long buffer of ones.
+-   `ChainspecRegistry` serializes as a 32 byte long buffer of ones.
+-   `ChecksumRegistry` serializes as a 32 byte long buffer of zeros.
+-   `BidAddr` may be one of three types:
+    -   `Unified` serializes as the tag `0` followed by a 32 byte long buffer containing the byte representation of a legacy bid.
+    -   `Validator` serializes as the tag `1` followed by a 32 byte long buffer containing the byte representation of a validator's hash.
+    -   `Delegator` serializes as the tag `2` followed by a 32 byte long buffer containing the byte representation of the associated validator's hash, appended with a 32 byte long buffer containing the byte representation of the given delegator's hash.
+<!-- TODO
+-   `Package` 
+-   `AddressableEntity` 
+-   `ByteCode` 
+-   `Message`
+-->
 
 ## Permissions {#serialization-standard-permissions}
 
@@ -559,26 +580,18 @@ Hex-encoded transfer address, which serializes as a byte representation of itsel
 
 The actual transformation performed while executing a deploy. It serializes as a single `u8` value indicating the type of transform performed as per the following table. The remaining bytes represent the information and serialization as listed.
 
-| Transform Type       | Serialization | Description                                                                  |
-|----------------------|---------------|------------------------------------------------------------------------------|
-|Identity              | 0             | A transform having no effect.                                                |
-|Write_CLValue         | 1             | Writes the given [`CLValue`](#clvalue-calvalue) to global state.             |
-|Write_Account         | 2             | Write the given [`Account`](#account-hash) to global state.                  |
-|Write_Contract_WASM   | 3             | Writes a smart [contract as Wasm](#contractwasmhash) to global state.        |
-|Write_Contract        | 4             | Writes a smart [contract](#contracthash) to global state.                    | 
-|Write_Contract_Package| 5             | Writes a smart [contract package](#contractpackagehash) to global state.     |
-|Write_Deploy_Info     | 6             | Writes the given [`DeployInfo`](#deployinfo) to global state.                |
-|Write_Transfer        | 7             | Writes the given [Transfer](#transferaddr) to global state.                  |
-|Write_Era_Info        | 8             | Writes the given [`EraInfo`](#erainfo) to global state.                      |
-|Write_Bid             | 9             | Writes the given [`Bid`](#bid) to global state.                              |
-|Write_Withdraw        | 10            | Writes the given [Withdraw](#unbondingpurse) to global state.                |
-|Add_INT32             | 11            | Adds the given [`i32`](#clvalue-numeric).                                    |
-|Add_UINT64            | 12            | Adds the given [`u64`](#clvalue-numeric).                                    |
-|Add_UINT128           | 13            | Adds the given [`U128`](#clvalue-numeric).                                   |
-|Add_UINT256           | 14            | Adds the given [`U256`](#clvalue-numeric).                                   |
-|Add_UINT512           | 15            | Adds the given [`U512`](#clvalue-numeric).                                   |
-|Add_Keys              | 16            | Adds the given collection of [named keys](#namedkey).                        |
-|Failure               | 17            | A failed transformation, containing an error message.                        |
+| Transform Type | Serialization | Description |
+| -------------- | ------------- | ----------- |
+| Identity       | 0             | A transform having no effect, created as a result of reading from the global state. |
+| Write          | 1             | Writes a new value in the global state. |
+| AddInt32       | 2             | Adds the given [`i32`](#clvalue-numeric). |
+| AddUInt64      | 3             | Adds the given [`u64`](#clvalue-numeric). |
+| AddUInt128     | 4             | Adds the given [`U128`](#clvalue-numeric). |
+| AddUInt256     | 5             | Adds the given [`U256`](#clvalue-numeric). |
+| AddUInt512     | 6             | Adds the given [`U512`](#clvalue-numeric). |
+| AddKeys        | 7             | Adds the given collection of [named keys](#namedkey). |
+| Failure        | 8             | A failed transformation, containing an error message. |
+| Prune          | 9             | Removes the pathing to the global state entry of the specified key. The pruned element remains reachable from previously generated global state root hashes, but will not be included in the next generated global state root hash and subsequent states. |
 
 ## TransformEntry {#transformentry}
 

--- a/source/docs/casper/concepts/serialization-standard.md
+++ b/source/docs/casper/concepts/serialization-standard.md
@@ -472,12 +472,6 @@ Given the different variants for the over-arching `Key` data-type, each of the d
     -   `Unified` serializes as the tag `0` followed by a 32 byte long buffer containing the byte representation of a legacy bid.
     -   `Validator` serializes as the tag `1` followed by a 32 byte long buffer containing the byte representation of a validator's hash.
     -   `Delegator` serializes as the tag `2` followed by a 32 byte long buffer containing the byte representation of the associated validator's hash, appended with a 32 byte long buffer containing the byte representation of the given delegator's hash.
-<!-- TODO
--   `Package` 
--   `AddressableEntity` 
--   `ByteCode` 
--   `Message`
--->
 
 ## Permissions {#serialization-standard-permissions}
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -461,6 +461,8 @@ If the `execution_results` field is empty, it means that the network processed t
 |Parameter|Type|Description|
 |---------|----|-----------|    
 |api_version|String|The RPC API version.|
+|[block_hash](./types_chain.md#blockhash)|Object|The Block hash, if found.|
+|block_height|Integer|The height of the Block.|
 |[deploy](./types_chain.md#deploy)|Object|The Deploy.|
 |[execution_results](./types_chain.md#jsonexecutionresult)|Array|An array of execution results with Block hashes.|
 
@@ -474,95 +476,255 @@ If the `execution_results` field is empty, it means that the network processed t
   "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "api_version": "1.4.13",
-    "deploy": {
-      "approvals": [
-        {
-          "signature": "014c1a89f92e29dd74fc648f741137d9caf4edba97c5f9799ce0c9aa6b0c9b58db368c64098603dbecef645774c05dff057cb1f91f2cf390bbacce78aa6f084007",
-          "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
-        }
-      ],
-      "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
-      "header": {
-        "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
-        "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
-        "chain_name": "casper-example",
-        "dependencies": [
-          "0101010101010101010101010101010101010101010101010101010101010101"
-        ],
-        "gas_price": 1,
-        "timestamp": "2020-11-17T00:39:24.072Z",
-        "ttl": "1h"
-      },
-      "payment": {
-        "StoredContractByName": {
-          "args": [
-            [
-              "amount",
-              {
-                "bytes": "e8030000",
-                "cl_type": "I32",
-                "parsed": 1000
-              }
-            ]
+    "value": {
+      "api_version": "1.5.3",
+      "deploy": {
+        "hash": "5c9b3b099c1378aa8e4a5f07f59ff1fcdc69a83179427c7e67ae0377d94d93fa",
+        "header": {
+          "account": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+          "timestamp": "2020-11-17T00:39:24.072Z",
+          "ttl": "1h",
+          "gas_price": 1,
+          "body_hash": "d53cf72d17278fd47d399013ca389c50d589352f1a12593c0b8e01872a641b50",
+          "dependencies": [
+            "0101010101010101010101010101010101010101010101010101010101010101"
           ],
-          "entry_point": "example-entry-point",
-          "name": "casper-example"
-        }
-      },
-      "session": {
-        "Transfer": {
-          "args": [
-            [
-              "amount",
-              {
-                "bytes": "e8030000",
-                "cl_type": "I32",
-                "parsed": 1000
-              }
-            ]
-          ]
-        }
-      }
-    },
-    "execution_results": [
-      {
-        "block_hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb",
-        "result": {
-          "Success": {
-            "cost": "123456",
-            "effect": {
-              "operations": [
+          "chain_name": "casper-example"
+        },
+        "payment": {
+          "StoredContractByName": {
+            "name": "casper-example",
+            "entry_point": "example-entry-point",
+            "args": [
+              [
+                "amount",
                 {
-                  "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
-                  "kind": "Write"
-                },
-                {
-                  "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                  "kind": "Read"
-                }
-              ],
-              "transforms": [
-                {
-                  "key": "uref-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb-007",
-                  "transform": {
-                    "AddUInt64": 8
-                  }
-                },
-                {
-                  "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
-                  "transform": "Identity"
+                  "cl_type": "I32",
+                  "bytes": "e8030000",
+                  "parsed": 1000
                 }
               ]
-            },
+            ]
+          }
+        },
+        "session": {
+          "Transfer": {
+            "args": [
+              [
+                "amount",
+                {
+                  "cl_type": "I32",
+                  "bytes": "e8030000",
+                  "parsed": 1000
+                }
+              ]
+            ]
+          }
+        },
+        "approvals": [
+          {
+            "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+            "signature": "014c1a89f92e29dd74fc648f741137d9caf4edba97c5f9799ce0c9aa6b0c9b58db368c64098603dbecef645774c05dff057cb1f91f2cf390bbacce78aa6f084007"
+          }
+        ]
+      },
+      "block_hash": "9ccc716f5f3c7ac238bf7aaad113c2add3586921a7966faffb3a5a253aa1d75e",
+      "block_height": 10,
+      "execution_result": {
+        "Version2": {
+          "Success": {
+            "effects": [
+              {
+                "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
+                "kind": {
+                  "AddUInt64": 8
+                }
+              },
+              {
+                "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+                "kind": "Identity"
+              }
+            ],
             "transfers": [
               "transfer-5959595959595959595959595959595959595959595959595959595959595959",
               "transfer-8282828282828282828282828282828282828282828282828282828282828282"
-            ]
+            ],
+            "cost": "123456"
           }
         }
       }
-    ]
+    }
+  }
+}
+
+```
+
+</details>
+
+## info_get_transaction {#info-get-transaction}
+
+This method retrieves a transaction from a network. It requires a `transaction_hash` to query the Deploy.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|[transaction_hash](types_chain.md#transactionhash)|String|The transaction hash.|
+|[finalized_approvals](types_chain.md#finalizedapprovals)|Boolean|Determines whether to return the transaction with the finalized approvals substituted. (Optional)|
+
+<details>
+
+<summary>Example info_get_transaction request</summary>
+
+```bash
+
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "info_get_transaction",
+  "params": [
+    {
+      "name": "transaction_hash",
+      "value": {
+        "Version1": "6aaf4a54499e3757eb4be6967503dcc431e4623bf8bb57a14c1729a114a1aaa2"
+      }
+    },
+    {
+      "name": "finalized_approvals",
+      "value": true
+    }
+  ],
+}
+
+```
+
+</details>
+
+### `info_get_transaction_result`
+
+The response contains the transaction and the results of executing the associated Deploy.
+
+If the `execution_results` field is empty, it means that the network processed the transaction, but has yet to execute it. If the network executed the transaction, it will return the results of the associated Deploy's execution. The execution results contain the Block hash which contains the Deploy.
+
+|Parameter|Type|Description|
+|---------|----|-----------|    
+|api_version|String|The RPC API version.|
+|[block_hash](./types_chain.md#blockhash)|Object|The Block hash, if found.|
+|block_height|Integer|The height of the Block.|
+|[transaction](./types_chain.md#transaction)|Object|The transaction.|
+|[execution_results](./types_chain.md#jsonexecutionresult)|Array|An array of execution results with Block hashes.|
+
+<details>
+
+<summary>Example info_get_transaction result</summary>
+
+```bash
+
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "value": {
+    "api_version": "1.5.3",
+    "transaction": {
+      "Version1": {
+        "hash": "6aaf4a54499e3757eb4be6967503dcc431e4623bf8bb57a14c1729a114a1aaa2",
+        "header": {
+          "chain_name": "casper-example",
+          "timestamp": "2020-11-17T00:39:24.072Z",
+          "ttl": "1h",
+          "body_hash": "d2433e28993036fbdf7c963cd753893fefe619e7dbb5c0cafa5cb03bcf3ff9db",
+          "pricing_mode": {
+            "GasPriceMultiplier": 1
+          },
+          "payment_amount": null,
+          "initiator_addr": {
+            "PublicKey": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+          }
+        },
+        "body": {
+          "args": [
+            [
+              "source",
+              {
+                "cl_type": "URef",
+                "bytes": "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a07",
+                "parsed": "uref-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a-007"
+              }
+            ],
+            [
+              "target",
+              {
+                "cl_type": "URef",
+                "bytes": "1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b00",
+                "parsed": "uref-1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b-000"
+              }
+            ],
+            [
+              "amount",
+              {
+                "cl_type": "U512",
+                "bytes": "0500ac23fc06",
+                "parsed": "30000000000"
+              }
+            ],
+            [
+              "to",
+              {
+                "cl_type": {
+                  "Option": {
+                    "ByteArray": 32
+                  }
+                },
+                "bytes": "012828282828282828282828282828282828282828282828282828282828282828",
+                "parsed": "2828282828282828282828282828282828282828282828282828282828282828"
+              }
+            ],
+            [
+              "id",
+              {
+                "cl_type": {
+                  "Option": "U64"
+                },
+                "bytes": "01e703000000000000",
+                "parsed": 999
+              }
+            ]
+          ],
+          "target": "Native",
+          "entry_point": "Transfer",
+          "scheduling": "Standard"
+        },
+        "approvals": [
+          {
+            "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+            "signature": "012152c1eab67f63faa6a482ec4847ecd145c3b2c3e2affe763303ecb4ccf8618a1b2d24de7313fbf8a2ac1b5256471cc6bbf21745af15516331e5fc3d4a2fa201"
+          }
+        ]
+      }
+    },
+    "block_hash": "9ccc716f5f3c7ac238bf7aaad113c2add3586921a7966faffb3a5a253aa1d75e",
+    "block_height": 10,
+    "execution_result": {
+      "Version2": {
+        "Success": {
+          "effects": [
+            {
+              "key": "account-hash-2c4a11c062a8a337bfc97e27fd66291caeb2c65865dcb5d3ef3759c4c97efecb",
+              "kind": {
+                "AddUInt64": 8
+              }
+            },
+            {
+              "key": "deploy-af684263911154d26fa05be9963171802801a0b6aff8f199b7391eacb8edc9e1",
+              "kind": "Identity"
+            }
+          ],
+          "transfers": [
+            "transfer-5959595959595959595959595959595959595959595959595959595959595959",
+            "transfer-8282828282828282828282828282828282828282828282828282828282828282"
+          ],
+          "cost": "123456"
+        }
+      }
+    }
   }
 }
 
@@ -762,7 +924,7 @@ This method returns a JSON representation of an [Account](../../concepts/design/
 
 |Parameter|Type|Description|
 |---------|----|-----------|
-|[public_key](types_chain.md#publickey)|String|The public key of the Account.|
+|[account_identifier](types_chain.md#AccountIdentifier)|String|The public key or account hash of the Account.|
 |[block_identifier](types_chain.md#blockidentifier)|Object|The Block identifier.|
 
 <details>
@@ -777,9 +939,15 @@ This method returns a JSON representation of an [Account](../../concepts/design/
   "method": "state_get_account_info",
   "params": [
     {
-      "Hash": "13c2d7a68ecdd4b74bf4393c88915c836c863fc4bf11d7f2bd930a1bbccacdcb"
+      "name": "account_identifier",
+      "value": "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
     },
-    "013b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29"
+    {
+      "name": "block_identifier",
+      "value": {
+        "Hash": "0707070707070707070707070707070707070707070707070707070707070707"
+      }
+    }
   ]
 }
 
@@ -805,23 +973,30 @@ This method returns a JSON representation of an [Account](../../concepts/design/
   "id": 1,
   "jsonrpc": "2.0",
   "result": {
-    "account": {
-      "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-      "action_thresholds": {
-        "deployment": 1,
-        "key_management": 1
-      },
-      "associated_keys": [
-        {
-          "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
-          "weight": 1
+    "value": {
+      "api_version": "1.5.3",
+      "account": {
+        "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+        "named_keys": [
+          {
+            "name": "main_purse",
+            "key": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007"
+          }
+        ],
+        "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
+        "associated_keys": [
+          {
+            "account_hash": "account-hash-e94daaff79c2ab8d9c31d9c3058d7d0a0dd31204a5638dc1451fa67b2e3fb88c",
+            "weight": 1
+          }
+        ],
+        "action_thresholds": {
+          "deployment": 1,
+          "key_management": 1
         }
-      ],
-      "main_purse": "uref-09480c3248ef76b603d386f3f4f8a5f87f597d4eaffd475433f861af187ab5db-007",
-      "named_keys": []
-    },
-    "api_version": "1.4.13",
-    "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
+      },
+      "merkle_proof": "01000000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625016ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a72536147614625000000003529cde5c621f857f75f3810611eb4af3f998caaa9d4a3413cf799f99c67db0307010000006ef2e0949ac76e55812421f755abe129b6244fe7168b77f47a7253614761462501010102000000006e06000000000074769d28aac597a36a03a932d4b43e4f10bf0403ee5c41dd035102553f5773631200b9e173e8f05361b681513c14e25e3138639eb03232581db7557c9e8dbbc83ce94500226a9a7fe4f2b7b88d5103a4fc7400f02bf89c860c9ccdd56951a2afe9be0e0267006d820fb5676eb2960e15722f7725f3f8f41030078f8b2e44bf0dc03f71b176d6e800dc5ae9805068c5be6da1a90b2528ee85db0609cc0fb4bd60bbd559f497a98b67f500e1e3e846592f4918234647fca39830b7e1e6ad6f5b7a99b39af823d82ba1873d000003000000010186ff500f287e9b53f823ae1582b1fa429dfede28015125fd233a31ca04d5012002015cc42669a55467a1fdf49750772bfc1aed59b9b085558eb81510e9b015a7c83b0301e3cf4a34b1db6bfa58808b686cb8fe21ebe0c1bcbcee522649d2b135fe510fe3"
+    }
   }
 }
 

--- a/source/docs/casper/developers/json-rpc/json-rpc-transactional.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-transactional.md
@@ -113,6 +113,143 @@ The result contains the [deploy_hash](./types_chain.md#deployhash), which is the
 
 </details>
 
+## account_put_transaction {#account-put-transaction}
+
+This endpoint allows sending a transaction to be executed by the network.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|[transaction](./types_chain.md#transaction)|Object|A transaction consists of an item containing a Deploy and a [`Transaction`](./types_chain.md#transaction) along with the requester's signature(s).|
+
+<details>
+
+<summary>Example account_put_transaction request</summary>
+
+```bash
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "account_put_transaction",
+  "params": [
+    {
+      "name": "transaction",
+      "value": {
+        "Version1": {
+          "hash": "6aaf4a54499e3757eb4be6967503dcc431e4623bf8bb57a14c1729a114a1aaa2",
+          "header": {
+            "chain_name": "casper-example",
+            "timestamp": "2020-11-17T00:39:24.072Z",
+            "ttl": "1h",
+            "body_hash": "d2433e28993036fbdf7c963cd753893fefe619e7dbb5c0cafa5cb03bcf3ff9db",
+            "pricing_mode": {
+              "GasPriceMultiplier": 1
+            },
+            "payment_amount": null,
+            "initiator_addr": {
+              "PublicKey": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+            }
+          },
+          "body": {
+            "args": [
+              [
+                "source",
+                {
+                  "cl_type": "URef",
+                  "bytes": "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a07",
+                  "parsed": "uref-0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a-007"
+                }
+              ],
+              [
+                "target",
+                {
+                  "cl_type": "URef",
+                  "bytes": "1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b00",
+                  "parsed": "uref-1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b1b-000"
+                }
+              ],
+              [
+                "amount",
+                {
+                  "cl_type": "U512",
+                  "bytes": "0500ac23fc06",
+                  "parsed": "30000000000"
+                }
+              ],
+              [
+                "to",
+                {
+                  "cl_type": {
+                    "Option": {
+                      "ByteArray": 32
+                    }
+                  },
+                  "bytes": "012828282828282828282828282828282828282828282828282828282828282828",
+                  "parsed": "2828282828282828282828282828282828282828282828282828282828282828"
+                }
+              ],
+              [
+                "id",
+                {
+                  "cl_type": {
+                    "Option": "U64"
+                  },
+                  "bytes": "01e703000000000000",
+                  "parsed": 999
+                }
+              ]
+            ],
+            "target": "Native",
+            "entry_point": "Transfer",
+            "scheduling": "Standard"
+          },
+          "approvals": [
+            {
+              "signer": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c",
+              "signature": "012152c1eab67f63faa6a482ec4847ecd145c3b2c3e2affe763303ecb4ccf8618a1b2d24de7313fbf8a2ac1b5256471cc6bbf21745af15516331e5fc3d4a2fa201"
+            }
+          ]
+        }
+      }
+    }
+  ],
+}
+
+```
+
+</details>
+
+### `account_put_transaction_result`
+
+The result contains the [transaction_hash](./types_chain.md#transactionhash), which is the primary identifier of a transaction within a Casper network.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|api_version|String|The RPC API version.|
+|[transaction_hash](./types_chain.md#transactionhash)|String| A hex-encoded hash of the transaction as sent.|
+
+<details>
+
+<summary>Example account_put_transaction result</summary>
+
+```bash
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+            "name": "account_put_transaction_example_result",
+            "value": {
+              "api_version": "1.5.3",
+              "transaction_hash": {
+                "Version1": "6aaf4a54499e3757eb4be6967503dcc431e4623bf8bb57a14c1729a114a1aaa2"
+              }
+            }
+          }
+}
+
+```
+
+</details>
+
 ## speculative_exec {#speculative_exec}
 
 The `speculative_exec` endpoint provides a method to execute a `Deploy` without committing its execution effects to global state. By default, `speculative_exec` is disabled on a node. Sending a request to a node with the endpoint disabled will result in an error message. If enabled, `speculative_exec` operates on a separate port from the primary JSON-RPC, using 7778.

--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -210,7 +210,7 @@ One of:
 
 ## BlockBodyV1 {#blockbodyv1}
 
-The body portion of a block.
+The body portion of a block prior to Casper 2.0.
 
 Required Parameters:
 
@@ -254,7 +254,7 @@ One of:
 
 ## BlockHeaderV1 {#blockheaderv1}
 
-The header portion of a block.
+The header portion of a block prior to Casper 2.0.
 
 Required Parameters:
 
@@ -354,7 +354,7 @@ A newtype wrapping a `u64`, which represents the block time.
 
 ## BlockV1 {#blockv1}
 
-A block after execution with the resulting global state root hash. This is the core component of the Casper linear blockchain.
+A block after execution with the resulting global state root hash prior to Casper 2.0. This is the core component of the Casper linear blockchain.
 
 Required Parameters:
 
@@ -678,7 +678,7 @@ Context of an entry point execution.
 
 ## EraEndV1 {#eraendv1}
 
-Information related to the end of an era and validator weights for the following era.
+Information related to the end of an era and validator weights for the following era prior to Casper 2.0.
 
 Required Parameters:
 
@@ -852,7 +852,7 @@ One of:
 
 ## ExecutionResultV1 {#executionresultV1}
 
-The result of executing a single deploy.
+The result of executing a single deploy prior to Casper 2.0.
 
 One of:
 

--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -22,6 +22,16 @@ Required Parameters:
 
 The AccountHash is a 32-byte hash derived from a supported PublicKey. Its role is to standardize keys that can vary in length.
 
+## AccountIdentifier {#accountidentifier}
+
+Identifier of an account.
+
+Contains one of:
+
+* [`PublicKey`](#publickey)
+
+* [`AccountHash`](#accounthash)
+
 ## ActionThresholds {#actionthresholds}
 
 Thresholds that have to be met when executing an action of a certain type.
@@ -29,6 +39,8 @@ Thresholds that have to be met when executing an action of a certain type.
 Required Parameters:
 
 * `deployment`
+
+* `upgrade_management`
 
 * `key_management`
 
@@ -40,6 +52,30 @@ The first era to which the associated protocol version applies.
 
 * [`timestamp`](#timestamp)
 
+## AddressableEntity {#addressableentity}
+
+* [`package_hash`](#packagehash)
+
+* [`byte_code_hash`](#bytecodehash)
+
+* [`named_keys`](#namedkeys)
+
+* [`entry_points`](#array_of_namedentrypoint)
+
+* [`protocol_version`](#protocolversion)
+
+* [`main_purse`](#uref)
+
+* [`associated_keys`](#associatedkeys)
+
+* [`action_thresholds`](#actionthresholds)
+
+* [`message_topics`](#array_of_messagetopic)
+
+## AddressableEntityHash {#addressableentityhash}
+
+The hex-encoded address of the addressable entity.
+
 ## Approval {#approval}
 
 A struct containing a signature and the public key of the signer.
@@ -50,6 +86,50 @@ Required Parameters:
 
 * [`signer`](#publickey)
 
+## Array_of_AssociatedKey {#array-of-associatedkey}
+
+An array of [AssociatedKeys](#associatedkey).
+
+## Array_of_BlockProof {#array-of-blockproof}
+
+An array of [`BlockProofs`](#blockproof).
+
+## Array_of_EntityVersionAndHash {#array-of-entityversionandhash}
+
+An array of [EntityVersionAndHashes](#entityversionandhash).
+
+## Array_of_EraReward {#array-of-erareward}
+
+An array of [EraRewards](#erareward).
+
+## Array_of_MessageTopic {#array-of-messagetopic}
+
+An array of [MessageTopics](#messagetopic).
+
+## Array_of_NamedEntryPoint {#array-of-namedentrypoint}
+
+An array of [named entry points](#namedentrypoint).
+
+## Array_of_NamedKey {#array-of-namedkey}
+
+An array of [NamedKeys](#namedkey).
+
+## Array_of_NamedUserGroup {#array-of-namedusergroup}
+
+An array of [NamedUserGroups](#namedusergroup).
+
+## Array_of_PublicKeyAndBid {#array-of-publickeyandbid}
+
+An array of [bids associated with give public keys](#publickeyandbid).
+
+## Array_of_PublicKeyAndDelegator {#array-of-publickeyanddelegator}
+
+An array consisting of [PublicKeyAndDelegators](#publickeyanddelegator).
+
+## Array_of_ValidatorWeight {#array-of-validatorweight}
+
+An array of [`ValidatorWeights`](#validatorweight).
+
 ## AssociatedKey {#associatedkey}
 
 A key granted limited permissions to an Account, for purposes such as multisig.
@@ -58,7 +138,11 @@ Required Parameters:
 
 * [`account_hash`](#accounthash)
 
-* `weight`
+* [`weight`](#weight)
+
+## AssociatedKeys {#associatedkeys}
+
+A [collection of weighted public keys](#array-of-associatedkey) (represented as account hashes) associated with an account.
 
 ## AuctionState {#auctionstate}
 
@@ -102,9 +186,127 @@ Additional Parameters:
 
 * [`vesting_schedule`](#vestingschedule) Vesting schedule for a genesis validator. `None` if non-genesis validator.
 
+## BidKind {#bidkind}
+
+Auction bid variants.
+
+One of:
+
+* `Unified` A unified record indexed on validator data, with an embedded collection of all delegator bids assigned to that validator. The `Unified`` variant is for legacy retrograde support, new instances will not be created going forward.
+
+* `Validator` A bid record containing only validator data.
+
+* `Delegator` A bid record containing only delegator data.
+
+## Block {#block}
+
+A block after execution.
+
+One of:
+
+* [`Version1`](#blockv1)
+
+* [`Version2`](#blockv2)
+
+## BlockBodyV1 {#blockbodyv1}
+
+The body portion of a block.
+
+Required Parameters:
+
+* [`deploy_hashes`](#deployhash)
+
+* [`proposer`](#publickey)
+
+* [`transfer_hashes`](#deployhash)
+
+## BlockBodyV2 {#blockbodyv2}
+
+The body portion of a block.
+
+Required Parameters:
+
+* [`install_upgrade`](#transactionhash) The hashes of the installer/upgrader transactions within the block.
+
+* [`proposer`](#publickey)
+
+* [`rewarded_signatures`](#rewardedsignatures)
+
+* [`staking`](#transactionhash) The hashes for non-transfer, native transactions within the block.
+
+* [`standard`](#transactionhash) The hashes of all other transactions within the block.
+
+* [`transfer`](#transactionhash) The hashes of the transfer transactions within the block.
+
 ## BlockHash {#blockhash}
 
 A cryptographic hash identifying a `Block`.
+
+## BlockHeader {#blockheader}
+
+The versioned header portion of a block. It encapsulates different variants of the `BlockHeader` struct.
+
+One of:
+
+* [`Version1`](#blockheaderv1)
+
+* [`Version2`](#blockheaderv2)
+
+## BlockHeaderV1 {#blockheaderv1}
+
+The header portion of a block.
+
+Required Parameters:
+
+* [`accumulated_seed`](#digest)
+
+* [`body_hash`](#digest)
+
+* [`era_id`](#eraid)
+
+* `height` The height of this block.
+
+* [`parent_hash`](#blockhash)
+
+* [`protocol_version`](#protocolversion)
+
+* `random_bit` A random bit needed for initializing a future era.
+
+* [`state_root_hash`](#digest)
+
+* [`timestamp`](#timestamp)
+
+Additional Parameters:
+
+* [`era_end`](#eraendv1)
+
+## BlockHeaderV2 {#blockheaderv1}
+
+The header portion of a block.
+
+Required Parameters:
+
+* [`accumulated_seed`](#digest)
+
+* [`body_hash`](#digest)
+
+* [`era_id`](#eraid)
+
+* `height` The height of this block.
+
+* [`parent_hash`](#blockhash)
+
+* [`protocol_version`](#protocolversion)
+
+* `random_bit` A random bit needed for initializing a future era.
+
+* [`state_root_hash`](#digest)
+
+* [`timestamp`](#timestamp)
+
+Additional Parameters:
+
+* [`era_end`](#eraendv2)
 
 ## BlockIdentifier {#blockidentifier}
 
@@ -114,25 +316,93 @@ Identifier for possible ways to retrieve a Block.
 
 * `Height` Identify and retrieve the Block with its height.
 
+## BlockProof {#blockproof}
+
+A validator's public key paired with a corresponding signature of a given block hash.
+
+Required Parameters:
+
+* [`public_key`](#publickey)
+
+* [`signature`](#signature)
+
 ## BlockSynchronizerStatus {#blocksynchronizerstatus}
 
 The status of the block synchronizer.
 
-* `Historical` The status of syncing a historical block, if any.
+* [`Historical`](#blocksyncstatus) The status of syncing a historical block, if any.
 
-    * [`block_hash`](#blockhash-blockhash) The block hash.
+* [`Forward`](#blocksyncstatus) The status of syncing a forward block, if any.
 
-    * `block_height` The height of the block, if known.
+## BlockSyncStatus {#blocksyncstatus}
 
-    * `acquisition_state` The state of acquisition of the data associated with the block.
+The status of syncing an individual block.
 
-* `Forward` The status of syncing a forward block, if any.
+Required Parameters:
 
-    * [`block_hash`](#blockhash-blockhash) The block hash.
+* `acquisition_state` The state of acquisition of the data associated with the block as a string.
 
-    * `block_height` The height of the block, if known.
+* [`block_hash`](#blockhash)
 
-    * `acquisition_state` The state of acquisition of the data associated with the block.
+Additional Parameters:
+
+* `block_height` The height of the block, if known.
+
+## BlockTime {#blocktime}
+
+A newtype wrapping a `u64` which represents the block time.
+
+## BlockV1 {#blockv1}
+
+A block after execution with the resulting global state root hash. This is the core component of the Casper linear blockchain.
+
+Required Parameters:
+
+* [`body`](#blockbodyv1)
+
+* [`hash`](#blockhash)
+
+* [`header`](#blockheaderv1)
+
+## BlockV2 {#blockv2}
+
+A block after execution, with the resulting global state root hash. This is the core component of the Casper linear blockchain.
+
+Required Parameters:
+
+* [`body`](#blockbodyv2)
+
+* [`hash`](#blockhash)
+
+* [`header`](#blockheaderv2)
+
+## Bytes {#bytes}
+
+Hex-encoded bytes.
+
+## ByteCode {#bytecode}
+
+A container for contract's Wasm bytes.
+
+Required Parameters:
+
+* [`bytes`](#bytes)
+
+* [`kind`](#ByteCodeKind)
+
+## ByteCodeHash {#bytecodehash}
+
+The hex-encoded address of a smart contract [`AddressableEntity`](#addressableentity)
+
+## ByteCodeKind {#bytecodekind}
+
+The type of byte code.
+
+One of:
+
+* `Empty` Empty byte code.
+
+* `V1CasperWasm` Byte code to be executed with the version 1 Casper execution engine.
 
 ## ChainspecRawBytes {#chainspecrawbytes}
 
@@ -172,15 +442,27 @@ Required Parameters:
 
 * [`access_key`](#uref)
 
-* [`disabled_versions`](#disabledversions)
+* [`disabled_versions`](#contractversionkey)
 
-* [`groups`](#groups)
+* [`groups`](#array_of_namedusergroup)
 
-* [`versions`](#contractversion)
+* [`versions`](#contracthash)
+
+* [`lock_status`](#contractpackagestatus)
 
 ## ContractPackageHash {#contractpackagehash}
 
 The hash address of the contract package.
+
+## ContractPackageStatus {#contractpackagestatus}
+
+An enum to determine the lock status of the contract package.
+
+One of:
+
+* `Locked` The package is locked and cannot be versioned.
+
+* `Unlocked` The package is unlocked and can be versioned.
 
 ## ContractVersion {#contractversion}
 
@@ -193,6 +475,18 @@ Required Parameters:
 * `contract_version`
 
 * `protocol_version_major`
+
+## ContractVersionKey {#contractversionkey}
+
+Major element of `ProtocolVersion` combined with `ContractVersion`.
+
+## ContractWasm {#contractwasm}
+
+A container for a contract's Wasm bytes.
+
+Required Parameter:
+
+* [`bytes`](#bytes)
 
 ## ContractWasmHash {#contractwasmhash}
 
@@ -231,6 +525,16 @@ Required properties:
 * [`payment`](#executabledeployitem)
 
 * [`sessions`](#executabledeployitem)
+
+## DeployApproval {#deployapproval}
+
+A struct containing a signature of a deploy hash and the public key of the signer.
+
+Required parameters:
+
+* [`signature`](#signature)
+
+* [`signer`](#publickey)
 
 ## DeployHash {#deployhash}
 
@@ -314,6 +618,30 @@ Required Parameters:
 
 * `protocol_version_major`
 
+## Effects {#effects}
+
+A log of all [transforms](#tranform) produced during execution.
+
+## EntityVersionAndHash {#entityversionandhash}
+
+An entity version associated with the given hash.
+
+Required Parameters:
+
+* [`addressable_entity_hash`](#addressableenetityhash)
+
+* [`entity_version_key`](#entityversionkey)
+
+## EntityVersionKey {#entityversionkey}
+
+Major element of `ProtocolVersion` combined with `EntityVersion`.
+
+Required Parameters:
+
+* `entity_version`
+
+* `protocol_version_major`
+
 ## EntryPoint {#entrypoint}
 
 Metadata describing a callable entry point and its return value, if any. All required parameters should be declared, whereas all non-required parameters should not be declared. Non-required parameters should not be confused with optional parameters.
@@ -342,9 +670,35 @@ Enum describing the possible access control options for a contract entry point.
 
 Context of an entry point execution.
 
-* `session` Executes in the caller's context.
+* `Session` Runs as session code in the context of the caller. Deprecated and retained to allow read back of legacy stored session.
 
-* `contract` Executes in the callee's context.
+* `AddressableEntity` Runs within called entity's context.
+
+* `Factory` This entry point is intended to extract a subset of bytecode. Runs within called entity's context.
+
+## EraEndV1 {#eraendv1}
+
+Information related to the end of an era and validator weights for the following era.
+
+Required Parameters:
+
+* [`era_report`](#erareport_for_publickey)
+
+* [`next_era_validator_weights`](#array_of_validatorweight)
+
+## EraEndV2 {#eraendv2}
+
+Information related to the end of an era and validator weights for the following era.
+
+Required Parameters:
+
+* [`equivocators`](#publickey)
+
+* [`inactive_validators`](#publickey)
+
+* [`next_era_validator_weights`](#array-of-validatorweight)
+
+* [`rewards`](#U512)
 
 ## EraID {#eraid}
 
@@ -357,6 +711,28 @@ Auction metadata. Intended to be recorded at each era.
 Required Parameters:
 
 * [`seigniorage_allocation`](#seigniorageallocation-seigniorageallocation) Information about a seigniorage allocation.
+
+## EraReport_for_PublicKey {#erareport-for-publickey}
+
+Equivocation, reward and validator inactivity information.
+
+Required Parameters:
+
+* [`equivocators`](#publickey)
+
+* [`rewards`](#array_of_erareward)
+
+* [`inactive_validators`](#publickey)
+
+## EraReward {#erareward}
+
+A validator's public key paired with a measure of the value of its contribution to consensus, as a fraction of the configured maximum block reward.
+
+Required Parameters:
+
+* `amount`
+
+* [`validator`](#publickey)
 
 ## EraSummary {#erasummary}
 
@@ -466,7 +842,19 @@ Required Parameters:
 
 ## ExecutionResult {#executionresult}
 
-The result of executing a single Deploy.
+The versioned result of executing a single Deploy.
+
+One of:
+
+* [`Version1`](#executionresultv1) Version 1 of execution result type.
+
+* [`Version2`](#executionresultv2) VErsion 2 of execution result type.
+
+## ExecutionResultV1 {#executionresultV1}
+
+The result of executing a single deploy.
+
+One of:
 
 * `Failure` The result of a failed execution`
 
@@ -490,6 +878,34 @@ The result of executing a single Deploy.
 
     [`cost`](#u512)
 
+## ExecutionResultV2 {#executionresultv2}
+
+The result of executing a single deploy.
+
+One of:
+
+* `Failure` The result of a failed execution.
+
+    Required Parameters:
+
+    [`effects`](#effects)
+
+    [`transfers`](#transferaddr)
+
+    [`cost`](#u512)
+
+    `error_message` The error message associated with executing the Deploy.
+
+* `Success` The result of a successful execution.
+
+    Required Parameters:
+
+    [`effects`](#effects)
+
+    [`transfers`](#transferaddr)
+
+    [`cost`](#u512)
+
 ## FinalizedApprovals {#finalizedapprovals}
 
 A boolean value that determines whether to return the deploy with the finalized approvals substituted. If `false` or omitted, returns the deploy with the approvals that were originally received by the node.
@@ -499,6 +915,8 @@ A boolean value that determines whether to return the deploy with the finalized 
 Identifier for possible ways to query global state.
 
 * [`BlockHash`](#blockhash) Query using a Block hash.
+
+* `BlockHeight` Query using a block height.
 
 * [`StateRootHash`](#digest) Query using the state root hash.
 
@@ -513,6 +931,18 @@ Required Parameters:
 * `group`
 
 * [`keys`](#uref)
+
+## InitiatorAddr {#initiatoraddr}
+
+The address of the initiator of a TransactionV1.
+
+Contains one of:
+
+* [`publickey`](#publickey) The public key of the initiator.
+
+* [`accounthash`](#accounthash) The account hash derived from the public key of the initiator.
+
+* [`entityaddr`](#entityaddr) The hex-encoded entity address of the initiator.
 
 ## JsonBid {#jsonbid}
 
@@ -591,6 +1021,16 @@ JSON representation of a Block header.
 Additional Parameters:
 
 * [`era_end`](#jsoneraend) The era end.
+
+## JsonBlockWithSignatures {#jsonblockwithsignatures}
+
+A JSON-friendly representation of a block and the signatures for that block.
+
+Required Parameters:
+
+* [`block`](#block)
+
+* [`proofs`](#array-of-blockproof)
 
 ## JsonDelegator {#jsondelegator}
 
@@ -684,9 +1124,37 @@ Required Parameters:
 
 * [`weight`](#u512)
 
+## Key {#key}
+
+The key as a formatted string, under which data can be stored in global state.
+
 ## Merkle_Proof {#merkle-proof}
 
 A merkle proof is a construction created using a merkle trie that allows verification of the associated hashes.
+
+## MessageChecksum {#messagechecksum}
+
+Message checksum as a formatted string.
+
+## MessageTopic {#messagetopic}
+
+A topic for contract level messages.
+
+Required Parameters:
+
+* `topic_name` A string used to identify the message topic.
+
+* [`topic_name_hash`](#topicnamehash)
+
+## MessageTopicSummary {#messagetopicsummary}
+
+Summary of a message topic that will be stored in global state.
+
+Required Parameters:
+
+* [`blocktime`](#blocktime)
+
+* `message_count` The number of messages in this topic.
 
 ## MinimalBlockInfo {#minimalblockinfo}
 
@@ -710,6 +1178,16 @@ Required Parameters:
 
 Named arguments to a contract.
 
+## NamedEntryPoint {#namedentrypoint}
+
+A named [entry point](#entrypoint).
+
+Required Parameters:
+
+* [`entry_point`](#entrypoint)
+
+* `name` A string identifying the entry point.
+
 ## NamedKey {#namedkey}
 
 A named key.
@@ -719,6 +1197,20 @@ Required Parameters:
 * `key` The value of the entry: a casper `Key` type.
 
 * `name` The name of the entry.
+
+## NamedKeys {#namedkeys}
+
+A [collection of named keys](#array-of-namedkey).
+
+## NamedUserGroup {#namedusergroup}
+
+A named [`group`](#group).
+
+Required Parameters:
+
+* [`group_name`](#group)
+
+* [`group_users`](#uref)
 
 ## NextUpgrade {#nextupgrade}
 
@@ -748,6 +1240,36 @@ Required Parameters:
 
 The type of operation performed while executing a Deploy.
 
+One of:
+
+* `Read` A read operation.
+
+* `Write` A write operation.
+
+* `Add` An addition.
+
+* `NoOp` An operation which has no effect.
+
+* `Prune` A prune operation.
+
+## Package {#package}
+
+Entity definition, metadata and security container.
+
+Required Parameters:
+
+* [`access_key`](#uref)
+
+* [`disabled_versions`](#EntityVersionKey)
+
+* [`groups`](#array_of_namedusergroup)
+
+* [`lock_status`](#packagestatus)
+
+* [`package_kind`](#packagekind)
+
+* [`versions`](#array-of-entityversionandhash)
+
 ## Parameter {#parameter}
 
 Parameter to an entry point.
@@ -757,6 +1279,32 @@ Required Parameters:
 * [`cl_type`](#cltype)
 
 * `name`
+
+## PackageHash {#packagehash}
+
+The hex-encoded address of a package associated with an [`AddressableEntity`](#addressableentity).
+
+## PackageKind {#packagekind}
+
+The type of `Package`.
+
+One of:
+
+* `System` Package associated with a native contract implementation.
+
+* `Account` Package associated with an Account hash.
+
+* `SmartContract` Packages associated with Wasm stored on chain.
+
+## PackageStatus {#packagestatus}
+
+An enum to determine the lock status of the package.
+
+One of:
+
+* `Locked` The package is locked and cannot be versioned.
+
+* `Unlocked` The package is unlocked and can be versioned.
 
 ## PeerEntry {#peerentry}
 
@@ -770,6 +1318,18 @@ Required Parameters:
 
 Map of peer IDs to network addresses.
 
+## PricingMode {#pricingmode}
+
+The pricing mode of a transaction.
+
+One of:
+
+* `GasPriceMultiplier` Multiplies the gas used by the given amount.
+
+* `Fixed` First-in-first-out handling of transactions.
+
+* `Reserved` The payment for this transaction was previously reserved.
+
 ## ProtocolVersion {#protocolversion}
 
 Casper Platform protocol version.
@@ -777,6 +1337,26 @@ Casper Platform protocol version.
 ## PublicKey {#publickey}
 
 Hex-encoded cryptographic public key, including the algorithm tag prefix.
+
+## PublicKeyAndBid {#publickeyandbid}
+
+A bid associated with the given public key.
+
+Required Parameters:
+
+* [`bid`](#bid)
+
+* [`public_key`](#publickey)
+
+## PublicKeyAndDelegator {#publickeyanddelegator}
+
+A delegator associated with the given validator.
+
+Required Parameters:
+
+* [`delegator_public_key`](#publickey)
+
+* [`delegator`](#delegator)
 
 ## PurseIdentifier {#purseidentifier}
 
@@ -812,6 +1392,10 @@ Required Parameters:
 
 * [`validator`](#publickey)
 
+## RewardedSigantures {#rewardedsignatures}
+
+Describes finality signatures that will be rewarded in a block. Consists of a vector of [`SingleBlockRewardedSignatures`](#singleblockrewardedsignatures), each of which describes signatures for a single ancestor block. The first entry represents the signatures for the parent block, the second for the parent of the parent, and so on.
+
 ## RuntimeArgs {#runtimeargs}
 
 Represents a collection of arguments passed to a smart contract.
@@ -819,6 +1403,8 @@ Represents a collection of arguments passed to a smart contract.
 ## SeigniorageAllocation {#seigniorageallocation}
 
 Information about a seigniorage allocation.
+
+One of:
 
 * `Validator` Info about a seigniorage allocation for a validator.
 
@@ -842,9 +1428,13 @@ Information about a seigniorage allocation.
 
 Hex-encoded cryptographic signature, including the algorithm tag prefix.
 
+## SingleBlockRewardedSignatures {#singleblockrewardedsignatures}
+
+List of identifiers for finality signatures for a particular past block. That past block height is equal to `current_height` minus `signature_rewards_max_delay`, the latter being defined in the chainspec.
+
 ## StoredValue {#storedvalue}
 
-Representation of a value stored in global state. `Account`, `Contract` and `ContractPackage` have their own `json_compatibility` representation (see their docs for further info).
+Representation of a value stored in global state.
 
 * [`CLValue`](#clvalue) A Casper-specific value.
 
@@ -866,6 +1456,32 @@ Representation of a value stored in global state. `Account`, `Contract` and `Con
 
 * [`Withdraw`](#unbondingpurse) A withdraw.
 
+* [`Unbonding`](#unbondingpurse) Unbonding information.
+
+* [`AddressableEntity`](#addressableentity) An AddressableEntity.
+
+* [`BidKind`](#bidkind) A variant that stored `BidKind`.
+
+* [`Package`] A `Package`.
+
+* [`ByteCode`] A record of byte code.
+
+* [`MessageTopic`](#messagetopics) A variant that stores a message topic.
+
+* [`Message`](#messagechecksum) A variant that stores a message digest.
+
+## SystemEntityType {#systementitytype}
+
+System contract types.
+
+* `Mint`
+
+* `HandlePayment`
+
+* `StandardPayment`
+
+* `Auction`
+
 ## TimeDiff {#timediff}
 
 Human-readable duration.
@@ -873,6 +1489,210 @@ Human-readable duration.
 ## Timestamp {#timestamp}
 
 Timestamp formatted as per RFC 3339.
+
+## TopicNameHash {#topicnamehash}
+
+The hash of the name of the [message topic](#messagetopics).
+
+## Transaction {#transaction}
+
+A versioned wrapper for a transaction or deploy.
+
+Contains one of:
+
+* [`deploy`](#deploy)
+
+or
+
+* [`Version1`](#TransactionV1)
+
+## TransactionEntryPoint {#transactionentrypoint}
+
+An entry point of a transaction.
+
+One of:
+
+* `Custom` A non-native, arbitrary entry point.
+
+* `Transfer` The `transfer` native entry point, used to reference motes from a source purse to a target purse.
+
+* `AddBid` The `add_bid` native entry point, used to create or top off a bid purse.
+
+* `WithdrawBid` The `withdraw_bid` native entry point, used to decrease a stake.
+
+* `Delegate` The `delegate` native entry point, used to add a new delegator or increase an existing delegator's stake.
+
+* `Undelegate` The `undelegate` native entry point, used to reduce a delegator's stake or remove the delegator if the remaining stake is zero.
+
+* `Redelegate` the `redelegate` native entry point, used to reduce a delegator's stake or remove the delegator if the remaining stake is zero. After the unbonding delay, it will automatically delegate to a new validator.
+
+## TransactionHash {#transactionhash}
+
+A versioned wrapper for a transaction hash or deploy hash.
+
+One of:
+
+* [`Deploy`](#deployhash)
+
+* [`Version`](#transactionv1hash)
+
+## TransactionInvocationTarget {#transactioninvocationtarget}
+
+The identifier of a `stored` transaction target.
+
+One of:
+
+* `InvocableEntity` The hex-encoded entity address indetifying the invocable entity.
+
+* `InvocableEntityAlias` The alias identifying the invocable entity.
+
+* `Package` The address and optional version identifying the package.
+
+    Required parameters for `package`
+
+    * `addr` The hex-encoded address of the package.
+
+    Optional parameters:
+
+    * `version` The package version. If `None`, the latest enabled version is implied.
+
+* `PackageAlias` The alias and optional version identifying the package.
+
+    Required parameters for `packagealias`
+
+    * `alias` The package alias.
+
+    Optional parameters:
+
+    * `version` The package version. If `None`, the latest enabled version is implied.
+
+## TransactionRuntime {#transactionruntime}
+
+Runtime used to execute a transaction.
+
+Parameters:
+
+* `VmCasperV1` The Casper Version 1 Virtual Machine.
+
+## TransactionScheduling {#transactionscheduling}
+
+The scheduling mode of a transaction.
+
+One of:
+
+* `Standard` No special scheduling applied.
+
+* `FutureEra` Execution should be scheduled fro the specific era.
+
+    Required parameters for `FutureEra`:
+
+    * [`FutureEra`](#eraid)
+
+* `FutureTimestamp` Execution should be scheduled for the specific timestamp or later.
+
+    Required parameters for `FutureTimestamp`:
+
+    * [`FutureTimestamp`](#timestamp)
+
+## TransactionSessionKind {#transactionsessionkind}
+
+Session kind of a transaction.
+
+One of:
+
+* `standard` A standard (non-special-case) session. This kind of session is not allowed to install or upgrade a stored contract, but can call stored contracts.
+
+* `installer` A session which installs a stored contract.
+
+* `upgrader` A session which upgrades a previously-installed stored contract. `Upgrader` sessions must have the `package_id: PackageIdentifier` runtime arg present.
+
+* `isolated` A session which doesn't call any stored contracts. This kind of session is not allowed to install or upgrade a stored contract.
+
+## TransactionTarget {#transactiontarget}
+
+The execution target of a Transaction.
+
+One of:
+
+* `native` The execution target is a native operation.
+
+* `stored` The execution target is a stored entity or package.
+
+    Required parameters for a `stored` target:
+
+    * [`id`](#transactioninvocationtarget)
+
+    * [`runtime`](#transactionruntime)
+
+* `session` The exectuion target is the included module bytes.
+
+    Required parameters for a `session` target:
+
+    * [`kind`](#transactionsessionkind)
+
+    * [`module_bytes`](#bytes)
+
+    * [`runtime`](#transactionruntime)
+
+## TransactionV1 {#transactionV1}
+
+A unit of work sent by a client to the network, which when executed can cause global state to be altered.
+
+Required Parameters:
+
+* [`approvals`](#transactionV1approval)
+
+* [`body`](#transactionV1body)
+
+* [`hash`](#transactionV1hash)
+
+* [`header`](##transactionV1header)
+
+## TransactionV1Approval {#transactionV1Approval}
+
+A struct containing a signature of a transaction hash and the public key of the signer.
+
+Required Parameters:
+
+* [`signer`](#publickey)
+
+* [`signature`](#signature)
+
+## TransactionV1Body {#transactionV1body}
+
+The body of a TransactionV1.
+
+Required Parameters:
+
+* [`args`](#runtimeargs)
+
+* [`entry_point`](#entrypoint)
+
+* [`scheduling`](#transactionscheduling)
+
+* [`target`](#transactiontarget)
+
+## TransactionV1Hash {#transactionV1hash}
+
+A hex-encoded TransactionV1 hash.
+
+## TransactionV1Header {#transactionV1header}
+
+The header portion of a TransactionV1.
+
+Required Parameters:
+
+* [`body_hash`](#digest)
+
+* `chain_name`
+
+* [`initiator_addr`](#initiator_addr)
+
+* [`pricing_mode`](#pricingmode)
+
+* [`timestamp`](#timestamp)
+
+* [`ttl`](#timediff)
 
 ## Transfer {#transfer}
 
@@ -906,19 +1726,35 @@ Hex-encoded transfer address.
 
 The actual transformation performed while executing a Deploy.
 
-* `WriteCLValue` Write the given [CLValue](#clvalue) to global state.
+One of:
 
-* `WriteAccount` Writes the given [Account](#accounthash) to global state.
+* `Identity` A transform having no effect.
 
-* `WriteDeployInfo` Writes the given [DeployInfo](#deployinfo) to global state.
+* `WriteCLValue` Writes the given CLValue to global state.
 
-* `WriteEraInfo` Writes the given [EraInfo](#erainfo) to global state.
+* `WriteAccount` Writes the given Account to global state.
 
-* `WriteTransfer` Writes the given [Transfer](#transfer) to global state.
+* `WriteContractWasm` Writes a smart contract as Wasm to global state.
 
-* `WriteBid` Writes the given [Bid](#bid) to global state.
+* `WriteContract` Writes a smart contract to global state.
 
-* `WriteWithdraw` Writes the given [Withdraw](#unbondingpurse) to global state.
+* `WriteContractPackage` Writes a smart contract package to global state.
+
+* `WriteDeployInfo` Writes the given DeployInfo to global state.
+
+* `WriteEraInfo` Writes the given EraInfo to global state.
+
+* `WriteTransfer` Writes the given Transfer to global state.
+
+* `WriteBid` Writes the given Bid to global state.
+
+* `WriteWithdraw` Writes the given Withdraw to global state.
+
+* `WriteUnbonding` Writes the given Unbonding to global state.
+
+* `WriteAddressableEntity` Writes the addressable entity to global state.
+
+* `WriteBidKind` Writes the given BidKind to global state.
 
 * `AddInt32` Adds the given `i32`.
 
@@ -931,6 +1767,8 @@ The actual transformation performed while executing a Deploy.
 * `AddUInt512` Adds the given [`U512`](#u512).
 
 * `AddKeys` Adds the given collection of [named keys](#namedkey).
+
+* `Prune` Removes the pathing to the global state entry of the specified key. The pruned element remains reachable from previously generated global state root hashes, but will not be included in the next generated global state root hash and subsequent states.
 
 * `Failure` A failed transformation, containing an error message.
 
@@ -978,6 +1816,22 @@ Required Parameters:
 
 Hex-encoded, formatted URef.
 
+## ValidatorBid {#validatorbid}
+
+An entry in the validator map.
+
+* [`bonding_purse`](#uref) Bonding purse.
+
+* `delegation_rate` The delegation rate.
+
+* `inactive` `true` if the validator has been "evicted".
+
+* [`staked_amount`](#u512) The amount of tokens staked by a validator.
+
+* [`validator_public_key`](#publickey) The validator's public key.
+
+* [`vesting_schedule`](#vestingschedule) 
+
 ## ValidatorChange {#validatorchange}
 
 A change to a validator's status between two eras.
@@ -1003,6 +1857,10 @@ Required Parameters:
 ## VestingSchedule {#vestingschedule}
 
 Vesting schedule for a genesis validator.
+
+## Weight {#weight}
+
+The weight associated with public keys in an account's associated keys.
 
 ## WithdrawPurse {#withdrawpurse}
 

--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -120,7 +120,7 @@ An array of [NamedUserGroups](#namedusergroup).
 
 ## Array_of_PublicKeyAndBid {#array-of-publickeyandbid}
 
-An array of [bids associated with give public keys](#publickeyandbid).
+An array of [bids associated with given public keys](#publickeyandbid).
 
 ## Array_of_PublicKeyAndDelegator {#array-of-publickeyanddelegator}
 
@@ -192,7 +192,7 @@ Auction bid variants.
 
 One of:
 
-* `Unified` A unified record indexed on validator data, with an embedded collection of all delegator bids assigned to that validator. The `Unified`` variant is for legacy retrograde support, new instances will not be created going forward.
+* `Unified` A unified record indexed on validator data, with an embedded collection of all delegator bids assigned to that validator. The `Unified`` variant is for legacy retrograde support; new instances will not be created going forward.
 
 * `Validator` A bid record containing only validator data.
 
@@ -350,7 +350,7 @@ Additional Parameters:
 
 ## BlockTime {#blocktime}
 
-A newtype wrapping a `u64` which represents the block time.
+A newtype wrapping a `u64`, which represents the block time.
 
 ## BlockV1 {#blockv1}
 
@@ -382,7 +382,7 @@ Hex-encoded bytes.
 
 ## ByteCode {#bytecode}
 
-A container for contract's Wasm bytes.
+A container for a contract's Wasm bytes.
 
 Required Parameters:
 
@@ -672,9 +672,9 @@ Context of an entry point execution.
 
 * `Session` Runs as session code in the context of the caller. Deprecated and retained to allow read back of legacy stored session.
 
-* `AddressableEntity` Runs within called entity's context.
+* `AddressableEntity` Runs within the called entity's context.
 
-* `Factory` This entry point is intended to extract a subset of bytecode. Runs within called entity's context.
+* `Factory` This entry point is intended to extract a subset of bytecode. Runs within the called entity's context.
 
 ## EraEndV1 {#eraendv1}
 
@@ -848,7 +848,7 @@ One of:
 
 * [`Version1`](#executionresultv1) Version 1 of execution result type.
 
-* [`Version2`](#executionresultv2) VErsion 2 of execution result type.
+* [`Version2`](#executionresultv2) Version 2 of execution result type.
 
 ## ExecutionResultV1 {#executionresultV1}
 
@@ -856,7 +856,7 @@ The result of executing a single deploy.
 
 One of:
 
-* `Failure` The result of a failed execution`
+* `Failure` The result of a failed execution
 
     Required Parameters:
 
@@ -894,7 +894,7 @@ One of:
 
     [`cost`](#u512)
 
-    `error_message` The error message associated with executing the Deploy.
+    `error_message` The error message associated with executing the deploy.
 
 * `Success` The result of a successful execution.
 
@@ -914,7 +914,7 @@ A boolean value that determines whether to return the deploy with the finalized 
 
 Identifier for possible ways to query global state.
 
-* [`BlockHash`](#blockhash) Query using a Block hash.
+* [`BlockHash`](#blockhash) Query using a block hash.
 
 * `BlockHeight` Query using a block height.
 
@@ -1130,7 +1130,7 @@ The key as a formatted string, under which data can be stored in global state.
 
 ## Merkle_Proof {#merkle-proof}
 
-A merkle proof is a construction created using a merkle trie that allows verification of the associated hashes.
+A Merkle proof is a construction created using a Merkle trie that allows verification of the associated hashes.
 
 ## MessageChecksum {#messagechecksum}
 
@@ -1138,7 +1138,7 @@ Message checksum as a formatted string.
 
 ## MessageTopic {#messagetopic}
 
-A topic for contract level messages.
+A topic for contract-level messages.
 
 Required Parameters:
 
@@ -1518,7 +1518,7 @@ One of:
 
 * `AddBid` The `add_bid` native entry point, used to create or top off a bid purse.
 
-* `WithdrawBid` The `withdraw_bid` native entry point, used to decrease a stake.
+* `WithdrawBid` The `withdraw_bid` native entry point, used to decrease a validator's stake.
 
 * `Delegate` The `delegate` native entry point, used to add a new delegator or increase an existing delegator's stake.
 
@@ -1542,7 +1542,7 @@ The identifier of a `stored` transaction target.
 
 One of:
 
-* `InvocableEntity` The hex-encoded entity address indetifying the invocable entity.
+* `InvocableEntity` The hex-encoded entity address identifying the invocable entity.
 
 * `InvocableEntityAlias` The alias identifying the invocable entity.
 
@@ -1582,7 +1582,7 @@ One of:
 
 * `Standard` No special scheduling applied.
 
-* `FutureEra` Execution should be scheduled fro the specific era.
+* `FutureEra` Execution should be scheduled for the specific era.
 
     Required parameters for `FutureEra`:
 
@@ -1624,7 +1624,7 @@ One of:
 
     * [`runtime`](#transactionruntime)
 
-* `session` The exectuion target is the included module bytes.
+* `session` The execution target is the included module bytes.
 
     Required parameters for a `session` target:
 
@@ -1770,7 +1770,7 @@ One of:
 
 * `Prune` Removes the pathing to the global state entry of the specified key. The pruned element remains reachable from previously generated global state root hashes, but will not be included in the next generated global state root hash and subsequent states.
 
-* `Failure` A failed transformation, containing an error message.
+* `Failure` A failed transformation containing an error message.
 
 ## TransformEntry {#transformentry}
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR grew out of control from the Account/Contract merge ticket, but covers many items we would need to finish for 2.0.

It includes all (current) new endpoints for the JSON-RPC and associated types, as well as some of the account/contract merge - but I will finish that in another PR.

Closes #1342
Closes #1317

### Additional context
[Document New JSON-RPC API Endpoints #1317](https://github.com/casper-network/docs/issues/1317)
[Update state_get_account_info in the JSON-RPC Docs #1342](https://github.com/casper-network/docs/issues/1342)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
// Tag whoever needs to review. If you're not sure, leave blank.
