### PR TITLE
TTL Update

### DIFF
--- a/source/docs/casper/developers/cli/sending-deploys.md
+++ b/source/docs/casper/developers/cli/sending-deploys.md
@@ -334,7 +334,7 @@ casper-client query-global-state --help
 
 ### Time-to-live {#ttl}
 
-Time-to-live is the parameter that determines how long a deploy will wait for execution. The acceptable maximum `ttl` is configurable by chain, with the Casper Mainnet maximum set to `1day`. If you are sending a deploy to a different network, you will need to check `chainspec.toml` for that network to determine the acceptable maximum. The minimum is theoretically zero, but this will result in an immediate expiration and an invalid deploy.
+Time-to-live is the parameter that determines how long a deploy will wait for execution. The acceptable maximum `ttl` is configurable by chain, with the Casper Mainnet maximum set to `18hours`. If you are sending a deploy to a different network, you will need to check `chainspec.toml` for that network to determine the acceptable maximum. The minimum is theoretically zero, but this will result in an immediate expiration and an invalid deploy.
 
 In the event of a network outage or other event that prevents execution within the `ttl`, the solution is to resend the deploy in question.
 


### PR DESCRIPTION
### What does this PR fix/introduce?
TTL is now 18 hours rather than 1 day. This PR changes the value in the "Sending Deploy" doc.

### Additional context
[This Slack Conversation](https://casper-labs-team.slack.com/archives/C0135SDEGUC/p1704208825340459)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@sacherjj 
