### PR TITLE
Fix broken link for package required for compatibility with Ubuntu 22.04

### DIFF
--- a/source/docs/casper/operators/setup/install-node.md
+++ b/source/docs/casper/operators/setup/install-node.md
@@ -30,7 +30,7 @@ If you try to install packages, you will receive:
 casper-client : Depends: libssl1.1 (>= 1.1.0) but it is not installable
 ```
 
-This is due to the default openssl moving to 3.x with Ubuntu 22.04.  We need to install OpenSSL 1.x for prior versions of Ubuntu to use our binaries. We can use 20.04 libraries for this by downloading and install them:
+This message is due to the default `openssl` moving to 3.* with Ubuntu 22.04. You need to install OpenSSL 1.* for prior versions of Ubuntu to use the Casper binaries with the following command:
 
 ```
 curl -f -JLO http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb


### PR DESCRIPTION
### What does this PR fix/introduce?
Fixes the broken link to a required package during installation as the package no longer exists. The package is replaced with a higher version one. Also, adds the -f flag to curl to ensure it fails if the package is not found.

### Checklist

- [X] Docs are successfully building - `yarn install && yarn run build`.
- [X] All external links have been verified with `yarn run check:externals`.
- [X] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [X] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers

@ipopescu 