### PR TITLE
1357 - Clarification regarding token transfers

### DIFF
--- a/source/docs/casper/resources/advanced/transfer-token-to-contract.md
+++ b/source/docs/casper/resources/advanced/transfer-token-to-contract.md
@@ -7,7 +7,7 @@ slug: /resources/tutorials/advanced/transfer-token-to-contract
 
 This tutorial covers two methods to handle tokens via a contract. This is not a native process to a Casper network and will require the use of custom code. The following two scenarios provide a framework for developers and the pros and cons of each example. Developers should choose the option that best suits their individual needs.
 
-For increased security, token transfers from a main purse must be handled via contract code, not session code as in [other cases](../../developers/writing-onchain-code/writing-session-code.md#example-3-transfers-using-session-code-transfers-using-session-code). In this case, `transfer-*` methods are unavailable in stored session code, even when the stored session runs in the account context.
+For increased security, token transfers from a main purse must be handled via session code (WASM), as shown [here](../../developers/writing-onchain-code/writing-session-code.md#example-3-transfers-using-session-code-transfers-using-session-code). Therefore, `transfer-*` methods are unavailable in stored WASM for tokens originating from an account's main purse, even when the stored WASM runs in the account context.
 
 ## Scenario 1 - Creating a Throw-Away Purse {#scenario1}
 

--- a/source/docs/casper/resources/advanced/transfer-token-to-contract.md
+++ b/source/docs/casper/resources/advanced/transfer-token-to-contract.md
@@ -7,7 +7,7 @@ slug: /resources/tutorials/advanced/transfer-token-to-contract
 
 This tutorial covers two methods to handle tokens via a contract. This is not a native process to a Casper network and will require the use of custom code. The following two scenarios provide a framework for developers and the pros and cons of each example. Developers should choose the option that best suits their individual needs.
 
-For increased security, token transfers must be handled via contract code, not session code. As a result, `transfer-*` methods are unavailable in stored session code, even when the stored session runs in the account context.
+For increased security, token transfers from a main purse must be handled via contract code, not session code as in [other cases](../../developers/writing-onchain-code/writing-session-code.md#example-3-transfers-using-session-code-transfers-using-session-code). In this case, `transfer-*` methods are unavailable in stored session code, even when the stored session runs in the account context.
 
 ## Scenario 1 - Creating a Throw-Away Purse {#scenario1}
 

--- a/source/docs/casper/resources/advanced/transfer-token-to-contract.md
+++ b/source/docs/casper/resources/advanced/transfer-token-to-contract.md
@@ -7,7 +7,7 @@ slug: /resources/tutorials/advanced/transfer-token-to-contract
 
 This tutorial covers two methods to handle tokens via a contract. This is not a native process to a Casper network and will require the use of custom code. The following two scenarios provide a framework for developers and the pros and cons of each example. Developers should choose the option that best suits their individual needs.
 
-For increased security, `transfer-*` methods are unavailable in stored session code, even when the stored session code runs in the account context. The tokens must be handled via contract code, as shown below.
+For increased security, token transfers must be handled via contract code, not session code. As a result, `transfer-*` methods are unavailable in stored session code, even when the stored session runs in the account context.
 
 ## Scenario 1 - Creating a Throw-Away Purse {#scenario1}
 

--- a/source/docs/casper/resources/advanced/transfer-token-to-contract.md
+++ b/source/docs/casper/resources/advanced/transfer-token-to-contract.md
@@ -7,6 +7,8 @@ slug: /resources/tutorials/advanced/transfer-token-to-contract
 
 This tutorial covers two methods to handle tokens via a contract. This is not a native process to a Casper network and will require the use of custom code. The following two scenarios provide a framework for developers and the pros and cons of each example. Developers should choose the option that best suits their individual needs.
 
+For increased security, `transfer-*` methods are unavailable in stored session code, even when the stored session code runs in the account context. The tokens must be handled via contract code, as shown below.
+
 ## Scenario 1 - Creating a Throw-Away Purse {#scenario1}
 
 The first scenario involves the use of a single-use, throw-away purse. The caller creates and funds a purse independent of their main purse, before passing the URef to the callee.


### PR DESCRIPTION
### What does this PR fix/introduce?

As requested in [this thread](https://casper-labs-team.slack.com/archives/C01J86T699U/p1705923063189069?thread_ts=1705837279.975239&cid=C01J86T699U), I added a note clarifying that token transfers must be handled via stored contract (not stored session).

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.

### Reviewers
@ACStoneCL 
