### PR TITLE
Remove Broken Python SDK Link

### DIFF
--- a/source/docs/casper/developers/dapps/sdk/python-sdk.md
+++ b/source/docs/casper/developers/dapps/sdk/python-sdk.md
@@ -4,18 +4,11 @@ The [Python SDK](https://github.com/casper-network/casper-python-sdk) allows dev
 
 ## Installation
 
-Before installing the library, you need to install dependencies from [requirements.txt](https://github.com/casper-network/casper-python-sdk/blob/main/requirements.txt), which you can perform by running the following command:
+To install the library, run:
 
 ```bash
 
-    pip install -r requirements.txt
-```
-
-Finally, to install the library, run:
-
-```bash
-
-    pip install pycspr
+    pip3 install pycspr
 ```
 
 ## Tests


### PR DESCRIPTION
### What does this PR fix/introduce?
[Recent commits](https://github.com/casper-network/casper-python-sdk/commit/4355462b979d03a93cd401b5e51e8ef3be5b66c0) to the Python SDK have caused an external link failure. This updates the installation instructions so that the external link is no longer needed.

### Additional context
[Removal of requirements.txt](https://github.com/casper-network/casper-python-sdk/commit/4355462b979d03a93cd401b5e51e8ef3be5b66c0)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ipopescu 
