### PR TITLE
1361 Changelog Addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Documentation Updates by Protocol Release
+
+## Condor (2.0)
+
+### Concepts
+
+The following are changes introduced alongside release of the Condor network upgrade.
+
+[Understanding Hash Types](./source/docs/casper/concepts/hash-types.md) - Additional Key Types.
+
+[Serialization Standard](./source/docs/casper/concepts/serialization-standard.md) - Serialization information for new types.
+
+[Smart Contracts](./source/docs/casper/concepts/smart-contracts.md) - Information on the new factory pattern feature for smart contracts.
+
+### Developers
+
+[Building dApps -> Monitoring and Consuming Events](./source/docs/casper/developers/dapps/monitor-and-consume-events.md) - Information related to contract-level events.
+
+[Casper JSON-RPC API -> Informational JSON-RPC Methods](./source/docs/casper/developers/json-rpc/json-rpc-informational.md) - New RPC methods.
+
+[Casper JSON-RPC API -> Transactional JSON-RPC Methods](./source/docs/casper/developers/json-rpc/json-rpc-transactional.md) - New RPC methods.
+
+[Casper JSON-RPC API -> Types](./source/docs/casper/developers/json-rpc/types_chain.md) - New parameters used by the JSON-RPC API.
+
+[Writing On-Chain Code -> Contract-Level Events](./source/docs/casper/developers/writing-onchain-code/emitting-contract-events.md) - Guide to the new contract-level events feature.
+
+[Writing On-Chain Code -> Factory Contracts](./source/docs/casper/developers/writing-onchain-code/factory-pattern.md) - Guide to the new factory pattern for smart contracts.
+
+### Operators
+
+[Private Network -> The Chainspec](./source/docs/casper/operators/setup-network/chain-spec.md) - Updates to the `chainpsec` relating to contract-level events.

--- a/config/sidebar.config.js
+++ b/config/sidebar.config.js
@@ -404,6 +404,7 @@ module.exports = {
                 //"resources/advanced/list-cspr",
             ],
         },
+        "resources/changelog",
     ],
     users: [
         "users/index",

--- a/source/docs/casper/resources/changelog.md
+++ b/source/docs/casper/resources/changelog.md
@@ -1,0 +1,31 @@
+# Documentation Updates by Protocol Release
+
+## Condor (2.0)
+
+### Concepts
+
+The following are changes introduced alongside release of the Condor network upgrade.
+
+[Understanding Hash Types](./concepts/hash-types.md) - Additional Key Types.
+
+[Serialization Standard](./concepts/serialization-standard.md) - Serialization information for new types.
+
+[Smart Contracts](./concepts/smart-contracts.md) - Information on the new factory pattern feature for smart contracts.
+
+### Developers
+
+[Building dApps -> Monitoring and Consuming Events](./developers/dapps/monitor-and-consume-events.md) - Information related to contract-level events.
+
+[Casper JSON-RPC API -> Informational JSON-RPC Methods](./developers/json-rpc/json-rpc-informational.md) - New RPC methods.
+
+[Casper JSON-RPC API -> Transactional JSON-RPC Methods](./developers/json-rpc/json-rpc-transactional.md) - New RPC methods.
+
+[Casper JSON-RPC API -> Types](./developers/json-rpc/types_chain.md) - New parameters used by the JSON-RPC API.
+
+[Writing On-Chain Code -> Contract-Level Events](./developers/writing-onchain-code/emitting-contract-events.md) - Guide to the new contract-level events feature.
+
+[Writing On-Chain Code -> Factory Contracts](./developers/writing-onchain-code/factory-pattern.md) - Guide to the new factory pattern for smart contracts.
+
+### Operators
+
+[Private Network -> The Chainspec](./operators/setup-network/chain-spec.md) - Updates to the `chainpsec` relating to contract-level events.

--- a/source/docs/casper/resources/index.md
+++ b/source/docs/casper/resources/index.md
@@ -23,3 +23,9 @@
 | [Quickstart](./quick-start.md) | Install Rust and setup a Casper environment  |
 | [Beginner](./beginner/index.md) | Learn the basics, such as installing and upgrading contracts |
 | [Advanced](./advanced/index.md) | Learn about multi-sig, authorization keys, exchange integration, and storage |
+
+## Documentation Changes
+
+| Topic                                                       | Description                                                      |
+| ----------------------------------------------------------- | ---------------------------------------------------------------- |
+| [Documentation Change Log](./changelog.md) | A list of changes made during major protocol releases.                            |


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR establishes a `CHANGELOG.md` for the `docs` repo, as well as a version available on the actual documentation site that allows for quick reference of changes made during protocol releases.

Closes #1361

### Additional context
[Establish a Change Log for the Docs #1361](https://github.com/casper-network/docs/issues/1361)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
@ipopescu 
