### PR TITLE
Add details about the secret key file

### DIFF
--- a/source/docs/casper/concepts/accounts-and-keys.md
+++ b/source/docs/casper/concepts/accounts-and-keys.md
@@ -18,7 +18,7 @@ You can also [generate an account hash](#generating-an-account-hash) from a publ
 
 ## Creating Accounts and Keys {#creating-accounts-and-keys}
 
-When you create an account on the Casper blockchain, a cryptographic key-pair will be created when using either the [Casper command-line client](#option-1-key-generation-using-the-casper-client) or a block explorer.
+When you create an account on the Casper blockchain, a cryptographic key-pair will be created when using either the [Casper command-line client](#option-1-key-generation-using-the-casper-client) or a block explorer. Developers must use the Casper command-line client as described below. Otherwise, they won't have access to the secret key file needed during development.
 
 :::note
 
@@ -104,6 +104,8 @@ For instance, on the official Testnet, the [CSPR.live](https://testnet.cspr.live
 Start by creating an account using the [Casper Wallet](https://www.casperwallet.io/), [Ledger](https://support.ledger.com/hc/en-us/articles/4416379141009-Casper-CSPR-?support=true), or [Torus Wallet](https://casper.tor.us/).
 
 :::caution
+
+Developers must generate keys using the [Casper command-line client](#option-1-key-generation-using-the-casper-client) to access the `secret_key.pem` file.
 
 The Casper Signer has been replaced with the Casper Wallet and will be deprecated. We recommend migrating all your Casper accounts to the Casper Wallet as outlined [here](https://www.casperwallet.io/user-guide/signer-user-start-here).
 

--- a/source/docs/casper/developers/prerequisites.md
+++ b/source/docs/casper/developers/prerequisites.md
@@ -242,11 +242,9 @@ The Casper blockchain uses an on-chain account-based model, uniquely identified 
 
 By default, a transactional interaction with the blockchain takes the form of a `Deploy` cryptographically signed by the key-pair corresponding to the `PublicKey` used to create the account.
 
-Users can create accounts using the [Casper command-line client](../concepts/accounts-and-keys.md#option-1-generating-keys-using-the-casper-client-option-1-key-generation-using-the-casper-client). 
+Developers must create accounts using the [Casper command-line client](../concepts/accounts-and-keys.md#option-1-generating-keys-using-the-casper-client-option-1-key-generation-using-the-casper-client) to access the `secret_key.pem` file needed during development.
 
-Alternatively, some Casper networks, such as the official Testnet and Mainnet, provide a browser-based block explorer that allows account creation as outlined [here](../concepts/accounts-and-keys.md#option-2-generating-keys-using-a-block-explorer-option-2-key-generation-using-a-block-explorer). 
-
-Use either method to generate an account and its corresponding cryptographic key-pair.
+Some Casper networks, such as the official Testnet and Mainnet, provide wallets that allow account creation as outlined here. However, these wallets do not give developers access to the secret key file.
 
 ### Generating the account hash
 


### PR DESCRIPTION
### What does this PR fix/introduce?

Developers need to use the Casper client to generate keys. Otherwise, they won't have access to the secret key fiel.

Closes #1435 

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.

### Reviewers
@ACStoneCL 