### PR TITLE
Introducing a Document Clarifying the `Transaction` concept

### DIFF
--- a/source/docs/casper/concepts/transactions.md
+++ b/source/docs/casper/concepts/transactions.md
@@ -5,4 +5,16 @@ slug: /transactions
 
 # Transactions
 
-<!-- TODO Page in place for structural purposes, to be propagated at a later date. -->
+Transactions are a new form of interacting with a Casper network that supersedes the concept of a [deploy](./glossary/D.md#deploy). They are a unit of work sent by a client to the network, which when executed can cause global state to be altered. Legacy deploys will continue to function in most cases, but new transaction variants are cheaper and more efficient. Moving forward, we suggest using transaction variants over legacy deploy architecture.
+
+Blocks contain separate slots for each transaction variant, preventing a scenario where a single type of transaction (legitimate or malicious) can prevent critical consensus related actions. The following is a description of the available transaction variants:
+
+* `mint`: Mint transactions interact with the `mint` system contract and involve transfers between purse URefs.
+
+* `auction`: Auction transactions include placing bids to become a validator, as well as delegating, undelegating and redelegating.
+
+* `install_upgrade`: Install/upgrade transactions pertain to installing smart contracts onto global state, as well as upgrading existing contracts.
+
+* `standard`: Standard transactions include all other transactions that do not fall under `mint`, `auction` or `install_upgrade`. Standard transactions also include legacy deploys.
+
+Information on the number of each transaction allowed in a single block can be found in the [chainspec.toml](./glossary/C.md#chainspec) for a given Casper network.

--- a/source/docs/casper/concepts/transactions.md
+++ b/source/docs/casper/concepts/transactions.md
@@ -9,12 +9,12 @@ Transactions are a new form of interacting with a Casper network that supersedes
 
 Blocks contain separate slots for each transaction variant, preventing a scenario where a single type of transaction (legitimate or malicious) can prevent critical consensus related actions. The following is a description of the available transaction variants:
 
-* `mint`: Mint transactions interact with the `mint` system contract and involve transfers between purse URefs.
+* `mint`: Mint transactions interact with the `mint` system contract and involve transfers between purse URefs. It also includes any native trfansfers.
 
 * `auction`: Auction transactions include placing bids to become a validator, as well as delegating, undelegating and redelegating.
 
 * `install_upgrade`: Install/upgrade transactions pertain to installing smart contracts onto global state, as well as upgrading existing contracts.
 
-* `standard`: Standard transactions include all other transactions that do not fall under `mint`, `auction` or `install_upgrade`. Standard transactions also include legacy deploys.
+* `standard`: Standard transactions include all other transactions that do not fall under `mint`, `auction` or `install_upgrade`. Standard transactions also include legacy deploys, other than native transfers.
 
 Information on the number of each transaction allowed in a single block can be found in the [chainspec.toml](./glossary/C.md#chainspec) for a given Casper network.


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR introduces a document to describe the new `Transaction` architecture.

### Additional context
See previous PR for terminology update across docs: #1439 

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@ipopescu 