### PR TITLE
Updating JSON-RPC API with `info_get_reward` method

### DIFF
--- a/source/docs/casper/developers/json-rpc/json-rpc-informational.md
+++ b/source/docs/casper/developers/json-rpc/json-rpc-informational.md
@@ -561,6 +561,75 @@ If the `execution_results` field is empty, it means that the network processed t
 
 </details>
 
+## info_get_reward {#info-get-reward}
+
+This method returns the reward for a given era and a validator or delegator.
+
+|Parameter|Type|Description|
+|---------|----|-----------|
+|[validator](types_chain.md#publickey)|String|The public key of the validator.|
+|[era_identifier](types_chain.md#eraientifier)|Object|The era identifier. If `None`, the last finalized era is used.|
+|[delegator](types_chain.md#publickey)|String|The public key of the delegator. If `Some`, the rewards for the delegator are returned. If `None`, the rewards for the validator are returned.|
+
+<details>
+
+<summary>Example info_get_reward request</summary>
+
+```bash
+
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "info_get_reward",
+  "params": [
+      {
+          "name": "era_identifier",
+          "value": {
+              "Era": 1
+          }
+      },
+      {
+          "name": "validator",
+          "value": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+      },
+      {
+          "name": "delegator",
+          "value": "01d9bf2148748a85c89da5aad8ee0b0fc2d105fd39d41a4c796536354f0ae2900c"
+      }
+  ],
+}
+
+```
+
+</details>
+
+### `info_get_reward_result`
+
+|Parameter|Type|Description|
+|---------|----|-----------|    
+|api_version|String|The RPC API version.|
+|[era_id](types_chain.md#eraid)|Integer|The era for which the reward was calculated.|
+|[reward_amount](types_chain.md#U512)|Integer|The total reward amount in the requested era.|
+
+<details>
+
+<summary>Example info_get_reward result</summary>
+
+```bash
+
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "value": {
+      "api_version": "2.0.0",
+      "reward_amount": "42",
+      "era_id": 1
+  }  
+
+```
+
+</details>
+
 ## info_get_transaction {#info-get-transaction}
 
 This method retrieves a transaction from a network. It requires a `transaction_hash` to query the Deploy.

--- a/source/docs/casper/developers/json-rpc/types_chain.md
+++ b/source/docs/casper/developers/json-rpc/types_chain.md
@@ -755,6 +755,16 @@ Required Parameters:
 
 Era ID newtype.
 
+## EraIdentifier {#eraidentifier}
+
+Identifier for an era.
+
+One of:
+
+* [`Era`](#eraid) 
+
+* [`Block`](#blockidentifier)
+
 ## EraInfo {#erainfo}
 
 Auction metadata. Intended to be recorded at each era.


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR introduces the newly added `info_get_reward` method to the JSON-RPC API documentation.

### Additional context
The JSON-RPC will require additional updates, but this will get necessary information out for third parties.

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).

### Reviewers
@ipopescu 
