### PR TITLE
Adding Quickstart to Navbar

### DIFF
--- a/config/navbar.config.js
+++ b/config/navbar.config.js
@@ -47,6 +47,10 @@ module.exports = {
             position: "left",
         },
         {
+            href: "https://docs.casper.network/resources/quick-start/",
+            label: "Quickstart",
+        },
+        {
             href: "https://support.casperlabs.io/",
             label: "Support",
         },


### PR DESCRIPTION
### What does this PR fix/introduce?
One of the major bullet points to come out of the Starton dev demo was the difficulty finding the Quickstart guide.

This PR rises it to the top level within the docs and makes it clearly visible to anyone searching the site for the first time.

This PR will also trigger the CI/CD build for the main docs repo, updating the DevPortal-level navbars and footer.

### Additional context
[Starton Presentation](https://docs.google.com/presentation/d/1-lf-7lI4DdGijLCgrnQmhKL_1yVkJOZ38vtJmc4umjA/edit?usp=sharing)

### Checklist
(Delete any that aren't relevant)

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [x] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
@melpadden
