### PR TITLE
Promote Quickstart in nav bar

### DIFF
--- a/config/navbar.config.js
+++ b/config/navbar.config.js
@@ -17,6 +17,11 @@ module.exports = {
         //     position: "left",
         // },
         {
+            to: `${routePrefix}/resources/quick-start`,
+            label: "Quickstart",
+            position: "left",
+        },
+        {
             to: `${routePrefix}/concepts`,
             activeBasePath: `${routePrefix}/concepts`,
             label: "Concepts",
@@ -45,10 +50,6 @@ module.exports = {
             activeBasePath: `${routePrefix}/resources`,
             label: "Resources",
             position: "left",
-        },
-        {
-            href: "https://docs.casper.network/resources/quick-start/",
-            label: "Quickstart",
         },
         {
             href: "https://support.casperlabs.io/",


### PR DESCRIPTION
### What does this PR fix/introduce?
Promote the Quickstart link to be the first thing a user sees.
Make it open in the same window
Make it a relative Docusaurus link 

- [ ] Docs are successfully building - `yarn install && yarn run build`.
- [ ] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [ ] All external links have been verified with `yarn run check:externals`.
- [ ] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [ ] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).
- [ ] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
// Tag whoever needs to review. If you're not sure, leave blank.
@ACStoneCL 
