### PR TITLE
Added Public CasperLabs JSON-RPC Endpoints

### DIFF
--- a/source/docs/casper/developers/prerequisites.md
+++ b/source/docs/casper/developers/prerequisites.md
@@ -262,7 +262,7 @@ Clients can interact with a node on the blockchain via requests sent to that nod
 
 The node address is the IP address or URL of a peer node.
 
-Casper Labs provides public Casper node JSON RPC endpoints for each network:
+Casper Labs provides public Casper node JSON-RPC endpoints for each network:
 
 * Mainnet: https://rpc.mainnet.casperlabs.io/rpc
 * Testnet: https://rpc.testnet.casperlabs.io/rpc

--- a/source/docs/casper/developers/prerequisites.md
+++ b/source/docs/casper/developers/prerequisites.md
@@ -258,11 +258,17 @@ On Mainnet, a pre-existing account must transfer CSPR tokens to the newly create
 
 ## Acquiring a Node Address from the Network {#acquire-node-address-from-network-peers}
 
-Clients can interact with a node on the blockchain via requests sent to that node's JSON-RPC endpoint, `http://<node-ip-address>:7777` by default.
+Clients can interact with a node on the blockchain via requests sent to that node's JSON-RPC endpoint, `http://<node-address>:7777` by default.
 
-The node address is the IP of a peer node.
+The node address is the IP address or URL of a peer node.
 
-Both the official Testnet and Mainnet provide block explorers that list the IP addresses of nodes on their respective networks.
+Casper Labs provides public Casper node JSON RPC endpoints for each network:
+
+* Mainnet: https://rpc.mainnet.casperlabs.io/rpc
+* Testnet: https://rpc.testnet.casperlabs.io/rpc
+* Integration network: https://rpc.integration.casperlabs.io/rpc
+
+Additionally, both the official Testnet and Mainnet provide block explorers that list the IP addresses of nodes on their respective networks.
 
 You can get the `node-ip-address` of a node on the network by visiting the following block explorers:
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR adds the public CasperLabs JSON-RPC endpoints as the preferred method of communicating with the network.

### Additional context
The current method encourages choosing from a list of currently online Casper Network peers, many of which may have RPC ports disabled or could theoretically act in malicious ways.

### Checklist

- [x] Docs are successfully building - `yarn install && yarn run build`.
- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] All external links have been verified with `yarn run check:externals`.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).