### PR TITLE
Fix datalayer because both gtag and gtm was activated

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -71,7 +71,7 @@ module.exports = {
                     // editCurrentVersion: true,
                     // onlyIncludeVersions: process.env.PREVIEW_DEPLOY === "true" ? ["current", ...versions.slice(0, 2)] : undefined,
                 },
-                ...(gtagConfig["trackingID"] && { gtag: gtagConfig }),
+                //...(gtagConfig["trackingID"] && { gtag: gtagConfig }),
                 ...(gtmConfig["containerId"] && { googleTagManager: gtmConfig }),
                 // IMPORTANT: disable blog feature
                 blog: false,


### PR DESCRIPTION
### What does this PR fix/introduce?

Currently, GTM is added but is not working. We can see for example that the web-vitals script which is configured to be loaded on every page from GTM is not loaded.

### Additional context

This occurs because gtag is initialized afterward and also uses ```window.dataLayer```. Data is already being sent to Google Analytics from GTM, so we can remove gtag.

### Reviewers
@ACStoneCL
