### PR TITLE
Reproducibility: how to use rustc wrapper

### DIFF
--- a/source/docs/casper/developers/writing-onchain-code/getting-started.md
+++ b/source/docs/casper/developers/writing-onchain-code/getting-started.md
@@ -20,6 +20,16 @@ cargo casper my-project
 
 If you look inside the newly-created _my-project_ folder, you will find two crates: `contract` and `tests`. This is a complete basic smart contract that saves a value, passed as an argument, on the blockchain. The `tests` crate provides a runtime environment of the Casper virtual machine, and a basic smart contract test.
 
+### Reproducibility
+
+Currently, [cargo](https://github.com/rust-lang/cargo/issues/8140) does not provide cross-platform reproducibility for binary files, including WebAssembly. The ability to compile a smart contract to exactly the same binary file is important, for example, when there is a need to verify the smart contract binary stored on the blockchain is exactly the same as the provided source code.
+
+To work around the issue, `cargo casper` crate provides `rustc` wrapper, which can be enabled using `--wrapper` option.
+
+```bash
+cargo casper my_project --wrapper
+```
+
 ### Using the nightly toolchain
 
 Navigate to the `my-project` folder and open the `rust-toolchain` file. You will notice that the file's contents specify a nightly version of Rust. Here is an example:
@@ -46,7 +56,7 @@ To support smart contract development with Rust, the following crates are publis
 - [casper-engine-test-support](https://crates.io/crates/casper-engine-test-support) - a virtual machine against which you can test your smart contracts.
 - [casper-types](https://crates.io/crates/casper-types) - a library with types we use across the Rust ecosystem.
 
-A crate is a compilation unit that can be compiled into a binary or a library. 
+A crate is a compilation unit that can be compiled into a binary or a library.
 
 :::note
 


### PR DESCRIPTION
### What does this PR fix/introduce?
Reproducibility: how to use rustc wrapper

- [*] Docs are successfully building - `yarn install && yarn run build`.
- [*] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [*] All external links have been verified with `yarn run check:externals`.
- [*] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).
- [*] All technical procedures have been tested (if you want help with this, mention it in [Reviewers](#reviewers)).
- [*] If structural changes are introduced (not just content changes), cross-broswer testing has been completed.

### Reviewers
// Tag whoever needs to review. If you're not sure, leave blank.
